### PR TITLE
chore: add renovate.json for grouped dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "group:all"
+  ],
+  "postUpdateOptions": ["gomodTidy"]
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json` to configure Renovate bot for the project
- Groups all dependency PRs into a single combined PR via `group:all`
- Runs `go mod tidy` after Go dependency updates via `postUpdateOptions`

## Test plan
- [ ] Verify Renovate picks up the config on next run
- [ ] Confirm dependency updates are batched into one PR