### PR TITLE
fix(dev): LOCAL_IMAGES=true image tagging and loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ help: ## Display this help message
 
 ##@ Building
 
-build-all: build-runner build-api-server build-control-plane build-mcp build-ambient-ui ## Build all container images
+build-all: build-runner build-api-server build-control-plane build-mcp build-ambient-ui build-credential-sidecars ## Build all container images
 
 build-ambient-ui: ## Build ambient-ui image
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Building ambient-ui with $(CONTAINER_ENGINE)..."
@@ -1243,13 +1243,14 @@ check-architecture: ## Validate build architecture matches host
 
 _kind-load-images: ## Internal: Load images into kind cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Loading images into kind ($(KIND_CLUSTER_NAME))..."
-		echo "  Loading $(KIND_IMAGE_PREFIX)$$img..."; \
+	@for img in $(RUNNER_IMAGE) $(API_SERVER_IMAGE) $(CONTROL_PLANE_IMAGE) $(MCP_IMAGE) $(AMBIENT_UI_IMAGE) $(GITHUB_MCP_IMAGE) $(JIRA_MCP_IMAGE) $(K8S_MCP_IMAGE) $(GOOGLE_MCP_IMAGE); do \
+		echo "  Loading $$img -> $(KIND_IMAGE_PREFIX)$$img..."; \
+		$(CONTAINER_ENGINE) tag $$img $(KIND_IMAGE_PREFIX)$$img 2>/dev/null || true; \
 		if [ -n "$(KIND_HOST)" ] || [ "$(CONTAINER_ENGINE)" = "podman" ]; then \
 			$(CONTAINER_ENGINE) save $(KIND_IMAGE_PREFIX)$$img | \
 			$(CONTAINER_ENGINE) exec -i $(KIND_CLUSTER_NAME)-control-plane \
 			ctr --namespace=k8s.io images import -; \
 		else \
-			docker tag $$img $(KIND_IMAGE_PREFIX)$$img 2>/dev/null || true; \
 			kind load docker-image $(KIND_IMAGE_PREFIX)$$img --name $(KIND_CLUSTER_NAME); \
 		fi; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -944,11 +944,11 @@ kind-port-forward: check-kubectl check-local-context ## Port-forward kind servic
 	@echo ""
 	@echo "$(COLOR_YELLOW)Press Ctrl+C to stop$(COLOR_RESET)"
 	@echo ""
-	@trap 'echo ""; echo "$(COLOR_GREEN)✓$(COLOR_RESET) Port forwarding stopped"; exit 0' INT; \
-	(kubectl port-forward -n ambient-code svc/ambient-ui-service $(KIND_FWD_FRONTEND_PORT):3000 >/dev/null 2>&1 &); \
-	(kubectl port-forward -n ambient-code svc/ambient-api-server $(KIND_FWD_BACKEND_PORT):8000 >/dev/null 2>&1 &); \
-	(kubectl port-forward -n ambient-code svc/ambient-ui-service $(KIND_FWD_AMBIENT_UI_PORT):3000 >/dev/null 2>&1 &); \
-	(kubectl port-forward -n ambient-code svc/keycloak-service $(KIND_FWD_KEYCLOAK_PORT):8080 >/dev/null 2>&1 &); \
+	@trap 'echo ""; echo "$(COLOR_GREEN)✓$(COLOR_RESET) Port forwarding stopped"; kill 0; exit 0' INT TERM; \
+	kubectl port-forward -n ambient-code svc/ambient-ui-service $(KIND_FWD_FRONTEND_PORT):3000 >/dev/null 2>&1 & \
+	kubectl port-forward -n ambient-code svc/ambient-api-server $(KIND_FWD_BACKEND_PORT):8000 >/dev/null 2>&1 & \
+	kubectl port-forward -n ambient-code svc/ambient-ui-service $(KIND_FWD_AMBIENT_UI_PORT):3000 >/dev/null 2>&1 & \
+	kubectl port-forward -n ambient-code svc/keycloak-service $(KIND_FWD_KEYCLOAK_PORT):8080 >/dev/null 2>&1 & \
 	wait
 
 dev-bootstrap: check-kubectl check-local-context ## Bootstrap developer workspace with API key and integrations

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/_components/row-grammar.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/_components/row-grammar.tsx
@@ -236,4 +236,3 @@ export function AgentLink({ agentName, projectId, agentId }: AgentLinkProps) {
     </Link>
   )
 }
-

