### PR TITLE
fix(ci): split auto-merge into label-on-open + enqueue-on-checks-pass

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,14 +3,18 @@ name: Auto-Merge Queue
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  check_suite:
+    types: [completed]
 
 permissions:
   pull-requests: write
   contents: write
+  checks: read
 
 jobs:
-  auto-merge:
+  label-eligible:
     if: >-
+      github.event_name == 'pull_request' &&
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
@@ -29,10 +33,65 @@ jobs:
             echo "eligible=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Add label and enable auto-merge
+      - name: Add auto-merge-pending label
         if: steps.check.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr edit "${{ github.event.pull_request.number }}" --add-label auto-merge-queue --repo "${{ github.repository }}"
-          gh pr merge "${{ github.event.pull_request.number }}" --auto --repo "${{ github.repository }}"
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --add-label auto-merge-pending \
+            --remove-label auto-merge-queue \
+            --repo "${{ github.repository }}" 2>/dev/null || true
+
+  enqueue:
+    if: >-
+      github.event_name == 'check_suite' &&
+      github.event.check_suite.conclusion == 'success' &&
+      github.event.check_suite.head_branch != github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Find PR with auto-merge-pending label
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.check_suite.head_branch }}"
+          PR=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number,labels --jq '
+            .[] | select(.labels | map(.name) | index("auto-merge-pending")) | .number
+          ' 2>/dev/null)
+          if [ -n "$PR" ]; then
+            echo "pr=$PR" >> "$GITHUB_OUTPUT"
+            echo "Found eligible PR: $PR"
+          else
+            echo "No eligible PR on branch $BRANCH"
+          fi
+
+      - name: Check all required checks passed
+        if: steps.find.outputs.pr != ''
+        id: ready
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ steps.find.outputs.pr }}"
+          FAILED=$(gh pr checks "$PR" --repo "${{ github.repository }}" --required 2>/dev/null | grep -c 'fail' || true)
+          PENDING=$(gh pr checks "$PR" --repo "${{ github.repository }}" --required 2>/dev/null | grep -c 'pending' || true)
+          if [ "$FAILED" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Required checks failing"
+          elif [ "$PENDING" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Required checks still pending"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "All required checks passed"
+          fi
+
+      - name: Enqueue PR
+        if: steps.find.outputs.pr != '' && steps.ready.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ steps.find.outputs.pr }}"
+          gh pr edit "$PR" --add-label auto-merge-queue --remove-label auto-merge-pending --repo "${{ github.repository }}"
+          gh pr merge "$PR" --auto --repo "${{ github.repository }}"


### PR DESCRIPTION
Fixes auto-merge not reliably enqueuing into merge queue. Splits into two phases: label on PR open, enqueue after checks pass.