### PR TITLE
feat(manifests): add ambient-ui to MPP OpenShift overlay

### DIFF
--- a/components/manifests/overlays/mpp-openshift/README.md
+++ b/components/manifests/overlays/mpp-openshift/README.md
@@ -17,6 +17,7 @@ kubectl apply -k components/manifests/overlays/mpp-openshift/
 - Mounts `tenantaccess-ambient-control-plane-token` for the CP's project kube client
 - Mounts `ambient-runner-api-token` for runner pods to authenticate as service callers on gRPC
 - Adds `allow-ambient-tenant-ingress` NetworkPolicy (ports 8000/9000 from all `ambient-code` tenant namespaces)
+- Deploys `ambient-ui` BFF with native SSO authentication (reads `sso-credentials` secret)
 
 ## ⚠️ One-Time Manual Bootstrap
 
@@ -95,6 +96,20 @@ The api-server must know the static token so it can recognise the runner as a se
 | `ambient-control-plane-rbac.yaml` | RBAC for the CP SA |
 | `ambient-tenant-ingress-netpol.yaml` | NetworkPolicy allowing runner→api-server traffic |
 | `ambient-cp-tenant-sa.yaml` | TenantServiceAccount CR (applied manually — see Step A) |
+| `ambient-ui.yaml` | ambient-ui Deployment, ServiceAccount, Service (BFF with native SSO) |
+| `ambient-ui-route.yaml` | OpenShift Route for ambient-ui (TLS edge termination) |
+
+### Step D — SSO Credentials for ambient-ui
+
+The ambient-ui BFF requires an OIDC confidential client. Create the `sso-credentials` secret:
+
+```bash
+kubectl create secret generic sso-credentials -n <namespace> \
+  --from-literal=SSO_ISSUER_URL=<issuer-url> \
+  --from-literal=SSO_CLIENT_ID=<client-id> \
+  --from-literal=SSO_CLIENT_SECRET=<client-secret> \
+  --from-literal=SESSION_SECRET="$(openssl rand -base64 32)"
+```
 
 ## Re-Bootstrap Required?
 

--- a/components/manifests/overlays/mpp-openshift/ambient-ui-route.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-ui-route.yaml
@@ -1,0 +1,20 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ambient-ui
+  namespace: ambient-code--runtime-int
+  labels:
+    app: ambient-ui
+    shard: internal
+  annotations:
+    haproxy.router.openshift.io/timeout: 10m
+    haproxy.router.openshift.io/timeout-tunnel: 10m
+spec:
+  to:
+    kind: Service
+    name: ambient-ui
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/components/manifests/overlays/mpp-openshift/ambient-ui.yaml
+++ b/components/manifests/overlays/mpp-openshift/ambient-ui.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ambient-ui
+  namespace: ambient-code--runtime-int
+  labels:
+    app: ambient-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-ui
+  namespace: ambient-code--runtime-int
+  labels:
+    app: ambient-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ambient-ui
+  template:
+    metadata:
+      labels:
+        app: ambient-ui
+    spec:
+      serviceAccountName: ambient-ui
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ambient-ui
+          image: quay.io/ambient_code/acp_ambient_ui:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: API_SERVER_URL
+              value: "http://ambient-api-server.ambient-code--runtime-int.svc:8000"
+            - name: NODE_ENV
+              value: "production"
+            - name: SSO_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: sso-credentials
+                  key: SSO_ISSUER_URL
+            - name: SSO_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: sso-credentials
+                  key: SSO_CLIENT_ID
+            - name: SSO_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: sso-credentials
+                  key: SSO_CLIENT_SECRET
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: sso-credentials
+                  key: SESSION_SECRET
+            - name: NODE_EXTRA_CA_CERTS
+              value: "/etc/ssl/service-ca/service-ca.crt"
+          volumeMounts:
+            - name: next-cache
+              mountPath: /app/.next/cache
+            - name: tmp
+              mountPath: /tmp
+            - name: service-ca
+              mountPath: /etc/ssl/service-ca
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: next-cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: service-ca
+          configMap:
+            name: openshift-service-ca.crt
+            optional: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ambient-ui
+  namespace: ambient-code--runtime-int
+  labels:
+    app: ambient-ui
+spec:
+  selector:
+    app: ambient-ui
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  type: ClusterIP

--- a/components/manifests/overlays/mpp-openshift/kustomization.yaml
+++ b/components/manifests/overlays/mpp-openshift/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
 - ambient-control-plane-sa.yaml
 - tenant-rbac/
 - ambient-tenant-ingress-netpol.yaml
+- ambient-ui.yaml
+- ambient-ui-route.yaml
 
 patches:
 - path: ambient-api-server-args-patch.yaml
@@ -40,4 +42,6 @@ images:
   newName: quay.io/ambient_code/acp_control_plane
   newTag: latest
 - name: quay.io/ambient_code/acp_mcp
+  newTag: latest
+- name: quay.io/ambient_code/acp_ambient_ui
   newTag: latest


### PR DESCRIPTION
## Summary

- Adds ambient-ui Deployment, ServiceAccount, Service, and Route to the `mpp-openshift` kustomize overlay
- Route uses `shard: internal` label and HAProxy timeout annotations to match existing API server route pattern (required by MPP NetworkPolicy `internal-1`)
- UI BFF reads SSO credentials from `sso-credentials` secret (bootstrap documented in README Step D)
- Deployment follows security conventions: `runAsNonRoot`, `readOnlyRootFilesystem`, drop `ALL` capabilities, `seccompProfile: RuntimeDefault`

## Files Changed

 < /dev/null |  File | Change |
|------|--------|
| `ambient-ui.yaml` | New — SA, Deployment (SSO env, service-ca mount, health probes), Service |
| `ambient-ui-route.yaml` | New — Route with `shard: internal` + TLS edge termination |
| `kustomization.yaml` | Added UI resources + `acp_ambient_ui` image entry |
| `README.md` | Documented UI bullet, file table entries, Step D SSO bootstrap |

## Test plan

- [x] `kubectl kustomize` validates — all 4 components rendered (API, DB, CP, UI)
- [x] Deployed to S4 sector manually — pod Running, `/api/healthz` returns 200
- [ ] Route reachable after ArgoCD sync sets `spec.host` on internal shard

🤖 Generated with [Claude Code](https://claude.ai/code)