### PR TITLE
feat(templates): parameterize DB secret and SSL mode for app-interface RDS support

### DIFF
--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -212,22 +212,22 @@ objects:
               - name: PGHOST
                 valueFrom:
                   secretKeyRef:
-                    name: ambient-api-server-db
+                    name: ${DB_SECRET_NAME}
                     key: db.host
               - name: PGUSER
                 valueFrom:
                   secretKeyRef:
-                    name: ambient-api-server-db
+                    name: ${DB_SECRET_NAME}
                     key: db.user
               - name: PGPASSWORD
                 valueFrom:
                   secretKeyRef:
-                    name: ambient-api-server-db
+                    name: ${DB_SECRET_NAME}
                     key: db.password
               - name: PGDATABASE
                 valueFrom:
                   secretKeyRef:
-                    name: ambient-api-server-db
+                    name: ${DB_SECRET_NAME}
                     key: db.name
           - name: migration
             image: ${IMAGE_AMBIENT_API_SERVER}:${IMAGE_TAG}
@@ -240,7 +240,7 @@ objects:
               - --db-user-file=/secrets/db/db.user
               - --db-password-file=/secrets/db/db.password
               - --db-name-file=/secrets/db/db.name
-              - --db-sslmode=disable
+              - --db-sslmode=${DB_SSLMODE}
               - --alsologtostderr
               - -v=4
             volumeMounts:
@@ -303,7 +303,7 @@ objects:
               - --metrics-server-bindaddress=:4433
               - --health-check-server-bindaddress=:4434
               - --enable-health-check-https=false
-              - --db-sslmode=disable
+              - --db-sslmode=${DB_SSLMODE}
               - --db-max-open-connections=50
               - --enable-db-debug=false
               - --enable-metrics-https=false
@@ -366,7 +366,7 @@ objects:
         volumes:
           - name: db-secrets
             secret:
-              secretName: ambient-api-server-db
+              secretName: ${DB_SECRET_NAME}
           - name: app-secrets
             secret:
               secretName: ambient-api-server
@@ -735,18 +735,24 @@ parameters:
   - name: NAMESPACE
     description: Target namespace
     value: ambient-api
+  - name: DB_SECRET_NAME
+    description: Name of the Secret containing db.host, db.port, db.user, db.password, db.name
+    value: ambient-api-server-db
+  - name: DB_SSLMODE
+    description: PostgreSQL SSL mode (disable for in-cluster, require for RDS)
+    value: disable
   - name: KEYCLOAK_REALM_URL
     description: Keycloak realm URL (e.g. https://keycloak.example.com/realms/ambient-code)
     required: true
   - name: ROUTE_HOST_API
-    description: API server route hostname
-    required: true
+    description: API server route hostname (leave empty for auto-generated)
+    value: ""
   - name: ROUTE_HOST_UI
-    description: UI route hostname
-    required: true
+    description: UI route hostname (leave empty for auto-generated)
+    value: ""
   - name: SSO_REDIRECT_URI
-    description: OIDC callback URL for ambient-ui
-    required: true
+    description: OIDC callback URL for ambient-ui (leave empty to derive from route)
+    value: ""
   - name: ANTHROPIC_VERTEX_PROJECT_ID
     description: GCP project ID for Vertex AI
     value: itpc-gcp-hcm-pe-eng-claude

--- a/components/manifests/templates/validate.sh
+++ b/components/manifests/templates/validate.sh
@@ -12,9 +12,6 @@ for template in template-services.yaml; do
   oc process -f "$template" \
     --param=IMAGE_TAG=validation-test \
     --param=KEYCLOAK_REALM_URL=https://keycloak.example.com/realms/ambient-code \
-    --param=ROUTE_HOST_API=api.example.com \
-    --param=ROUTE_HOST_UI=ui.example.com \
-    --param=SSO_REDIRECT_URI=https://ui.example.com/api/auth/sso/callback \
     --local > /dev/null
   echo "    ✓ Valid"
 done


### PR DESCRIPTION
## Summary
- Adds `DB_SECRET_NAME` and `DB_SSLMODE` parameters to the OpenShift template, enabling deployment with external databases (e.g. AWS RDS provisioned by app-interface) instead of only the in-cluster PostgreSQL
- Makes `ROUTE_HOST_API`, `ROUTE_HOST_UI`, and `SSO_REDIRECT_URI` optional with empty defaults for auto-generation
- Updates `validate.sh` to match the simplified required parameters

## Motivation
The `ambient-code` namespace on HCMAIS is managed by [app-interface](https://gitlab.cee.redhat.com/service/app-interface), which provisions an RDS PostgreSQL database via external resources. The RDS secret (`ambient-code-rds`) has the same key schema (`db.host`, `db.port`, `db.user`, `db.password`, `db.name`) as the in-cluster `ambient-api-server-db` secret, so parameterizing the secret name and SSL mode is all that's needed.

App-interface saasfile will pass:
```yaml
parameters:
  DB_SECRET_NAME: ambient-code-rds
  DB_SSLMODE: require
```

## Test plan
- [x] `oc process -f template-services.yaml --param IMAGE_TAG=latest --param KEYCLOAK_REALM_URL=https://keycloak.example.com/realms/ambient-code --local` succeeds
- [x] `oc process` with `DB_SECRET_NAME=ambient-code-rds --param DB_SSLMODE=require` correctly substitutes all secret references and sslmode flags
- [x] Existing behavior (in-cluster DB, `ambient-api-server-db` secret, `sslmode=disable`) is preserved as defaults

🤖 Generated with [Claude Code](https://claude.ai/code)