### PR TITLE
fix(kind): enable unauthenticated users on OpenShell gateway and add e2e tests

### DIFF
--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -67,6 +67,7 @@ for TENANT in "${TENANTS[@]}"; do
     helm install openshell-gateway "$OPENSHELL_GATEWAY_CHART" \
       --namespace "$TENANT" \
       --set "pkiInitJob.serverDnsNames={openshell-gateway.${TENANT}.svc.cluster.local}" \
+      --set "server.auth.allowUnauthenticatedUsers=true" \
       --wait --timeout 120s
     echo "    Installed OpenShell gateway in '$TENANT'"
   fi

--- a/tests/pod-mode-session.sh
+++ b/tests/pod-mode-session.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# E2E test: pod-mode session provisioning (OPENSHELL_USE_GATEWAY=false)
+#
+# Verifies that when operating in standard pod mode, a Kubernetes Pod is
+# created in the project namespace when a session is started.
+#
+# Prerequisites:
+#   - kind-up with OPENSHELL_USE_GATEWAY=false (default)
+#   - TEST_TOKEN set, or e2e/.env.test present
+#
+# Usage:
+#   ./tests/pod-mode-session.sh [API_URL]
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-ambient-code}"
+
+if [ -z "${TEST_TOKEN:-}" ] && [ -f "$(dirname "$0")/../e2e/.env.test" ]; then
+  # shellcheck disable=SC1090
+  source "$(dirname "$0")/../e2e/.env.test"
+fi
+TOKEN="${TEST_TOKEN:-}"
+
+PF_PID=""
+PF_PORT=18767
+if [ -n "${API_URL:-}" ] && [ "${API_URL}" != "http://localhost:" ]; then
+  : # use as-is
+elif [ -n "${1:-}" ]; then
+  API_URL="${1}"
+else
+  API_URL="http://localhost:${PF_PORT}"
+  kubectl port-forward -n "$NAMESPACE" svc/ambient-api-server "${PF_PORT}:8000" \
+    >/dev/null 2>&1 &
+  PF_PID=$!
+  for i in $(seq 1 10); do
+    sleep 1
+    if curl -sf "http://localhost:${PF_PORT}/api/ambient/v1/projects" \
+        -H "Authorization: Bearer ${TOKEN}" >/dev/null 2>&1; then
+      break
+    fi
+  done
+fi
+trap 'kill "${PF_PID}" 2>/dev/null || true' EXIT
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+PROJECT_ID=""
+SESSION_ID=""
+PROJECT_NS=""
+
+pass() { echo -e "  ${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
+section() { echo ""; echo -e "${BOLD}$1${NC}"; }
+
+api_get()  { curl -sf --max-time 10 -H "Authorization: Bearer ${TOKEN}" "${API_URL}${1}" 2>/dev/null; }
+api_post() {
+  curl -sf --max-time 10 -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$2" "${API_URL}${1}" 2>/dev/null
+}
+api_delete() {
+  curl -sf --max-time 10 -X DELETE \
+    -H "Authorization: Bearer ${TOKEN}" "${API_URL}${1}" 2>/dev/null || true
+}
+
+require_token() {
+  if [ -z "$TOKEN" ]; then
+    echo -e "${RED}Error:${NC} TEST_TOKEN not set. Run 'make kind-up' first."
+    exit 1
+  fi
+}
+
+cleanup() {
+  echo ""
+  echo -e "${BOLD}Cleanup${NC}"
+  if [ -n "$SESSION_ID" ]; then
+    api_delete "/api/ambient/v1/sessions/${SESSION_ID}" && echo "  Deleted session $SESSION_ID" || true
+  fi
+  if [ -n "$PROJECT_ID" ]; then
+    api_delete "/api/ambient/v1/projects/${PROJECT_ID}" && echo "  Deleted project $PROJECT_ID" || true
+  fi
+  if [ -n "$PROJECT_NS" ] && kubectl get namespace "$PROJECT_NS" >/dev/null 2>&1; then
+    kubectl delete namespace "$PROJECT_NS" --ignore-not-found >/dev/null && echo "  Deleted namespace $PROJECT_NS" || true
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Section 1: Control plane is running in pod mode
+# ---------------------------------------------------------------------------
+
+section "1. Control plane pod mode"
+require_token
+
+CP_GATEWAY=$(kubectl get deployment ambient-control-plane -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSHELL_USE_GATEWAY")].value}' 2>/dev/null || echo "")
+if [ "${CP_GATEWAY}" = "true" ]; then
+  fail "OPENSHELL_USE_GATEWAY=true in control plane deployment — this test requires pod mode"
+  echo ""
+  echo -e "${BOLD}Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}"
+  exit 1
+else
+  pass "Control plane is in pod mode (OPENSHELL_USE_GATEWAY=${CP_GATEWAY:-false})"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 2: Create a test project and its namespace
+# ---------------------------------------------------------------------------
+
+section "2. Project and namespace setup"
+
+PROJECT_RESP=$(api_post "/api/ambient/v1/projects" \
+  '{"name": "pod-mode-e2e", "description": "pod-mode e2e test project"}' || echo "")
+PROJECT_ID=$(echo "$PROJECT_RESP" | jq -r '.id // empty' 2>/dev/null || echo "")
+
+if [ -n "$PROJECT_ID" ]; then
+  pass "ACP project created (id: $PROJECT_ID)"
+else
+  fail "Failed to create ACP project"
+  echo ""
+  echo -e "${BOLD}Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}"
+  exit 1
+fi
+
+# Namespace = lowercase project ID (StandardNamespaceProvisioner.NamespaceName)
+PROJECT_NS=$(echo "$PROJECT_ID" | tr '[:upper:]' '[:lower:]')
+kubectl create namespace "$PROJECT_NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+pass "Namespace created: $PROJECT_NS"
+
+# ---------------------------------------------------------------------------
+# Section 3: Create and start a session
+# ---------------------------------------------------------------------------
+
+section "3. Session creation and start"
+
+SESSION_RESP=$(api_post "/api/ambient/v1/sessions" \
+  "{\"name\": \"pod-mode-e2e\", \"project_id\": \"${PROJECT_ID}\"}" || echo "")
+SESSION_ID=$(echo "$SESSION_RESP" | jq -r '.id // empty' 2>/dev/null || echo "")
+
+if [ -n "$SESSION_ID" ]; then
+  pass "Session created (id: $SESSION_ID)"
+else
+  fail "Failed to create session"
+  echo ""
+  echo -e "${BOLD}Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}"
+  exit 1
+fi
+
+api_post "/api/ambient/v1/sessions/${SESSION_ID}/start" "{}" >/dev/null 2>&1 || true
+pass "Session start requested"
+
+# ---------------------------------------------------------------------------
+# Section 4: Wait for pod to appear in project namespace
+# ---------------------------------------------------------------------------
+
+section "4. Pod provisioning"
+
+echo "  Waiting up to 60s for pod in namespace $PROJECT_NS..."
+POD_NAME=""
+for i in $(seq 1 20); do
+  sleep 3
+  POD_NAME=$(kubectl get pods -n "$PROJECT_NS" \
+    -l "ambient-code.io/session-id=${SESSION_ID}" \
+    --no-headers -o custom-columns=":metadata.name" 2>/dev/null | head -1 || echo "")
+  if [ -n "$POD_NAME" ]; then
+    break
+  fi
+done
+
+if [ -n "$POD_NAME" ]; then
+  POD_PHASE=$(kubectl get pod "$POD_NAME" -n "$PROJECT_NS" \
+    -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+  pass "Pod created: $POD_NAME (phase: $POD_PHASE)"
+else
+  # Show control plane logs for diagnosis
+  echo "  No pod found — control plane logs (last 20 lines):"
+  kubectl logs -n "$NAMESPACE" -l app=ambient-control-plane --tail=20 2>/dev/null | sed 's/^/    /' || true
+  fail "No pod created in namespace $PROJECT_NS within 60s"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo -e "${BOLD}Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}"
+echo ""
+
+[ "$FAILED" -eq 0 ]

--- a/tests/run-e2e-both-modes.sh
+++ b/tests/run-e2e-both-modes.sh
@@ -9,6 +9,8 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
+
 BOLD='\033[1m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -22,7 +24,7 @@ banner() { echo ""; echo -e "${BOLD}══════════════�
 teardown() {
   echo ""
   echo "▶ Tearing down kind cluster..."
-  make kind-down CONTAINER_ENGINE=docker 2>&1 || true
+  make kind-down CONTAINER_ENGINE="$CONTAINER_ENGINE" 2>&1 || true
 }
 
 get_token_and_port() {
@@ -56,13 +58,13 @@ patch_cp_pull_policy() {
 banner "Phase 1: Pod mode (OPENSHELL_USE_GATEWAY=false)"
 
 echo "▶ Starting kind cluster (Quay.io images)..."
-if make kind-up CONTAINER_ENGINE=docker 2>&1; then
+if make kind-up CONTAINER_ENGINE="$CONTAINER_ENGINE" 2>&1; then
   echo -e "${GREEN}✓ kind-up complete${NC}"
 
   patch_cp_pull_policy
 
   echo "▶ Rebuilding and reloading control plane from local source..."
-  if make kind-reload-ambient-control-plane CONTAINER_ENGINE=docker 2>&1; then
+  if make kind-reload-ambient-control-plane CONTAINER_ENGINE="$CONTAINER_ENGINE" 2>&1; then
     echo -e "${GREEN}✓ Control plane reloaded${NC}"
 
     get_token_and_port
@@ -99,13 +101,13 @@ teardown
 banner "Phase 2: Gateway mode (OPENSHELL_USE_GATEWAY=true)"
 
 echo "▶ Starting kind cluster (Quay.io images + gateway prerequisites)..."
-if make kind-up OPENSHELL_USE_GATEWAY=true CONTAINER_ENGINE=docker 2>&1; then
+if make kind-up OPENSHELL_USE_GATEWAY=true CONTAINER_ENGINE="$CONTAINER_ENGINE" 2>&1; then
   echo -e "${GREEN}✓ kind-up complete (gateway prereqs installed, CP patched)${NC}"
 
   patch_cp_pull_policy
 
   echo "▶ Rebuilding and reloading control plane from local source..."
-  if make kind-reload-ambient-control-plane CONTAINER_ENGINE=docker 2>&1; then
+  if make kind-reload-ambient-control-plane CONTAINER_ENGINE="$CONTAINER_ENGINE" 2>&1; then
     echo -e "${GREEN}✓ Control plane reloaded${NC}"
 
     # Restore OPENSHELL_USE_GATEWAY=true — kind-reload restarts the pod but

--- a/tests/run-e2e-both-modes.sh
+++ b/tests/run-e2e-both-modes.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Run e2e session provisioning tests for both pod mode and gateway mode.
+# Strategy: deploy all components from Quay.io, then reload only the
+# control plane from a local build so we exercise our specific changes
+# without hitting pre-existing build failures in other components.
+#
+# Usage: ./tests/run-e2e-both-modes.sh
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PHASE1_RESULT="PENDING"
+PHASE2_RESULT="PENDING"
+
+banner() { echo ""; echo -e "${BOLD}════════════════════════════════════════${NC}"; echo -e "${BOLD} $1${NC}"; echo -e "${BOLD}════════════════════════════════════════${NC}"; echo ""; }
+
+teardown() {
+  echo ""
+  echo "▶ Tearing down kind cluster..."
+  make kind-down CONTAINER_ENGINE=docker 2>&1 || true
+}
+
+get_token_and_port() {
+  unset TEST_TOKEN KIND_FWD_API_SERVER_PORT
+  # Re-source the freshly-written .env.test
+  if [ -f e2e/.env.test ]; then
+    # shellcheck disable=SC1091
+    source e2e/.env.test
+  fi
+  TEST_TOKEN="${TEST_TOKEN:-$(kubectl get secret test-user-token -n ambient-code \
+    -o jsonpath='{.data.token}' 2>/dev/null | base64 -d)}"
+  KIND_FWD_API_SERVER_PORT="${KIND_FWD_API_SERVER_PORT:-12269}"
+  export TEST_TOKEN KIND_FWD_API_SERVER_PORT
+}
+
+# The Quay.io-based 'kind' overlay sets imagePullPolicy: Always on the CP.
+# Patch it to IfNotPresent first so the locally-loaded image is used instead of
+# the kubelet trying (and failing) to pull localhost/<image> from a registry.
+patch_cp_pull_policy() {
+  echo "  Patching CP imagePullPolicy → IfNotPresent..."
+  kubectl patch deployment ambient-control-plane -n ambient-code \
+    -p '{"spec":{"template":{"spec":{"containers":[{"name":"ambient-control-plane","imagePullPolicy":"IfNotPresent"}]}}}}' \
+    >/dev/null
+  kubectl rollout status deployment/ambient-control-plane \
+    -n ambient-code --timeout=90s >/dev/null
+  echo "  CP imagePullPolicy patched."
+}
+
+# ─── Phase 1: Pod mode (OPENSHELL_USE_GATEWAY=false) ─────────────────────────
+
+banner "Phase 1: Pod mode (OPENSHELL_USE_GATEWAY=false)"
+
+echo "▶ Starting kind cluster (Quay.io images)..."
+if make kind-up CONTAINER_ENGINE=docker 2>&1; then
+  echo -e "${GREEN}✓ kind-up complete${NC}"
+
+  patch_cp_pull_policy
+
+  echo "▶ Rebuilding and reloading control plane from local source..."
+  if make kind-reload-ambient-control-plane CONTAINER_ENGINE=docker 2>&1; then
+    echo -e "${GREEN}✓ Control plane reloaded${NC}"
+
+    get_token_and_port
+    API_URL="http://localhost:${KIND_FWD_API_SERVER_PORT}"
+
+    echo "▶ Starting port-forward..."
+    kubectl port-forward -n ambient-code svc/ambient-api-server \
+      "${KIND_FWD_API_SERVER_PORT}:8000" >/dev/null 2>&1 &
+    PF1_PID=$!
+    sleep 3
+
+    echo "▶ Running pod-mode session test against $API_URL..."
+    if TEST_TOKEN="$TEST_TOKEN" API_URL="$API_URL" ./tests/pod-mode-session.sh 2>&1; then
+      PHASE1_RESULT="PASSED"
+      echo -e "${GREEN}✓ Phase 1 PASSED${NC}"
+    else
+      PHASE1_RESULT="FAILED"
+      echo -e "${RED}✗ Phase 1 FAILED${NC}"
+    fi
+    kill "$PF1_PID" 2>/dev/null || true
+  else
+    PHASE1_RESULT="FAILED (CP build error)"
+    echo -e "${RED}✗ Control plane rebuild failed${NC}"
+  fi
+else
+  PHASE1_RESULT="FAILED (kind-up error)"
+  echo -e "${RED}✗ kind-up failed for pod mode${NC}"
+fi
+
+teardown
+
+# ─── Phase 2: Gateway mode (OPENSHELL_USE_GATEWAY=true) ──────────────────────
+
+banner "Phase 2: Gateway mode (OPENSHELL_USE_GATEWAY=true)"
+
+echo "▶ Starting kind cluster (Quay.io images + gateway prerequisites)..."
+if make kind-up OPENSHELL_USE_GATEWAY=true CONTAINER_ENGINE=docker 2>&1; then
+  echo -e "${GREEN}✓ kind-up complete (gateway prereqs installed, CP patched)${NC}"
+
+  patch_cp_pull_policy
+
+  echo "▶ Rebuilding and reloading control plane from local source..."
+  if make kind-reload-ambient-control-plane CONTAINER_ENGINE=docker 2>&1; then
+    echo -e "${GREEN}✓ Control plane reloaded${NC}"
+
+    # Restore OPENSHELL_USE_GATEWAY=true — kind-reload restarts the pod but
+    # doesn't re-apply the env patch from setup-kind-openshell.sh.
+    kubectl set env deployment/ambient-control-plane \
+      -n ambient-code OPENSHELL_USE_GATEWAY=true >/dev/null
+    kubectl rollout status deployment/ambient-control-plane \
+      -n ambient-code --timeout=120s >/dev/null
+    echo "  OPENSHELL_USE_GATEWAY=true confirmed on reloaded CP"
+
+    get_token_and_port
+    API_URL="http://localhost:${KIND_FWD_API_SERVER_PORT}"
+
+    echo "▶ Starting port-forward..."
+    kubectl port-forward -n ambient-code svc/ambient-api-server \
+      "${KIND_FWD_API_SERVER_PORT}:8000" >/dev/null 2>&1 &
+    PF2_PID=$!
+    sleep 3
+
+    echo "▶ Running dual-tenant gateway test against $API_URL..."
+    if TEST_TOKEN="$TEST_TOKEN" API_URL="$API_URL" ./tests/openshell-dual-tenant.sh 2>&1; then
+      PHASE2_RESULT="PASSED"
+      echo -e "${GREEN}✓ Phase 2 PASSED${NC}"
+    else
+      PHASE2_RESULT="FAILED"
+      echo -e "${RED}✗ Phase 2 FAILED${NC}"
+    fi
+    kill "$PF2_PID" 2>/dev/null || true
+  else
+    PHASE2_RESULT="FAILED (CP build error)"
+    echo -e "${RED}✗ Control plane rebuild failed${NC}"
+  fi
+else
+  PHASE2_RESULT="FAILED (kind-up error)"
+  echo -e "${RED}✗ kind-up failed for gateway mode${NC}"
+fi
+
+teardown
+
+# ─── Combined summary ─────────────────────────────────────────────────────────
+
+banner "Combined Results"
+if [ "$PHASE1_RESULT" = "PASSED" ]; then
+  echo -e "  Phase 1 (pod mode):     ${GREEN}PASSED${NC}"
+else
+  echo -e "  Phase 1 (pod mode):     ${RED}${PHASE1_RESULT}${NC}"
+fi
+if [ "$PHASE2_RESULT" = "PASSED" ]; then
+  echo -e "  Phase 2 (gateway mode): ${GREEN}PASSED${NC}"
+else
+  echo -e "  Phase 2 (gateway mode): ${RED}${PHASE2_RESULT}${NC}"
+fi
+echo ""
+
+[ "$PHASE1_RESULT" = "PASSED" ] && [ "$PHASE2_RESULT" = "PASSED" ]


### PR DESCRIPTION
Apparently, we forgot to commit these tests during the feature work.

## Summary
- Fix `setup-kind-openshell.sh` to pass `server.auth.allowUnauthenticatedUsers=true` when installing the OpenShell gateway Helm chart — without this, CreateSandbox RPCs fail with "missing authorization header" even though mTLS transport works correctly
- Add `tests/pod-mode-session.sh` — e2e test for standard pod-mode session provisioning
- Add `tests/run-e2e-both-modes.sh` — orchestrator that runs both pod-mode and gateway-mode e2e tests with full cluster lifecycle (kind-up, test, kind-down for each mode)

## Test plan
- [x] Ran `make kind-up OPENSHELL_USE_GATEWAY=true` with the fix applied
- [x] Verified `allow_unauthenticated_users = true` in gateway config
- [x] Ran `tests/openshell-dual-tenant.sh` — 10/10 passed (sandbox CRs now created successfully in both tenant namespaces)
- [x] Run `tests/pod-mode-session.sh` standalone against a pod-mode cluster
- [x] Run `tests/run-e2e-both-modes.sh` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)