### PR TITLE
fix(dev): update vertex setup and fix RBAC for kind clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: local-dev-token
 .PHONY: local-logs local-logs-api-server local-logs-ui local-logs-control-plane local-shell-api-server local-shell-ui
 .PHONY: local-test local-test-dev local-test-quick test-all local-troubleshoot local-port-forward local-stop-port-forward
-.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-status kind-login kind-sso-toggle
+.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-status kind-login kind-sso-toggle kind-setup-vertex
 .PHONY: preflight-cluster preflight dev-env dev
 .PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift
 .PHONY: unleash-port-forward unleash-status
@@ -855,6 +855,7 @@ kind-up: preflight-cluster ## Start kind cluster and deploy the platform (LOCAL_
 		ANTHROPIC_VERTEX_PROJECT_ID="$(ANTHROPIC_VERTEX_PROJECT_ID)" \
 		CLOUD_ML_REGION="$(CLOUD_ML_REGION)" \
 		GOOGLE_APPLICATION_CREDENTIALS="$(GOOGLE_APPLICATION_CREDENTIALS)" \
+		AMBIENT_UI_URL="http://$$(if [ -n "$(KIND_HOST)" ]; then echo "$(KIND_HOST)"; else echo "localhost"; fi):$(KIND_FWD_AMBIENT_UI_PORT)" \
 		./scripts/setup-vertex-kind.sh; \
 	fi
 	@if [ -f .dev-bootstrap.env ] && [ -f ./scripts/bootstrap-workspace.sh ]; then \
@@ -1028,9 +1029,7 @@ screenshots-clean: ## Remove generated screenshots
 	@rm -rf e2e/cypress/screenshots/output/
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Screenshot output cleaned"
 
-kind-rebuild: check-kind check-kubectl check-local-context build-all ## Rebuild, reload, and restart all components in kind
-	@$(if $(filter podman,$(CONTAINER_ENGINE)),KIND_EXPERIMENTAL_PROVIDER=podman) kind get clusters 2>/dev/null | grep -q '^$(KIND_CLUSTER_NAME)$$' || \
-		(echo "$(COLOR_RED)✗$(COLOR_RESET) Kind cluster '$(KIND_CLUSTER_NAME)' not found. Run 'make kind-up LOCAL_IMAGES=true' first." && exit 1)
+kind-rebuild: check-kind check-kubectl check-local-context _kind-require-cluster build-all ## Rebuild, reload, and restart all components in kind
 	@$(MAKE) --no-print-directory _kind-load-images
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Applying kind-local manifests..."
 	@kubectl apply --validate=false -k components/manifests/overlays/kind-local/ $(QUIET_REDIRECT)
@@ -1114,6 +1113,11 @@ kind-status: check-kind ## Show all kind clusters and their port assignments
 			fi; \
 		done; \
 	fi
+
+kind-setup-vertex: check-kubectl _kind-require-cluster ## Configure Vertex AI for the kind cluster
+	@NAMESPACE=$(NAMESPACE) \
+		AMBIENT_UI_URL="http://$$(if [ -n "$(KIND_HOST)" ]; then echo "$(KIND_HOST)"; else echo "localhost"; fi):$(KIND_FWD_AMBIENT_UI_PORT)" \
+		./scripts/setup-vertex-kind.sh
 
 kind-clean: kind-down ## Alias for kind-down
 
@@ -1240,6 +1244,10 @@ check-architecture: ## Validate build architecture matches host
 	else \
 		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Using native architecture"; \
 	fi
+
+_kind-require-cluster: ## Internal: Fail fast if kind cluster is not running
+	@$(if $(filter podman,$(CONTAINER_ENGINE)),KIND_EXPERIMENTAL_PROVIDER=podman) kind get clusters 2>/dev/null | grep -q '^$(KIND_CLUSTER_NAME)$$' || \
+		(echo "$(COLOR_RED)✗$(COLOR_RESET) Kind cluster '$(KIND_CLUSTER_NAME)' not found. Run 'make kind-up LOCAL_IMAGES=true' first, or set KIND_CLUSTER_NAME to an existing cluster." && exit 1)
 
 _kind-load-images: ## Internal: Load images into kind cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Loading images into kind ($(KIND_CLUSTER_NAME))..."

