### PR TITLE
refactor(agents): remove unused parent_agent_id field

### DIFF
--- a/components/ambient-api-server/openapi/openapi.agents.yaml
+++ b/components/ambient-api-server/openapi/openapi.agents.yaml
@@ -423,8 +423,6 @@ components:
             project_id:
               type: string
               description: The project this agent belongs to
-            parent_agent_id:
-              type: string
             owner_user_id:
               type: string
             name:

--- a/components/ambient-api-server/pkg/api/openapi/api/openapi.yaml
+++ b/components/ambient-api-server/pkg/api/openapi/api/openapi.yaml
@@ -4857,8 +4857,6 @@ components:
           project_id:
             description: The project this agent belongs to
             type: string
-          parent_agent_id:
-            type: string
           owner_user_id:
             type: string
           name:
@@ -4924,7 +4922,6 @@ components:
         llm_max_tokens: 5
         labels: labels
         environment_variables: environment_variables
-        parent_agent_id: parent_agent_id
         updated_at: 2000-01-23T04:56:07.000+00:00
         project_id: project_id
         bot_account_name: bot_account_name
@@ -4962,7 +4959,6 @@ components:
           llm_max_tokens: 5
           labels: labels
           environment_variables: environment_variables
-          parent_agent_id: parent_agent_id
           updated_at: 2000-01-23T04:56:07.000+00:00
           project_id: project_id
           bot_account_name: bot_account_name
@@ -4985,7 +4981,6 @@ components:
           llm_max_tokens: 5
           labels: labels
           environment_variables: environment_variables
-          parent_agent_id: parent_agent_id
           updated_at: 2000-01-23T04:56:07.000+00:00
           project_id: project_id
           bot_account_name: bot_account_name

--- a/components/ambient-api-server/pkg/api/openapi/docs/Agent.md
+++ b/components/ambient-api-server/pkg/api/openapi/docs/Agent.md
@@ -10,7 +10,6 @@ Name | Type | Description | Notes
 **CreatedAt** | Pointer to **time.Time** |  | [optional] 
 **UpdatedAt** | Pointer to **time.Time** |  | [optional] 
 **ProjectId** | **string** | The project this agent belongs to | 
-**ParentAgentId** | Pointer to **string** |  | [optional] 
 **OwnerUserId** | Pointer to **string** |  | [optional] 
 **Name** | **string** | Human-readable identifier; unique within the project | 
 **DisplayName** | Pointer to **string** |  | [optional] 
@@ -191,31 +190,6 @@ and a boolean to check if the value has been set.
 
 SetProjectId sets ProjectId field to given value.
 
-
-### GetParentAgentId
-
-`func (o *Agent) GetParentAgentId() string`
-
-GetParentAgentId returns the ParentAgentId field if non-nil, zero value otherwise.
-
-### GetParentAgentIdOk
-
-`func (o *Agent) GetParentAgentIdOk() (*string, bool)`
-
-GetParentAgentIdOk returns a tuple with the ParentAgentId field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetParentAgentId
-
-`func (o *Agent) SetParentAgentId(v string)`
-
-SetParentAgentId sets ParentAgentId field to given value.
-
-### HasParentAgentId
-
-`func (o *Agent) HasParentAgentId() bool`
-
-HasParentAgentId returns a boolean if a field has been set.
 
 ### GetOwnerUserId
 

--- a/components/ambient-api-server/pkg/api/openapi/model_agent.go
+++ b/components/ambient-api-server/pkg/api/openapi/model_agent.go
@@ -29,9 +29,8 @@ type Agent struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 	// The project this agent belongs to
-	ProjectId     string  `json:"project_id"`
-	ParentAgentId *string `json:"parent_agent_id,omitempty"`
-	OwnerUserId   *string `json:"owner_user_id,omitempty"`
+	ProjectId   string  `json:"project_id"`
+	OwnerUserId *string `json:"owner_user_id,omitempty"`
 	// Human-readable identifier; unique within the project
 	Name        string  `json:"name"`
 	DisplayName *string `json:"display_name,omitempty"`
@@ -255,38 +254,6 @@ func (o *Agent) GetProjectIdOk() (*string, bool) {
 // SetProjectId sets field value
 func (o *Agent) SetProjectId(v string) {
 	o.ProjectId = v
-}
-
-// GetParentAgentId returns the ParentAgentId field value if set, zero value otherwise.
-func (o *Agent) GetParentAgentId() string {
-	if o == nil || IsNil(o.ParentAgentId) {
-		var ret string
-		return ret
-	}
-	return *o.ParentAgentId
-}
-
-// GetParentAgentIdOk returns a tuple with the ParentAgentId field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Agent) GetParentAgentIdOk() (*string, bool) {
-	if o == nil || IsNil(o.ParentAgentId) {
-		return nil, false
-	}
-	return o.ParentAgentId, true
-}
-
-// HasParentAgentId returns a boolean if a field has been set.
-func (o *Agent) HasParentAgentId() bool {
-	if o != nil && !IsNil(o.ParentAgentId) {
-		return true
-	}
-
-	return false
-}
-
-// SetParentAgentId gets a reference to the given string and assigns it to the ParentAgentId field.
-func (o *Agent) SetParentAgentId(v string) {
-	o.ParentAgentId = &v
 }
 
 // GetOwnerUserId returns the OwnerUserId field value if set, zero value otherwise.
