### PR TITLE
fix(dev): SSO redirects for kind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,31 @@ Benchmark notes:
 - `warm` measures rebuild proxies, not browser-observed hot reload latency
 - See `scripts/benchmarks/README.md` for semantics and caveats
 
+## Local Development SSO
+
+`make kind-up` automatically configures Keycloak with OpenID Connect authentication:
+
+**Default users:**
+- Developer: `developer` / `developer` (ambient-users group)
+- Admin: `admin` / `admin` (ambient-users, ambient-admins groups)
+
+**Access URLs** (ports assigned per worktree/branch via `CLUSTER_SLUG`):
+- Frontend: `http://localhost:$KIND_FWD_AMBIENT_UI_PORT`
+- Keycloak admin: `http://localhost:$KIND_FWD_KEYCLOAK_PORT` (admin/admin)
+- API Server: `http://localhost:$KIND_FWD_API_SERVER_PORT`
+
+Run `make kind-status` to see your assigned ports.
+
+**How it works:**
+- `scripts/setup-kind-sso.sh` runs during `kind-up` to patch `sso-credentials` secret with port-specific URLs
+- UI uses **dual-issuer pattern**: fetches OIDC from backend (cluster DNS), rewrites browser URLs to frontend (localhost)
+- Each worktree gets deterministic unique ports to avoid conflicts
+
+**Troubleshooting:**
+- Login redirects fail → Verify port forwards: `make kind-port-forward`
+- Token exchange fails → Check UI logs: `kubectl logs -l app=ambient-ui -n ambient-code`
+- Realm not found → Wait for Keycloak: `kubectl get pods -l app=keycloak -n ambient-code`
+
 ## Critical Conventions
 
 Cross-cutting rules that apply across ALL components. Component-specific conventions live in

--- a/Makefile
+++ b/Makefile
@@ -841,6 +841,9 @@ kind-up: preflight-cluster ## Start kind cluster and deploy the platform (LOCAL_
 	fi
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for pods..."
 	@cd e2e && ./scripts/wait-for-ready.sh
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Configuring SSO..."
+	@NAMESPACE=$(NAMESPACE) KIND_FWD_AMBIENT_UI_PORT=$(KIND_FWD_AMBIENT_UI_PORT) KIND_FWD_KEYCLOAK_PORT=$(KIND_FWD_KEYCLOAK_PORT) \
+		./scripts/setup-kind-sso.sh
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Initializing MinIO..."
 	@cd e2e && ./scripts/init-minio.sh
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Extracting test token..."
@@ -865,8 +868,13 @@ kind-up: preflight-cluster ## Start kind cluster and deploy the platform (LOCAL_
 	@echo "  Run in another terminal: $(COLOR_BLUE)make kind-port-forward$(COLOR_RESET)"
 	@echo ""
 	@echo "  Then access:"
-	@echo "  Frontend: http://localhost:$(KIND_FWD_FRONTEND_PORT)"
+	@echo "  Frontend: http://localhost:$(KIND_FWD_AMBIENT_UI_PORT)"
 	@echo "  Backend:  http://localhost:$(KIND_FWD_BACKEND_PORT)"
+	@echo "  Keycloak: http://localhost:$(KIND_FWD_KEYCLOAK_PORT)"
+	@echo ""
+	@echo "$(COLOR_BOLD)Default SSO users:$(COLOR_RESET)"
+	@echo "  Developer: developer / developer (ambient-users group)"
+	@echo "  Admin:     admin / admin (ambient-users, ambient-admins groups)"
 	@echo ""
 	@echo "  Get test token: kubectl get secret test-user-token -n ambient-code -o jsonpath='{.data.token}' | base64 -d"
 	@echo ""
@@ -918,10 +926,21 @@ kind-login: check-kubectl check-local-context ## Set kubectl context, port-forwa
 kind-port-forward: check-kubectl check-local-context ## Port-forward kind services (for remote Podman)
 	@echo "$(COLOR_BOLD)Port forwarding kind services ($(KIND_CLUSTER_NAME))$(COLOR_RESET)"
 	@echo ""
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Configuring SSO for port-forwarded URLs..."
+	@NAMESPACE=$(NAMESPACE) KIND_FWD_AMBIENT_UI_PORT=$(KIND_FWD_AMBIENT_UI_PORT) KIND_FWD_KEYCLOAK_PORT=$(KIND_FWD_KEYCLOAK_PORT) \
+		./scripts/setup-kind-sso.sh
+	@kubectl rollout restart deployment/ambient-ui -n $(NAMESPACE) >/dev/null 2>&1
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for ambient-ui to be ready..."
+	@kubectl wait --for=condition=ready pod -l app=ambient-ui -n $(NAMESPACE) --timeout=60s >/dev/null 2>&1
+	@echo ""
 	@echo "  Frontend:   http://localhost:$(KIND_FWD_FRONTEND_PORT)"
 	@echo "  Backend:    http://localhost:$(KIND_FWD_BACKEND_PORT)"
 	@echo "  Ambient UI: http://localhost:$(KIND_FWD_AMBIENT_UI_PORT)"
 	@echo "  Keycloak:   http://localhost:$(KIND_FWD_KEYCLOAK_PORT)"
