### PR TITLE
fix(deps): bump rh-trex-ai v0.0.29 → v0.0.30 to fix migration SQL bug

### DIFF
--- a/components/ambient-api-server/go.mod
+++ b/components/ambient-api-server/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/onsi/gomega v1.27.1
 	github.com/openshift-online/ocm-sdk-go v0.1.334
-	github.com/openshift-online/rh-trex-ai v0.0.29
+	github.com/openshift-online/rh-trex-ai v0.0.30
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	google.golang.org/grpc v1.79.3

--- a/components/ambient-api-server/go.sum
+++ b/components/ambient-api-server/go.sum
@@ -432,8 +432,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/openshift-online/ocm-sdk-go v0.1.334 h1:45WSkXEsmpGekMa9kO6NpEG8PW5/gfmMekr7kL+1KvQ=
 github.com/openshift-online/ocm-sdk-go v0.1.334/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
-github.com/openshift-online/rh-trex-ai v0.0.29 h1:AHkJ8q3JJtV55oAQRe6scswDO6xxCUBbS9b9hqvJCyg=
-github.com/openshift-online/rh-trex-ai v0.0.29/go.mod h1:5NVw/etu4mOCO1N8A8656vE6yvt0N2tjO1yT6gjHblc=
+github.com/openshift-online/rh-trex-ai v0.0.30 h1:fgd/5XozbOb7wtkXzMQcOrO7TL1bbluLzP1GrASZCWY=
+github.com/openshift-online/rh-trex-ai v0.0.30/go.mod h1:5NVw/etu4mOCO1N8A8656vE6yvt0N2tjO1yT6gjHblc=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Summary
- Bumps `github.com/openshift-online/rh-trex-ai` from v0.0.29 to v0.0.30
- Fixes migration init container crash: `pq: got 2 parameters but the statement requires 1` at `migrate.go:30`
- This is a blocker for S4 API server deployment — the migration must succeed before the API server pod can start

## Test plan
- [ ] CI passes (build, lint, vet, integration tests)
- [ ] Deploy to S4 cluster and verify migration init container completes successfully
- [ ] API server pod starts and serves requests

🤖 Generated with [Claude Code](https://claude.ai/code)