--- a/components/ambient-control-plane/cmd/ambient-control-plane/main.go
+++ b/components/ambient-control-plane/cmd/ambient-control-plane/main.go
@@ -189,7 +189,7 @@ func runKubeMode(ctx context.Context, cfg *config.ControlPlaneConfig) error {
 
 	inf := informer.New(sdk, watchManager, log.Logger)
 
-	projectReconciler := reconciler.NewProjectReconciler(factory, kube, projectKube, provisioner, cfg.CPRuntimeNamespace, log.Logger)
+	projectReconciler := reconciler.NewProjectReconciler(factory, kube, projectKube, provisioner, cfg.CPRuntimeNamespace, cfg.PlatformMode, log.Logger)
 	projectSettingsReconciler := reconciler.NewProjectSettingsReconciler(factory, kube, log.Logger)
 
 	inf.RegisterHandler("projects", projectReconciler.Reconcile)

--- a/components/ambient-control-plane/internal/reconciler/project_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/project_reconciler.go
@@ -21,6 +21,7 @@ type ProjectReconciler struct {
 	projectKube        *kubeclient.KubeClient
 	provisioner        kubeclient.NamespaceProvisioner
 	cpRuntimeNamespace string
+	platformMode       string
 	logger             zerolog.Logger
 }
 
@@ -31,13 +32,14 @@ func (r *ProjectReconciler) nsKube() *kubeclient.KubeClient {
 	return r.kube
 }
 
-func NewProjectReconciler(factory *SDKClientFactory, kube *kubeclient.KubeClient, projectKube *kubeclient.KubeClient, provisioner kubeclient.NamespaceProvisioner, cpRuntimeNamespace string, logger zerolog.Logger) *ProjectReconciler {
+func NewProjectReconciler(factory *SDKClientFactory, kube *kubeclient.KubeClient, projectKube *kubeclient.KubeClient, provisioner kubeclient.NamespaceProvisioner, cpRuntimeNamespace, platformMode string, logger zerolog.Logger) *ProjectReconciler {
 	return &ProjectReconciler{
 		factory:            factory,
 		kube:               kube,
 		projectKube:        projectKube,
 		provisioner:        provisioner,
 		cpRuntimeNamespace: cpRuntimeNamespace,
+		platformMode:       platformMode,
 		logger:             logger.With().Str("reconciler", "projects").Logger(),
 	}
 }
@@ -188,7 +190,7 @@ func (r *ProjectReconciler) ensureCreatorRoleBinding(ctx context.Context, projec
 }
 
 func (r *ProjectReconciler) controlPlaneRBACRules() []interface{} {
-	return []interface{}{
+	rules := []interface{}{
 		map[string]interface{}{
 			"apiGroups": []interface{}{""},
 			"resources": []interface{}{"secrets", "serviceaccounts", "services"},
@@ -204,22 +206,29 @@ func (r *ProjectReconciler) controlPlaneRBACRules() []interface{} {
 			"resources": []interface{}{"rolebindings"},
 			"verbs":     []interface{}{"get", "list", "watch", "create", "delete"},
 		},
-		map[string]interface{}{
-			"apiGroups": []interface{}{"build.openshift.io"},
-			"resources": []interface{}{"buildconfigs", "buildconfigs/instantiate", "builds", "builds/log"},
-			"verbs":     []interface{}{"get", "list", "create", "update", "delete"},
-		},
-		map[string]interface{}{
-			"apiGroups": []interface{}{"image.openshift.io"},
-			"resources": []interface{}{"imagestreams", "imagestreamtags", "imagestreamimages"},
-			"verbs":     []interface{}{"get", "list", "create", "update", "delete"},
-		},
-		map[string]interface{}{
-			"apiGroups": []interface{}{"route.openshift.io"},
-			"resources": []interface{}{"routes"},
-			"verbs":     []interface{}{"get", "list", "create", "update", "delete"},
-		},
 	}
+
+	if r.platformMode == "mpp" {
+		rules = append(rules,
+			map[string]interface{}{
+				"apiGroups": []interface{}{"build.openshift.io"},
+				"resources": []interface{}{"buildconfigs", "buildconfigs/instantiate", "builds", "builds/log"},
+				"verbs":     []interface{}{"get", "list", "create", "update", "delete"},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{"image.openshift.io"},
+				"resources": []interface{}{"imagestreams", "imagestreamtags", "imagestreamimages"},
+				"verbs":     []interface{}{"get", "list", "create", "update", "delete"},
+			},
+			map[string]interface{}{
+				"apiGroups": []interface{}{"route.openshift.io"},
+				"resources": []interface{}{"routes"},
+				"verbs":     []interface{}{"get", "list", "create", "update", "delete"},
+			},
+		)
+	}
+
+	return rules
 }
 
 func (r *ProjectReconciler) ensureControlPlaneRBAC(ctx context.Context, project types.Project) error {

--- a/components/ambient-control-plane/internal/reconciler/project_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/project_reconciler_test.go
@@ -36,17 +36,46 @@ func newFakeKubeClient(objects ...runtime.Object) *kubeclient.KubeClient {
 	return kubeclient.NewFromDynamic(dynClient, zerolog.Nop())
 }
 
-func newTestProjectReconciler(kube *kubeclient.KubeClient) *ProjectReconciler {
+func newTestProjectReconciler(kube *kubeclient.KubeClient, platformMode string) *ProjectReconciler {
 	return &ProjectReconciler{
 		kube:               kube,
 		provisioner:        &stubProvisioner{},
 		cpRuntimeNamespace: "ambient-system",
+		platformMode:       platformMode,
 		logger:             zerolog.Nop(),
 	}
 }
 
-func TestControlPlaneRBACRules_ContainsAllAPIGroups(t *testing.T) {
-	r := newTestProjectReconciler(nil)
+func TestControlPlaneRBACRules_StandardMode(t *testing.T) {
+	r := newTestProjectReconciler(nil, "standard")
+	rules := r.controlPlaneRBACRules()
+
+	expectedGroups := map[string]bool{
+		"":                          false,
+		"rbac.authorization.k8s.io": false,
+	}
+
+	for _, rule := range rules {
+		ruleMap := rule.(map[string]interface{})
+		apiGroups := ruleMap["apiGroups"].([]interface{})
+		for _, g := range apiGroups {
+			expectedGroups[g.(string)] = true
+		}
+	}
+
+	for group, found := range expectedGroups {
+		if !found {
+			t.Errorf("expected API group %q in RBAC rules, but not found", group)
+		}
+	}
+
+	if len(rules) != 3 {
+		t.Errorf("expected 3 rule entries in standard mode, got %d", len(rules))
+	}
+}
+
+func TestControlPlaneRBACRules_MPPMode(t *testing.T) {
+	r := newTestProjectReconciler(nil, "mpp")
 	rules := r.controlPlaneRBACRules()
 
 	expectedGroups := map[string]bool{
@@ -72,12 +101,12 @@ func TestControlPlaneRBACRules_ContainsAllAPIGroups(t *testing.T) {
 	}
 
 	if len(rules) != 6 {
-		t.Errorf("expected 6 rule entries, got %d", len(rules))
+		t.Errorf("expected 6 rule entries in mpp mode, got %d", len(rules))
 	}
 }
 
 func TestControlPlaneRBACRules_OpenShiftBuildResources(t *testing.T) {
-	r := newTestProjectReconciler(nil)
+	r := newTestProjectReconciler(nil, "mpp")
 	rules := r.controlPlaneRBACRules()
 
 	var buildRule map[string]interface{}
@@ -113,7 +142,7 @@ func TestControlPlaneRBACRules_OpenShiftBuildResources(t *testing.T) {
 
 func TestEnsureControlPlaneRBAC_CreatesRoleAndBinding(t *testing.T) {
 	kube := newFakeKubeClient()
-	r := newTestProjectReconciler(kube)
+	r := newTestProjectReconciler(kube, "standard")
 
 	project := types.Project{ObjectReference: types.ObjectReference{ID: "test-project"}, Name: "Test"}
 
@@ -130,8 +159,8 @@ func TestEnsureControlPlaneRBAC_CreatesRoleAndBinding(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("expected rules in created Role: found=%v err=%v", found, err)
 	}
-	if len(rules) != 6 {
-		t.Errorf("expected 6 rules in created Role, got %d", len(rules))
+	if len(rules) != 3 {
+		t.Errorf("expected 3 rules in created Role (standard mode), got %d", len(rules))
 	}
 }
 
@@ -155,7 +184,7 @@ func TestEnsureControlPlaneRBAC_UpdatesExistingRole(t *testing.T) {
 	}
 
 	kube := newFakeKubeClient(existingRole)
-	r := newTestProjectReconciler(kube)
+	r := newTestProjectReconciler(kube, "mpp")
 
 	project := types.Project{ObjectReference: types.ObjectReference{ID: "test-project"}, Name: "Test"}
 
@@ -173,6 +202,6 @@ func TestEnsureControlPlaneRBAC_UpdatesExistingRole(t *testing.T) {
 		t.Fatalf("expected rules in updated Role: found=%v err=%v", found, err)
 	}
 	if len(rules) != 6 {
-		t.Errorf("expected 6 rules after update (was 1), got %d", len(rules))
+		t.Errorf("expected 6 rules after update in mpp mode (was 1), got %d", len(rules))
 	}
 }

--- a/scripts/pre-commit/go-vet.sh
+++ b/scripts/pre-commit/go-vet.sh
@@ -21,21 +21,24 @@ GO_MODULES=(
 )
 
 # Determine which modules are affected by the staged files
-declare -A affected_modules=()
+affected_modules=""
 for file in "$@"; do
     for mod in "${GO_MODULES[@]}"; do
         if [[ "$file" == "$mod/"* || "$file" == "$REPO_ROOT/$mod/"* ]]; then
-            affected_modules["$mod"]=1
+            case " $affected_modules " in
+                *" $mod "*) ;;
+                *) affected_modules="$affected_modules $mod" ;;
+            esac
         fi
     done
 done
 
-if [ ${#affected_modules[@]} -eq 0 ]; then
+if [ -z "$affected_modules" ]; then
     exit 0
 fi
 
 exit_code=0
-for mod in "${!affected_modules[@]}"; do
+for mod in $affected_modules; do
     mod_dir="$REPO_ROOT/$mod"
     if [ -f "$mod_dir/go.mod" ]; then
         echo "go vet: $mod"

--- a/scripts/setup-vertex-kind.sh
+++ b/scripts/setup-vertex-kind.sh
@@ -178,8 +178,11 @@ else
 fi
 echo ""
 
+AMBIENT_UI_URL="${AMBIENT_UI_URL:-http://localhost:8080}"
+
 echo "Next steps:"
-echo "  1. Create a session via the UI at http://localhost:8080"
+echo "  - Create a session via the UI at $AMBIENT_UI_URL"
+echo "  - Note: Existing sessions will need to be restarted to use Vertex AI"
 echo ""
 echo "To switch back to Anthropic API, update the ConfigMap:"
 echo "  kubectl patch configmap operator-config -n $NAMESPACE --type merge \\"

--- a/scripts/setup-vertex-kind.sh
+++ b/scripts/setup-vertex-kind.sh
@@ -43,8 +43,8 @@
 #
 # WHAT THIS SCRIPT DOES:
 #   1. Creates a Kubernetes secret with your GCP service account credentials
-#   2. Patches the operator-config ConfigMap to enable Vertex AI mode
-#   3. Restarts the operator to pick up the new configuration
+#   2. Creates the operator-config ConfigMap to enable Vertex AI mode
+#   3. Restarts the control plane to pick up the new configuration
 #
 # VERIFICATION:
 #   After running, check operator logs:
@@ -139,24 +139,22 @@ kubectl create secret generic ambient-vertex \
 echo "  Done"
 echo ""
 
-# Step 2: Patch the operator-config ConfigMap with env vars
-echo "Step 2/3: Patching operator-config ConfigMap..."
-kubectl patch configmap operator-config -n "$NAMESPACE" --type merge -p "{
-  \"data\": {
-    \"USE_VERTEX\": \"1\",
-    \"ANTHROPIC_VERTEX_PROJECT_ID\": \"$ANTHROPIC_VERTEX_PROJECT_ID\",
-    \"CLOUD_ML_REGION\": \"$CLOUD_ML_REGION\",
-    \"GOOGLE_APPLICATION_CREDENTIALS\": \"/app/vertex/ambient-code-key.json\"
-  }
-}"
+# Step 2: Create the operator-config ConfigMap with Vertex env vars
+echo "Step 2/3: Creating operator-config ConfigMap..."
+kubectl delete configmap operator-config -n "$NAMESPACE" 2>/dev/null || true
+kubectl create configmap operator-config \
+  --from-literal=USE_VERTEX=1 \
+  --from-literal=ANTHROPIC_VERTEX_PROJECT_ID="$ANTHROPIC_VERTEX_PROJECT_ID" \
+  --from-literal=CLOUD_ML_REGION="$CLOUD_ML_REGION" \
+  --from-literal=GOOGLE_APPLICATION_CREDENTIALS="/app/vertex/ambient-code-key.json" \
+  -n "$NAMESPACE"
 echo "  Done"
 echo ""
 
-# Step 3: Restart operator and backend to pick up changes
-echo "Step 3/3: Restarting operator and backend to apply changes..."
-kubectl rollout restart deployment agentic-operator backend-api -n "$NAMESPACE"
-kubectl rollout status deployment agentic-operator -n "$NAMESPACE" --timeout=60s
-kubectl rollout status deployment backend-api -n "$NAMESPACE" --timeout=60s
+# Step 3: Restart control plane to pick up changes
+echo "Step 3/3: Restarting control plane to apply changes..."
+kubectl rollout restart deployment ambient-control-plane -n "$NAMESPACE"
+kubectl rollout status deployment ambient-control-plane -n "$NAMESPACE" --timeout=60s
 echo ""
 
 echo "=== Setup Complete ==="
@@ -186,4 +184,4 @@ echo ""
 echo "To switch back to Anthropic API, update the ConfigMap:"
 echo "  kubectl patch configmap operator-config -n $NAMESPACE --type merge \\"
 echo "    -p '{\"data\":{\"USE_VERTEX\":\"0\"}}'"
-echo "  kubectl rollout restart deployment agentic-operator -n $NAMESPACE"
+echo "  kubectl rollout restart deployment ambient-control-plane -n $NAMESPACE"


### PR DESCRIPTION
## Summary

- **Vertex setup script**: Fixed `setup-vertex-kind.sh` to create the `operator-config` ConfigMap (instead of patching one that doesn't exist), use the correct deployment name (`ambient-control-plane`), and accept `AMBIENT_UI_URL` for the frontend URL
- **RBAC fix**: Gate OpenShift-specific RBAC rules (`build.openshift.io`, `image.openshift.io`, `route.openshift.io`) on `PLATFORM_MODE=mpp` so they're excluded on kind, fixing a "forbidden" error when creating sessions
- **Makefile improvements**: Add `kind-setup-vertex` target, make `kind-rebuild` fail fast before building images if cluster doesn't exist, fix `go-vet` pre-commit hook for bash 3.2 compatibility

## Test plan

- [ ] Run `make kind-up` and verify cluster comes up
- [ ] Run `make kind-setup-vertex` with Vertex env vars set and verify ConfigMap and secret are created
- [ ] Create a session on kind and confirm no RBAC errors in control plane logs
- [ ] Run `make kind-rebuild` without a cluster and verify it fails immediately (before building)
- [ ] Run `go test ./internal/reconciler/` in the control plane to verify RBAC tests pass for both standard and mpp modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)