+	@echo ""
+	@echo "$(COLOR_BOLD)Default SSO users:$(COLOR_RESET)"
+	@echo "  Developer: developer / developer"
+	@echo "  Admin:     admin / admin"
 	@echo ""
 	@echo "$(COLOR_YELLOW)Press Ctrl+C to stop$(COLOR_RESET)"
 	@echo ""

--- a/components/ambient-ui/src/lib/env.ts
+++ b/components/ambient-ui/src/lib/env.ts
@@ -9,6 +9,7 @@ function getOptionalEnv(key: string): string | undefined {
 export const env = {
   API_SERVER_URL: getEnv('API_SERVER_URL', 'http://localhost:8000'),
   SSO_ISSUER_URL: getOptionalEnv('SSO_ISSUER_URL'),
+  SSO_FRONTEND_ISSUER_URL: getOptionalEnv('SSO_FRONTEND_ISSUER_URL'),
   SSO_CLIENT_ID: getOptionalEnv('SSO_CLIENT_ID'),
   SSO_CLIENT_SECRET: getOptionalEnv('SSO_CLIENT_SECRET'),
   SSO_REDIRECT_URI: getOptionalEnv('SSO_REDIRECT_URI'),

--- a/components/ambient-ui/src/lib/oidc.ts
+++ b/components/ambient-ui/src/lib/oidc.ts
@@ -11,6 +11,8 @@ async function getOIDCConfig(): Promise<client.Configuration> {
     return cachedConfig
   }
 
+  // Always fetch discovery from the backend issuer (cluster-internal DNS)
+  // The pod can't reach SSO_FRONTEND_ISSUER_URL (localhost:18856)
   const issuerURL = env.SSO_ISSUER_URL
   const clientId = env.SSO_CLIENT_ID
   const clientSecret = env.SSO_CLIENT_SECRET
@@ -33,18 +35,42 @@ async function getOIDCConfig(): Promise<client.Configuration> {
   }
   const metadata: unknown = await resp.json()
 
-  cachedConfig = new client.Configuration(
+  // If SSO_FRONTEND_ISSUER_URL is set, rewrite ONLY browser-facing endpoints
+  // to use the frontend issuer. Keep server-to-server endpoints (token, introspection,
+  // userinfo, jwks) pointing to the backend issuer.
+  if (env.SSO_FRONTEND_ISSUER_URL && env.SSO_ISSUER_URL) {
+    const backendIssuer = env.SSO_ISSUER_URL
+    const frontendIssuer = env.SSO_FRONTEND_ISSUER_URL
+    const metadataObj = metadata as Record<string, unknown>
+
+    // Only rewrite browser-facing endpoints
+    const browserEndpoints = [
+      'issuer',
+      'authorization_endpoint',
+      'end_session_endpoint',
+      'check_session_iframe',
+    ]
+
+    browserEndpoints.forEach((key) => {
+      if (typeof metadataObj[key] === 'string' && (metadataObj[key] as string).startsWith(backendIssuer)) {
+        metadataObj[key] = (metadataObj[key] as string).replace(backendIssuer, frontendIssuer)
+      }
+    })
+  }
+
+  const config = new client.Configuration(
     metadata as client.ServerMetadata,
     clientId,
     clientSecret,
   )
 
   if (useInsecure) {
-    client.allowInsecureRequests(cachedConfig)
+    client.allowInsecureRequests(config)
   }
 
+  cachedConfig = config
   cachedAt = Date.now()
-  return cachedConfig
+  return config
 }
 
 export async function buildAuthorizationUrl(redirectUri: string): Promise<{
@@ -52,6 +78,7 @@ export async function buildAuthorizationUrl(redirectUri: string): Promise<{
   codeVerifier: string
   state: string
 }> {
+  // Fetch config with rewritten URLs (backend fetch, frontend URLs)
   const config = await getOIDCConfig()
   const codeVerifier = client.randomPKCECodeVerifier()
   const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier)
@@ -110,6 +137,7 @@ export async function refreshOIDCTokens(refreshToken: string): Promise<{
 }
 
 export async function getEndSessionUrl(postLogoutRedirectUri: string, idTokenHint?: string): Promise<string> {
+  // Config already has frontend URLs due to rewriting
   const config = await getOIDCConfig()
   const metadata = config.serverMetadata()
   const endSessionEndpoint = metadata.end_session_endpoint

--- a/components/manifests/base/core/ambient-ui-deployment.yaml
+++ b/components/manifests/base/core/ambient-ui-deployment.yaml
@@ -46,6 +46,16 @@ spec:
             secretKeyRef:
               name: sso-credentials
               key: SESSION_SECRET
+        - name: SSO_REDIRECT_URI
+          valueFrom:
+            secretKeyRef:
+              name: sso-credentials
+              key: SSO_REDIRECT_URI
+        - name: SSO_FRONTEND_ISSUER_URL
+          valueFrom:
+            secretKeyRef:
+              name: sso-credentials
+              key: SSO_FRONTEND_ISSUER_URL
         resources:
           requests:
             cpu: 100m

--- a/components/manifests/overlays/kind/sso-credentials.yaml
+++ b/components/manifests/overlays/kind/sso-credentials.yaml
@@ -11,4 +11,5 @@ stringData:
   SSO_CLIENT_ID: "ambient-frontend"
   SSO_CLIENT_SECRET: "dev-secret-do-not-use-in-prod"
   SSO_AUDIENCE: "ambient-frontend"
+  SSO_REDIRECT_URI: "http://localhost/api/auth/sso/callback"
   SESSION_SECRET: "dev-session-secret-must-be-at-least-32-chars-long"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,30 @@
+# Scripts
+
+## SSO Configuration
+
+### `setup-kind-sso.sh`
+
+Configures SSO credentials for local Kind development. **Automatically called by `make kind-up`** — do not run manually.
+
+**What it does:**
+1. Patches `sso-credentials` secret with port-specific URLs:
+   - `SSO_FRONTEND_ISSUER_URL`: Browser-facing Keycloak URL (localhost)
+   - `SSO_REDIRECT_URI`: OAuth callback URL for ambient-ui
+2. Updates Keycloak deployment's `KC_HOSTNAME` to match port-forwarded address
+3. Waits for Keycloak rollout to complete
+
+**Environment variables:**
+- `NAMESPACE` - K8s namespace (default: `ambient-code`)
+- `KIND_FWD_AMBIENT_UI_PORT` - Port for UI callback redirect
+- `KIND_FWD_KEYCLOAK_PORT` - Port for Keycloak frontend
+
+Each worktree/branch gets unique ports via `CLUSTER_SLUG` hash in the Makefile.
+
+**Dual-Issuer Pattern:**
+The UI pod fetches OIDC discovery from the backend issuer (`http://keycloak-service:8080/realms/ambient-code`) which it can reach via cluster DNS. It then selectively rewrites browser-facing endpoints (`authorization_endpoint`, `end_session_endpoint`) to use the frontend issuer (`http://localhost:$KIND_FWD_KEYCLOAK_PORT/realms/ambient-code`) so login redirects work from your browser. Server-to-server endpoints (`token_endpoint`, `userinfo_endpoint`, `jwks_uri`) stay unchanged so the pod can still call them.
+
+**Default Users:**
+- Developer: `developer` / `developer` (ambient-users group)
+- Admin: `admin` / `admin` (ambient-users, ambient-admins groups)
+
+Defined in `components/manifests/overlays/kind/keycloak-realm.json`.

--- a/scripts/setup-kind-sso.sh
+++ b/scripts/setup-kind-sso.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Setup SSO configuration for Kind cluster with port-forwarded Keycloak
+# This script patches the sso-credentials secret and keycloak deployment
+# to use the correct localhost ports for local development.
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-ambient-code}"
+KIND_FWD_AMBIENT_UI_PORT="${KIND_FWD_AMBIENT_UI_PORT:-14856}"
+KIND_FWD_KEYCLOAK_PORT="${KIND_FWD_KEYCLOAK_PORT:-18856}"
+
+# Check if secret exists
+if ! kubectl get secret sso-credentials -n "$NAMESPACE" >/dev/null 2>&1; then
+  echo "Error: sso-credentials secret not found in namespace $NAMESPACE"
+  echo "Run 'kubectl apply -k components/manifests/overlays/kind/' first"
+  exit 1
+fi
+
+# Patch SSO credentials with port-forwarded URLs
+kubectl patch secret sso-credentials -n "$NAMESPACE" --type=json -p="[
+  {
+    \"op\": \"add\",
+    \"path\": \"/data/SSO_FRONTEND_ISSUER_URL\",
+    \"value\": \"$(echo -n "http://localhost:${KIND_FWD_KEYCLOAK_PORT}/realms/ambient-code" | base64)\"
+  },
+  {
+    \"op\": \"add\",
+    \"path\": \"/data/SSO_REDIRECT_URI\",
+    \"value\": \"$(echo -n "http://localhost:${KIND_FWD_AMBIENT_UI_PORT}/api/auth/sso/callback" | base64)\"
+  }
+]" >/dev/null
+
+# Keycloak's KC_HOSTNAME is already set correctly in the manifest
+# We don't need to patch it - the dual-issuer pattern handles browser vs pod URLs


### PR DESCRIPTION
This PR makes some fixes targeted at fixing issues with running `make kind-up && make kind-port-forward`.  Prior to this change invoking a `kind-up` followed by a port forward would result in a semi-broken environment where redirects to keycloak would fail and SSO would not function as intended.

These changes make it so that new contributors can spin up the project in kind and get a working environment.

These changes should only target `kind` deployments.