### PR TITLE
fixing vendor value

### DIFF
--- a/components/ambient-control-plane/Dockerfile
+++ b/components/ambient-control-plane/Dockerfile
@@ -31,7 +31,7 @@ USER 1001
 ENTRYPOINT ["/usr/local/bin/ambient-control-plane"]
 
 LABEL name="ambient-control-plane" \
-      vendor="Red Hat, Inc" \
+      vendor="Red Hat, Inc." \
       version="0.0.1" \
       summary="Ambient Control Plane" \
       description="Kubernetes reconciler for the Ambient Code Platform" \


### PR DESCRIPTION
# Purpose

Vendor value was missing `.` for `vendor="Red Hat, Inc."`. This is validated in the EC Konflux pipeline. 