### PR TITLE
fix(ci): remove path filters from push triggers on main

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -3,15 +3,6 @@ name: Build and Push Component Docker Images
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/components-build-deploy.yml'
-      - 'components/manifests/**'
-      - 'components/runners/**'
-      - 'components/ambient-api-server/**'
-      - 'components/ambient-control-plane/**'
-      - 'components/ambient-mcp/**'
-      - 'components/ambient-ui/**'
-      - 'components/credential-sidecars/**'
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,6 @@ name: Lint
 on:
   push:
     branches: [main]
-    paths:
-      - 'components/ambient-api-server/**'
-      - 'components/ambient-cli/**'
-      - '.github/workflows/lint.yml'
-      - '!**/*.md'
 
   pull_request:
     branches: [main]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,16 +6,6 @@ permissions:
 on:
   push:
     branches: [main]
-    paths:
-      - 'components/ambient-api-server/**'
-      - 'components/runners/ambient-runner/**'
-      - 'components/ambient-cli/**'
-      - 'components/ambient-sdk/go-sdk/**'
-      - 'components/ambient-ui/**'
-      - '.github/scripts/**'
-      - 'tests/**'
-      - '.github/workflows/unit-tests.yml'
-      - '!**/*.md'
 
   pull_request:
 


### PR DESCRIPTION
## Summary

Pushes to main should always run all jobs for full post-merge validation.
Path filters on push meant docs/manifest-only merges skipped tests and builds.

- Removed path filters from `push:` triggers in unit-tests, lint, and build workflows
- Internal `detect-changes` jobs still skip individual work when nothing relevant changed
- `pull_request:` triggers remain unfiltered (already fixed in prior PR)

## Test plan

- [x] Workflow YAML valid
- [ ] Next merge to main triggers all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)