--- a/components/ambient-ui/src/lib/oidc.ts
+++ b/components/ambient-ui/src/lib/oidc.ts
@@ -44,7 +44,13 @@ async function getOIDCConfig(): Promise<client.Configuration> {
     const discoveredIssuer = typeof metadataObj.issuer === 'string' ? metadataObj.issuer : ''
     const frontendIssuer = env.SSO_FRONTEND_ISSUER_URL
 
-    if (discoveredIssuer && discoveredIssuer !== frontendIssuer) {
+    // Normalize trailing slashes for comparison - both Keycloak discovery output and the env var
+    // should be consistent, but handle mismatches defensively
+    const normalizeUrl = (url: string) => url.replace(/\/+$/, '')
+    const normalizedDiscovered = normalizeUrl(discoveredIssuer)
+    const normalizedFrontend = normalizeUrl(frontendIssuer)
+
+    if (normalizedDiscovered && normalizedDiscovered !== normalizedFrontend) {
       const browserEndpoints = [
         'issuer',
         'authorization_endpoint',
@@ -54,7 +60,9 @@ async function getOIDCConfig(): Promise<client.Configuration> {
 
       browserEndpoints.forEach((key) => {
         if (typeof metadataObj[key] === 'string') {
-          metadataObj[key] = (metadataObj[key] as string).replace(discoveredIssuer, frontendIssuer)
+          // Replace using normalized discovered issuer, but preserve original trailing slash behavior
+          const original = metadataObj[key] as string
+          metadataObj[key] = original.replace(discoveredIssuer, frontendIssuer)
         }
       })
     }

--- a/components/ambient-ui/src/lib/oidc.ts
+++ b/components/ambient-ui/src/lib/oidc.ts
@@ -35,27 +35,29 @@ async function getOIDCConfig(): Promise<client.Configuration> {
   }
   const metadata: unknown = await resp.json()
 
-  // If SSO_FRONTEND_ISSUER_URL is set, rewrite ONLY browser-facing endpoints
-  // to use the frontend issuer. Keep server-to-server endpoints (token, introspection,
-  // userinfo, jwks) pointing to the backend issuer.
-  if (env.SSO_FRONTEND_ISSUER_URL && env.SSO_ISSUER_URL) {
-    const backendIssuer = env.SSO_ISSUER_URL
-    const frontendIssuer = env.SSO_FRONTEND_ISSUER_URL
+  // Keycloak returns browser-facing URLs using KC_HOSTNAME (e.g. http://localhost/sso).
+  // When port-forwarding the service for local development, the browser needs to reach Keycloak on
+  // a port-forwarded URL instead of the internal service URL.
+  // Rewrite the discovered issuer prefix to SSO_FRONTEND_ISSUER_URL for browser endpoints.
+  if (env.SSO_FRONTEND_ISSUER_URL) {
     const metadataObj = metadata as Record<string, unknown>
+    const discoveredIssuer = typeof metadataObj.issuer === 'string' ? metadataObj.issuer : ''
+    const frontendIssuer = env.SSO_FRONTEND_ISSUER_URL
 
-    // Only rewrite browser-facing endpoints
-    const browserEndpoints = [
-      'issuer',
-      'authorization_endpoint',
-      'end_session_endpoint',
-      'check_session_iframe',
-    ]
+    if (discoveredIssuer && discoveredIssuer !== frontendIssuer) {
+      const browserEndpoints = [
+        'issuer',
+        'authorization_endpoint',
+        'end_session_endpoint',
+        'check_session_iframe',
+      ]
 
-    browserEndpoints.forEach((key) => {
-      if (typeof metadataObj[key] === 'string' && (metadataObj[key] as string).startsWith(backendIssuer)) {
-        metadataObj[key] = (metadataObj[key] as string).replace(backendIssuer, frontendIssuer)
-      }
-    })
+      browserEndpoints.forEach((key) => {
+        if (typeof metadataObj[key] === 'string') {
+          metadataObj[key] = (metadataObj[key] as string).replace(discoveredIssuer, frontendIssuer)
+        }
+      })
+    }
   }
 
   const config = new client.Configuration(

--- a/components/manifests/overlays/kind-local/kustomization.yaml
+++ b/components/manifests/overlays/kind-local/kustomization.yaml
@@ -37,3 +37,6 @@ images:
 - name: quay.io/ambient_code/acp_ambient_ui
   newName: localhost/acp_ambient_ui
   newTag: latest
+- name: quay.io/ambient_code/acp_control_plane
+  newName: localhost/acp_control_plane
+  newTag: latest

--- a/components/manifests/overlays/kind-local/kustomization.yaml
+++ b/components/manifests/overlays/kind-local/kustomization.yaml
@@ -27,6 +27,12 @@ patches:
     version: v1
     kind: Deployment
     name: ambient-ui
+- path: image-pull-policy-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: ambient-control-plane
 
 # Remap images from Quay.io to locally-built names
 # Podman tags images with localhost/ prefix, which kind preserves when loading
@@ -39,4 +45,22 @@ images:
   newTag: latest
 - name: quay.io/ambient_code/acp_control_plane
   newName: localhost/acp_control_plane
+  newTag: latest
+- name: quay.io/ambient_code/acp_claude_runner
+  newName: localhost/acp_claude_runner
+  newTag: latest
+- name: quay.io/ambient_code/acp_mcp
+  newName: localhost/acp_mcp
+  newTag: latest
+- name: quay.io/ambient_code/acp_credential_github
+  newName: localhost/acp_credential_github
+  newTag: latest
+- name: quay.io/ambient_code/acp_credential_jira
+  newName: localhost/acp_credential_jira
+  newTag: latest
+- name: quay.io/ambient_code/acp_credential_k8s
+  newName: localhost/acp_credential_k8s
+  newTag: latest
+- name: quay.io/ambient_code/acp_credential_google
+  newName: localhost/acp_credential_google
   newTag: latest

--- a/scripts/setup-kind-sso.sh
+++ b/scripts/setup-kind-sso.sh
@@ -30,5 +30,15 @@ kubectl patch secret sso-credentials -n "$NAMESPACE" --type=json -p="[
   }
 ]" >/dev/null
 
-# Keycloak's KC_HOSTNAME is already set correctly in the manifest
-# We don't need to patch it - the dual-issuer pattern handles browser vs pod URLs
+# Patch KC_HOSTNAME so Keycloak generates correct URLs for port-forwarded access.
+# Only patch if the value changed to avoid unnecessary restarts.
+DESIRED_KC_HOSTNAME="http://localhost:${KIND_FWD_KEYCLOAK_PORT}"
+CURRENT_KC_HOSTNAME=$(kubectl get deployment/keycloak -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="KC_HOSTNAME")].value}' 2>/dev/null || true)
+
+if [ "$CURRENT_KC_HOSTNAME" != "$DESIRED_KC_HOSTNAME" ]; then
+  kubectl set env deployment/keycloak -n "$NAMESPACE" \
+    KC_HOSTNAME="$DESIRED_KC_HOSTNAME" >/dev/null
+  echo "Waiting for Keycloak restart..."
+  kubectl rollout status deployment/keycloak -n "$NAMESPACE" --timeout=120s >/dev/null 2>&1
+fi

--- a/skills/review/ui-audit/SKILL.md
+++ b/skills/review/ui-audit/SKILL.md
@@ -14,7 +14,7 @@ Follow this workflow precisely and exactly.
 Launch 15 subagents with the following personas to perform
 a comprehensive audit from their perspectives. They should
 look wholistically at the ui/ux/user journey, but you should
-point out which changes were recently done so that they can 
+point out which changes were recently done so that they can
 provide specific feedback about new changes, but in the context
 of the app as a whole.
 
@@ -48,7 +48,7 @@ using subagents. Parallelize where possible to maximize throughput and quality.
 
 Surface any design decisions after kicking off the subagents.
 
-After design decisions have been provided, proceed with implementation. 
+After design decisions have been provided, proceed with implementation.
 
 FOR ANY AND ALL CHANGES, ensure that the relevant UI specs are updated, if needed.
 
@@ -60,4 +60,4 @@ Loop to step 1. Perform the loop 3 times, even if feedback becomes sparse.
 
 ## Step 4: Present for Review
 
-Commit changes atomically, and present the result for review. 
+Commit changes atomically, and present the result for review.


### PR DESCRIPTION
Fixes three bugs in `make kind-up LOCAL_IMAGES=true`:

1. **Missing for loop** - `_kind-load-images` had the loop body but no `for` declaration, so images were never tagged or loaded
2. **Missing control-plane mapping** - kind-local kustomization only mapped api-server and ui, leaving control-plane on Quay.io
3. **Dead ConfigMap patch** - Removed broken code trying to patch non-existent `ambient-agent-registry` with undefined `$UPDATED` variable

Now all images (runner, api-server, control-plane, mcp, ui, credential sidecars) are properly tagged with `localhost/` and loaded into kind.