### PR TITLE
feat(ui): add platform health banner to dashboard

### DIFF
--- a/components/ambient-ui/package-lock.json
+++ b/components/ambient-ui/package-lock.json
@@ -69,7 +69,7 @@
         "@types/node": "^20.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.0",
-        "typescript": "~5.5.0"
+        "typescript": "~5.9.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9628,7 +9628,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/components/ambient-ui/src/app/(dashboard)/layout.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/layout.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation'
 import { AppSidebar } from '@/components/app-sidebar'
 import { NavHeader } from '@/components/nav-header'
 import { StatusBar } from '@/components/status-bar'
+import { PlatformHealthBanner } from '@/components/platform-health-banner'
 import { ChatSidebar } from '@/components/chat-sidebar'
 import { ChatSidebarProvider } from '@/components/chat-sidebar-context'
 import { CommandPalette } from '@/components/command-palette'
@@ -102,6 +103,7 @@ export default function DashboardLayout({
             sessionName={sessionId ? (session?.name ?? sessionId) : null}
             detailName={agentId ? (agent?.displayName ?? agent?.name ?? agentId) : null}
           />
+          <PlatformHealthBanner />
           <div className="flex-1 p-6 pb-10 max-w-7xl">{children}</div>
           <StatusBar />
           <CommandPalette />

--- a/components/ambient-ui/src/app/api/health/platform/route.ts
+++ b/components/ambient-ui/src/app/api/health/platform/route.ts
@@ -1,0 +1,51 @@
+import { env } from '@/lib/env'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type ComponentStatus = 'healthy' | 'unreachable' | 'unchecked'
+
+type PlatformHealthResponse = {
+  components: {
+    apiServer: ComponentStatus
+    controlPlane: ComponentStatus
+  }
+}
+
+async function checkReachable(url: string): Promise<boolean> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(5000),
+    cache: 'no-store',
+  })
+  return res.ok
+}
+
+export async function GET(): Promise<Response> {
+  const apiServerUrl = `${env.API_SERVER_URL}/api/ambient`
+  const controlPlaneUrl = env.CONTROL_PLANE_URL
+    ? `${env.CONTROL_PLANE_URL}/healthz`
+    : null
+
+  const [apiResult, cpResult] = await Promise.allSettled([
+    checkReachable(apiServerUrl),
+    controlPlaneUrl ? checkReachable(controlPlaneUrl) : Promise.resolve(null),
+  ])
+
+  const apiServer: ComponentStatus =
+    apiResult.status === 'fulfilled' && apiResult.value ? 'healthy' : 'unreachable'
+
+  let controlPlane: ComponentStatus
+  if (cpResult.status === 'fulfilled' && cpResult.value === null) {
+    controlPlane = 'unchecked'
+  } else if (cpResult.status === 'fulfilled' && cpResult.value) {
+    controlPlane = 'healthy'
+  } else {
+    controlPlane = 'unreachable'
+  }
+
+  const body: PlatformHealthResponse = {
+    components: { apiServer, controlPlane },
+  }
+
+  return Response.json(body)
+}

--- a/components/ambient-ui/src/components/platform-health-banner.tsx
+++ b/components/ambient-ui/src/components/platform-health-banner.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import { usePlatformHealth } from '@/hooks/use-platform-health'
+
+export function PlatformHealthBanner() {
+  const { apiServer, controlPlane, isHealthy, isLoading } = usePlatformHealth()
+
+  if (isLoading || isHealthy) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-2 border-b border-status-warning-border/40 bg-status-warning/10 px-4 py-2 text-sm text-status-warning-foreground"
+    >
+      <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+      <span>
+        Platform services are degraded. There may be issues starting, stopping,
+        or modifying sessions until the issue is resolved.
+      </span>
+    </div>
+  )
+}