@@ -819,9 +786,6 @@ func (o Agent) ToMap() (map[string]interface{}, error) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
 	toSerialize["project_id"] = o.ProjectId
-	if !IsNil(o.ParentAgentId) {
-		toSerialize["parent_agent_id"] = o.ParentAgentId
-	}
 	if !IsNil(o.OwnerUserId) {
 		toSerialize["owner_user_id"] = o.OwnerUserId
 	}

--- a/components/ambient-api-server/plugins/agents/factory_test.go
+++ b/components/ambient-api-server/plugins/agents/factory_test.go
@@ -64,7 +64,6 @@ func presentAgent(agent *agents.Agent) openapi.Agent {
 		CreatedAt:      openapi.PtrTime(agent.CreatedAt),
 		UpdatedAt:      openapi.PtrTime(agent.UpdatedAt),
 		ProjectId:      agent.ProjectId,
-		ParentAgentId:  agent.ParentAgentId,
 		OwnerUserId:    openapi.PtrString(agent.OwnerUserId),
 		Name:           agent.Name,
 		DisplayName:    agent.DisplayName,

--- a/components/ambient-api-server/plugins/agents/migration.go
+++ b/components/ambient-api-server/plugins/agents/migration.go
@@ -46,7 +46,6 @@ func agentSchemaExpansionMigration() *gormigrate.Migration {
 		ID: "202604181000",
 		Migrate: func(tx *gorm.DB) error {
 			stmts := []string{
-				`ALTER TABLE agents ADD COLUMN IF NOT EXISTS parent_agent_id TEXT`,
 				`ALTER TABLE agents ADD COLUMN IF NOT EXISTS owner_user_id TEXT NOT NULL DEFAULT ''`,
 				`ALTER TABLE agents ADD COLUMN IF NOT EXISTS display_name TEXT`,
 				`ALTER TABLE agents ADD COLUMN IF NOT EXISTS description TEXT`,
@@ -58,7 +57,6 @@ func agentSchemaExpansionMigration() *gormigrate.Migration {
 				`ALTER TABLE agents ADD COLUMN IF NOT EXISTS bot_account_name TEXT`,
 				`ALTER TABLE agents ADD COLUMN IF NOT EXISTS resource_overrides TEXT`,
 				`ALTER TABLE agents ADD COLUMN IF NOT EXISTS environment_variables TEXT`,
-				`CREATE INDEX IF NOT EXISTS idx_agents_parent_agent_id ON agents(parent_agent_id)`,
 			}
 			for _, s := range stmts {
 				if err := tx.Exec(s).Error; err != nil {
@@ -69,7 +67,7 @@ func agentSchemaExpansionMigration() *gormigrate.Migration {
 		},
 		Rollback: func(tx *gorm.DB) error {
 			cols := []string{
-				"parent_agent_id", "owner_user_id", "display_name", "description",
+				"owner_user_id", "display_name", "description",
 				"repo_url", "workflow_id", "llm_model", "llm_temperature", "llm_max_tokens",
 				"bot_account_name", "resource_overrides", "environment_variables",
 			}
@@ -79,6 +77,27 @@ func agentSchemaExpansionMigration() *gormigrate.Migration {
 				}
 			}
 			return nil
+		},
+	}
+}
+
+func dropParentAgentIdMigration() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202606171000",
+		Migrate: func(tx *gorm.DB) error {
+			stmts := []string{
+				`DROP INDEX IF EXISTS idx_agents_parent_agent_id`,
+				`ALTER TABLE agents DROP COLUMN IF EXISTS parent_agent_id`,
+			}
+			for _, s := range stmts {
+				if err := tx.Exec(s).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Exec(`ALTER TABLE agents ADD COLUMN IF NOT EXISTS parent_agent_id TEXT`).Error
 		},
 	}
 }

--- a/components/ambient-api-server/plugins/agents/model.go
+++ b/components/ambient-api-server/plugins/agents/model.go
@@ -8,7 +8,6 @@ import (
 type Agent struct {
 	api.Meta
 	ProjectId            string  `json:"project_id"             gorm:"not null;index"`
-	ParentAgentId        *string `json:"parent_agent_id"        gorm:"index"`
 	OwnerUserId          string  `json:"owner_user_id"          gorm:"not null"`
 	Name                 string  `json:"name"                   gorm:"not null"`
 	DisplayName          *string `json:"display_name"`

--- a/components/ambient-api-server/plugins/agents/plugin.go
+++ b/components/ambient-api-server/plugins/agents/plugin.go
@@ -117,4 +117,5 @@ func init() {
 
 	db.RegisterMigration(migration())
 	db.RegisterMigration(agentSchemaExpansionMigration())
+	db.RegisterMigration(dropParentAgentIdMigration())
 }

--- a/components/ambient-api-server/plugins/agents/presenter.go
+++ b/components/ambient-api-server/plugins/agents/presenter.go
@@ -14,7 +14,6 @@ func ConvertAgent(agent openapi.Agent) *Agent {
 		},
 	}
 	c.ProjectId = agent.ProjectId
-	c.ParentAgentId = agent.ParentAgentId
 	c.OwnerUserId = util.NilToEmptyString(agent.OwnerUserId)
 	c.Name = agent.Name
 	c.DisplayName = agent.DisplayName
@@ -60,7 +59,6 @@ func PresentAgent(agent *Agent) openapi.Agent {
 		CreatedAt:            openapi.PtrTime(agent.CreatedAt),
 		UpdatedAt:            openapi.PtrTime(agent.UpdatedAt),
 		ProjectId:            agent.ProjectId,
-		ParentAgentId:        agent.ParentAgentId,
 		OwnerUserId:          openapi.PtrString(agent.OwnerUserId),
 		Name:                 agent.Name,
 		DisplayName:          agent.DisplayName,

--- a/components/ambient-cli/cmd/acpctl/ambient/tui/views/detail.go
+++ b/components/ambient-cli/cmd/acpctl/ambient/tui/views/detail.go
@@ -514,7 +514,6 @@ func AgentDetail(a sdktypes.Agent) []DetailLine {
 		{Key: "Prompt", Value: a.Prompt},
 		{Key: "Current Session", Value: a.CurrentSessionID},
 		{Key: "Owner User ID", Value: a.OwnerUserID},
-		{Key: "Parent Agent ID", Value: a.ParentAgentID},
 		{Key: "Bot Account", Value: a.BotAccountName},
 		{Key: "LLM Model", Value: a.LlmModel},
 		{Key: "LLM Max Tokens", Value: formatInt32(a.LlmMaxTokens)},

--- a/components/ambient-sdk/go-sdk/types/agent.go
+++ b/components/ambient-sdk/go-sdk/types/agent.go
@@ -25,7 +25,6 @@ type Agent struct {
 	LlmTemperature       float64 `json:"llm_temperature,omitempty"`
 	Name                 string  `json:"name"`
 	OwnerUserID          string  `json:"owner_user_id,omitempty"`
-	ParentAgentID        string  `json:"parent_agent_id,omitempty"`
 	ProjectID            string  `json:"project_id"`
 	Prompt               string  `json:"prompt,omitempty"`
 	RepoURL              string  `json:"repo_url,omitempty"`
@@ -104,11 +103,6 @@ func (b *AgentBuilder) Name(v string) *AgentBuilder {
 
 func (b *AgentBuilder) OwnerUserID(v string) *AgentBuilder {
 	b.resource.OwnerUserID = v
-	return b
-}
-
-func (b *AgentBuilder) ParentAgentID(v string) *AgentBuilder {
-	b.resource.ParentAgentID = v
 	return b
 }
 

--- a/components/ambient-sdk/python-sdk/ambient_platform/agent.py
+++ b/components/ambient-sdk/python-sdk/ambient_platform/agent.py
@@ -31,7 +31,6 @@ class Agent:
     llm_temperature: float = 0.0
     name: str = ""
     owner_user_id: str = ""
-    parent_agent_id: str = ""
     project_id: str = ""
     prompt: str = ""
     repo_url: str = ""
@@ -58,7 +57,6 @@ class Agent:
             llm_temperature=data.get("llm_temperature", 0.0),
             name=data.get("name", ""),
             owner_user_id=data.get("owner_user_id", ""),
-            parent_agent_id=data.get("parent_agent_id", ""),
             project_id=data.get("project_id", ""),
             prompt=data.get("prompt", ""),
             repo_url=data.get("repo_url", ""),
@@ -137,10 +135,6 @@ class AgentBuilder:
 
     def owner_user_id(self, value: str) -> AgentBuilder:
         self._data["owner_user_id"] = value
-        return self
-
-    def parent_agent_id(self, value: str) -> AgentBuilder:
-        self._data["parent_agent_id"] = value
         return self
 
     def project_id(self, value: str) -> AgentBuilder:

--- a/components/ambient-sdk/ts-sdk/src/agent.ts
+++ b/components/ambient-sdk/ts-sdk/src/agent.ts
@@ -18,7 +18,6 @@ export type Agent = ObjectReference & {
   llm_temperature: number;
   name: string;
   owner_user_id: string;
-  parent_agent_id: string;
   project_id: string;
   prompt: string;
   repo_url: string;
@@ -42,7 +41,6 @@ export type AgentCreateRequest = {
   llm_temperature?: number;
   name: string;
   owner_user_id?: string;
-  parent_agent_id?: string;
   project_id: string;
   prompt?: string;
   repo_url?: string;
@@ -119,11 +117,6 @@ export class AgentBuilder {
 
   ownerUserId(value: string): this {
     this.data['owner_user_id'] = value;
-    return this;
-  }
-
-  parentAgentId(value: string): this {
-    this.data['parent_agent_id'] = value;
     return this;
   }
 

--- a/components/ambient-ui/src/adapters/__tests__/mappers.test.ts
+++ b/components/ambient-ui/src/adapters/__tests__/mappers.test.ts
@@ -474,7 +474,6 @@ function makeSdkAgent(overrides: Partial<Agent> = {}): Agent {
     llm_temperature: 0.7,
     name: 'test-agent',
     owner_user_id: 'user-42',
-    parent_agent_id: '',
     project_id: 'proj-123',
     prompt: 'You are a helpful agent.',
     repo_url: 'https://github.com/org/repo',

--- a/specs/platform/data-model.spec.md
+++ b/specs/platform/data-model.spec.md
@@ -72,7 +72,6 @@ erDiagram
     Agent {
         string ID PK "KSUID"
         string project_id FK
-        string parent_agent_id FK "nullable — parent agent for sub-agents"
         string owner_user_id FK "user who owns this agent"
         string name "human-readable; unique within project"
         string display_name "nullable — human-friendly display label"
@@ -440,7 +439,6 @@ Agent is scoped to a Project. The stable address is `{project_name}/{agent_name}
 | `display_name` | Nullable. Human-friendly label for UI display; does not affect addressing. |
 | `description` | Nullable. Free-text purpose description. |
 | `prompt` | Defines who the agent is. Mutable via PATCH. Access controlled by RBAC (`agent:editor` or higher). |
-| `parent_agent_id` | Nullable FK. Set when this agent was spawned as a sub-agent by another agent. |
 | `owner_user_id` | FK to the User who owns this agent. Set at creation; matches the authenticated caller. |
 | `repo_url` | Nullable. Primary repository URL cloned into every session the agent starts. Copied to `Session.repo_url` on ignite. |
 | `workflow_id` | Nullable. Default workflow identifier injected into sessions. Copied to `Session.workflow_id` on ignite. |


### PR DESCRIPTION
## Summary

- Remove `parent_agent_id` from the entire stack — model, presenter, migration, OpenAPI spec, generated client, CLI, all three SDKs (Go/Python/TS), UI test fixtures, and data-model spec
- Add drop-column migration `202606171000` that drops the index and column from the `agents` table
- Zero business logic depended on this field — no service queries it, no handler validates it, the control plane ignores it, and the UI excludes it from the domain model

## Files Changed (15)

 < /dev/null |  Component | Files | Change |
|---|---|---|
| API Server — model | `plugins/agents/model.go` | Remove `ParentAgentId` struct field |
| API Server — presenter | `plugins/agents/presenter.go` | Remove 2 references (ConvertAgent, PresentAgent) |
| API Server — migration | `plugins/agents/migration.go` | Remove from expansion migration, add `dropParentAgentIdMigration` |
| API Server — plugin | `plugins/agents/plugin.go` | Register drop migration |
| API Server — OpenAPI source | `openapi/openapi.agents.yaml` | Remove property |
| API Server — generated client | `pkg/api/openapi/model_agent.go` | Remove struct field + getter/setter/has methods |
| API Server — generated spec | `pkg/api/openapi/api/openapi.yaml` | Remove property + examples |
| API Server — generated docs | `pkg/api/openapi/docs/Agent.md` | Remove method docs |
| API Server — test factory | `plugins/agents/factory_test.go` | Remove from test fixture |
| CLI | `tui/views/detail.go` | Remove "Parent Agent ID" row |
| Go SDK | `types/agent.go` | Remove field + builder method |
| TS SDK | `src/agent.ts` | Remove from type, create request, builder |
| Python SDK | `agent.py` | Remove from dataclass, from_dict, builder |
| UI | `mappers.test.ts` | Remove from test fixture |
| Spec | `data-model.spec.md` | Remove from ER diagram + field table |

## Test plan

- [x] Go API server builds (`go build ./...`)
- [x] Go CLI builds (`go build ./...`)
- [x] Go SDK builds (`go build ./...`)
- [x] `go vet ./...` passes
- [x] `gofmt` passes
- [ ] CI pipeline validates all components

🤖 Generated with [Claude Code](https://claude.ai/code)