### PR TITLE
chore: fix renovate config to use per-ecosystem grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "group:all"
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "squash"
+    },
+    {
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    }
   ],
-  "postUpdateOptions": ["gomodTidy"]
+  "postUpdateOptions": ["gomodTidy"],
+  "labels": ["dependencies", "renovate"]
 }


### PR DESCRIPTION
## Summary

- Replaces `group:all` with `config:recommended`, which groups updates by ecosystem instead of bundling everything into one mega-PR
- Adds a weekly off-hours schedule (`before 6am on monday`) to reduce noise
- Caps concurrent open PRs at 5 (`prConcurrentLimit`)
- Auto-merges patch updates via squash (safe, low-risk changes)
- Disables indirect dependency updates to keep PR volume manageable
- Retains `gomodTidy` post-update option and adds standard labels

> **Note:** Konflux uses Renovate under the hood to open its dependency PRs — this config controls Konflux's Renovate behavior. This is not introducing a second bot alongside Konflux.

Addresses review feedback from #189.

## Test plan

- [ ] Verify `renovate.json` validates against the schema at https://docs.renovatebot.com/renovate-schema.json
- [ ] Confirm Konflux-opened PRs after merge group by ecosystem (Go modules separate from Actions/npm)
- [ ] Confirm patch updates are auto-merged; minor/major require review

🤖 Generated with [Claude Code](https://claude.com/claude-code)