### PR TITLE
feat(ci): set 48h expiration on PR image tags

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -159,6 +159,17 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.component.name }}-amd64
           cache-to: type=gha,mode=max,ignore-error=true,scope=${{ matrix.component.name }}-amd64
 
+      - name: Set PR tag expiration (48h)
+        if: github.event_name == 'pull_request'
+        run: |
+          REPO=$(echo "${{ matrix.component.image }}" | sed 's|quay.io/||')
+          TAG="pr-${{ github.event.pull_request.number }}-amd64"
+          EXPIRY=$(date -d '+48 hours' +%s)
+          curl -sf -X PUT "https://quay.io/api/v1/repository/${REPO}/tag/${TAG}" \
+            -H "Authorization: Bearer ${{ secrets.QUAY_PASSWORD }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"expiration\": ${EXPIRY}}" || echo "::warning::Could not set tag expiration"
+
   build-arm64:
     needs: build-matrix
     if: needs.build-matrix.outputs.has-builds == 'true'
@@ -217,6 +228,17 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.component.name }}-arm64
           cache-to: type=gha,mode=max,ignore-error=true,scope=${{ matrix.component.name }}-arm64
+
+      - name: Set PR tag expiration (48h)
+        if: github.event_name == 'pull_request'
+        run: |
+          REPO=$(echo "${{ matrix.component.image }}" | sed 's|quay.io/||')
+          TAG="pr-${{ github.event.pull_request.number }}-arm64"
+          EXPIRY=$(date -d '+48 hours' +%s)
+          curl -sf -X PUT "https://quay.io/api/v1/repository/${REPO}/tag/${TAG}" \
+            -H "Authorization: Bearer ${{ secrets.QUAY_PASSWORD }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"expiration\": ${EXPIRY}}" || echo "::warning::Could not set tag expiration"
 
   merge-manifests:
     needs: [build-matrix, build-amd64, build-arm64]


### PR DESCRIPTION
## Summary

After pushing PR-tagged images to Quay, call the Quay API to set a 48-hour
expiration on the `pr-<N>-amd64` and `pr-<N>-arm64` tags. Prevents stale
PR images from accumulating in the registry.

Failure to set expiration emits a warning but doesn't fail the build.

## Test plan

- [ ] PR build pushes images and sets expiration
- [ ] Verify tag expiration visible in Quay UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)