--- a/components/ambient-ui/src/hooks/use-platform-health.ts
+++ b/components/ambient-ui/src/hooks/use-platform-health.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useCurrentUser } from '@/hooks/use-current-user'
+
+type ComponentStatus = 'healthy' | 'unreachable' | 'unchecked'
+
+type PlatformHealthResponse = {
+  components: {
+    apiServer: ComponentStatus
+    controlPlane: ComponentStatus
+  }
+}
+
+type UsePlatformHealthReturn = {
+  apiServer: ComponentStatus
+  controlPlane: ComponentStatus
+  isHealthy: boolean
+  isLoading: boolean
+}
+
+async function fetchPlatformHealth(): Promise<PlatformHealthResponse> {
+  const res = await fetch('/api/health/platform')
+  if (!res.ok) {
+    throw new Error(`Platform health check failed: ${res.status}`)
+  }
+  return res.json() as Promise<PlatformHealthResponse>
+}
+
+export function usePlatformHealth(): UsePlatformHealthReturn {
+  const { user, isLoading: userLoading } = useCurrentUser()
+
+  const { data, isPending } = useQuery({
+    queryKey: ['platform-health'],
+    queryFn: fetchPlatformHealth,
+    refetchInterval: 30_000,
+    retry: 1,
+    enabled: user !== null,
+  })
+
+  if (userLoading || user === null) {
+    return { apiServer: 'healthy', controlPlane: 'unchecked', isHealthy: true, isLoading: true }
+  }
+
+  const apiServer = data?.components.apiServer ?? 'healthy'
+  const controlPlane = data?.components.controlPlane ?? 'unchecked'
+
+  const isHealthy =
+    apiServer === 'healthy' &&
+    (controlPlane === 'healthy' || controlPlane === 'unchecked')
+
+  return { apiServer, controlPlane, isHealthy, isLoading: isPending }
+}

--- a/components/ambient-ui/src/lib/env.ts
+++ b/components/ambient-ui/src/lib/env.ts
@@ -14,4 +14,5 @@ export const env = {
   SSO_CLIENT_SECRET: getOptionalEnv('SSO_CLIENT_SECRET'),
   SSO_REDIRECT_URI: getOptionalEnv('SSO_REDIRECT_URI'),
   SESSION_SECRET: getOptionalEnv('SESSION_SECRET'),
+  CONTROL_PLANE_URL: getOptionalEnv('CONTROL_PLANE_URL'),
 } as const

--- a/components/manifests/base/core/ambient-ui-deployment.yaml
+++ b/components/manifests/base/core/ambient-ui-deployment.yaml
@@ -26,6 +26,8 @@ spec:
           value: "http://ambient-api-server:8000"
         - name: NODE_ENV
           value: "production"
+        - name: CONTROL_PLANE_URL
+          value: "http://ambient-control-plane:8080"
         - name: SSO_ISSUER_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary

When hacking on ACP locally my control plane was in `CrashLoopBackOff` but I had no visibility into it from the UI, this PR adds a warning banner to the dashboard when the API server or control plane is unreachable. A new server-side `/api/health/platform` route checks both services from within the cluster, polled every 30s via a React Query hook. The banner is gated behind auth state so it doesn't flash during Keycloak redirects. The CONTROL_PLANE_URL env var is added to the UI deployment manifest pointing at the CP token server's /healthz endpoint.

## Screenshots
<img width="1250" height="744" alt="Screenshot 2026-06-24 at 3 42 21 PM" src="https://github.com/user-attachments/assets/2b2b8bdb-3161-4df0-b998-d294f99345f3" />

<img width="1250" height="744" alt="Screenshot 2026-06-24 at 3 42 07 PM" src="https://github.com/user-attachments/assets/f5cc750c-e4ad-4788-93d8-4fe29609e5a6" />

## Test plan
- [ ] Deploy to Kind cluster, verify banner does NOT appear when healthy
- [ ] kubectl scale deploy ambient-control-plane -n ambient-code --replicas=0 — wait 30s, verify amber banner appears
- [ ] Scale back up — verify banner auto-clears
- [ ] kubectl scale deploy ambient-api-server -n ambient-code --replicas=0 — verify banner appears
- [ ] Log out — verify banner does not appear during Keycloak redirect