### PR TITLE
fix(ui): debounce user search to prevent focus loss on keystroke

### DIFF
--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/_components/collaborator-manager.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/_components/collaborator-manager.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { Loader2, Users } from 'lucide-react'
@@ -166,11 +166,21 @@ function UserSearchInput({
   projectId: string
   existingUsernames: Set<string>
 }) {
-  const [searchQuery, setSearchQuery] = useState('')
+  const [inputValue, setInputValue] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
   const [open, setOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const { data: searchResults, isLoading: isSearching } = useUserSearch(searchQuery)
+  useEffect(() => {
+    if (inputValue.trim() === '') {
+      setDebouncedQuery('')
+      return
+    }
+    const id = setTimeout(() => setDebouncedQuery(inputValue.trim()), 300)
+    return () => clearTimeout(id)
+  }, [inputValue])
+
+  const { data: searchResults, isLoading: isSearching } = useUserSearch(debouncedQuery)
   const createBinding = useCreateRoleBinding()
 
   const filteredResults = useMemo(
@@ -196,7 +206,7 @@ function UserSearchInput({
       {
         onSuccess: () => {
           toast.success(`Added ${user.name || user.username}`)
-          setSearchQuery('')
+          setInputValue('')
           setOpen(false)
         },
         onError: (error) => {
@@ -211,22 +221,22 @@ function UserSearchInput({
     )
   }, [defaultRoleId, projectId, createBinding])
 
-  const showDropdown = searchQuery.length > 0 && (filteredResults.length > 0 || isSearching)
+  const showDropdown = inputValue.length > 0 && (filteredResults.length > 0 || isSearching)
 
   return (
-    <Popover open={open && showDropdown} onOpenChange={setOpen}>
+    <Popover open={open && showDropdown} onOpenChange={(v) => { if (!v) setOpen(false) }}>
       <PopoverAnchor asChild>
         <div className="relative">
           <Command shouldFilter={false} className="border rounded-md">
             <CommandInput
               ref={inputRef}
               placeholder="Add people..."
-              value={searchQuery}
+              value={inputValue}
               onValueChange={(v) => {
-                setSearchQuery(v)
+                setInputValue(v)
                 if (v.length > 0) setOpen(true)
               }}
-              onFocus={() => { if (searchQuery.length > 0) setOpen(true) }}
+              onFocus={() => { if (inputValue.length > 0) setOpen(true) }}
               className="h-11"
             />
           </Command>
@@ -244,7 +254,7 @@ function UserSearchInput({
                 <Loader2 className="size-4 animate-spin text-muted-foreground" />
               </div>
             )}
-            {!isSearching && filteredResults.length === 0 && searchQuery.length > 0 && (
+            {!isSearching && filteredResults.length === 0 && debouncedQuery.length > 0 && (
               <CommandEmpty>No users found.</CommandEmpty>
             )}
             {filteredResults.length > 0 && (


### PR DESCRIPTION
## What I Changed

Fixes #139 — the "Add people..." input in the project sharing dialog lost focus on every keystroke, requiring users to click back into the field after each character.

### Root Cause

Three interacting issues in `UserSearchInput`:

1. **No debounce on search** — `useUserSearch(searchQuery)` created a new React Query subscription (new query key) on every keystroke, triggering API calls and re-renders per character.
2. **Popover open state thrashing** — `showDropdown` derived from `isSearching` and `filteredResults` toggled rapidly between query transitions, causing the Radix Popover to unmount/remount `PopoverContent` and steal focus.
3. **Eager `onOpenChange`** — the Popover's `onOpenChange` was wired directly to `setOpen`, allowing external state changes to flip the popover open during typing.

### Fix (3 changes, 1 file)

| Change | Line(s) | Effect |
|--------|---------|--------|
| **300ms debounce** between `inputValue` and query | 174–181 | Query key stays stable during typing; API calls batch; `isSearching`/`filteredResults` don't thrash |
| **One-way `onOpenChange`** — only close, never open from Popover internals | 227 | Popover open state controlled exclusively by `onValueChange` and `onFocus`, preventing focus-stealing remounts |
| **"No users found" keyed to `debouncedQuery`** | 257 | Empty state only shows after debounce settles, not during mid-type |

Follows the same debounce pattern already used in `command-palette.tsx` (lines 47–67).

## Confidence

**[90%] High** — The debounce pattern is proven in the same codebase (`command-palette.tsx`). The fix addresses the root cause (query key thrashing → Popover remount → focus loss) rather than masking symptoms.

## Rollback

```bash
git revert 309ee26
```

## Risk Assessment

**Low** — Changes isolated to `UserSearchInput` component. No API schema changes, no new dependencies, no changes to data flow outside the component.

---
🤖 Amber