### PR TITLE
fix(gateway): add SA token auth, resilient provisioning, and multi-tenant CRB

### DIFF
--- a/components/ambient-control-plane/cmd/ambient-control-plane/main.go
+++ b/components/ambient-control-plane/cmd/ambient-control-plane/main.go
@@ -229,7 +229,7 @@ func runKubeMode(ctx context.Context, cfg *config.ControlPlaneConfig) error {
 			resolveCred = openshell.InsecureResolver()
 			log.Info().Msg("OpenShell gateway TLS disabled (plaintext)")
 		}
-		gateway = openshell.NewGatewayClient(cfg.OpenShellGatewayServiceName, cfg.OpenShellGatewayGRPCPort, resolveCred, log.Logger)
+		gateway = openshell.NewGatewayClient(cfg.OpenShellGatewayServiceName, cfg.OpenShellGatewayGRPCPort, resolveCred, cfg.OpenShellGatewaySATokenPath, log.Logger)
 		defer func() {
 			if err := gateway.Close(); err != nil {
 				log.Warn().Err(err).Msg("failed to close gateway client")

--- a/components/ambient-control-plane/internal/config/config.go
+++ b/components/ambient-control-plane/internal/config/config.go
@@ -56,6 +56,7 @@ type ControlPlaneConfig struct {
 	OpenShellGatewayTLSEnabled      bool
 	OpenShellGatewayClientTLSSecret string
 	OpenShellGatewayTLSServerName   string
+	OpenShellGatewaySATokenPath     string
 	ServiceIdentity                 string
 	CACertFile                      string
 	AllowedSandboxRegistries        []string
@@ -111,6 +112,7 @@ func Load() (*ControlPlaneConfig, error) {
 		OpenShellGatewayTLSEnabled:      os.Getenv("OPENSHELL_GATEWAY_TLS") != "false",
 		OpenShellGatewayClientTLSSecret: envOrDefault("OPENSHELL_GATEWAY_CLIENT_TLS_SECRET", "openshell-client-tls"),
 		OpenShellGatewayTLSServerName:   os.Getenv("OPENSHELL_GATEWAY_TLS_SERVER_NAME"),
+		OpenShellGatewaySATokenPath:     envOrDefault("OPENSHELL_GATEWAY_SA_TOKEN_PATH", "/var/run/secrets/kubernetes.io/serviceaccount/token"),
 		ServiceIdentity:                 strings.TrimSpace(os.Getenv("GRPC_SERVICE_ACCOUNT")),
 		CACertFile:                      envOrDefault("CA_CERT_FILE", "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"),
 		AllowedSandboxRegistries:        parseAllowedRegistries(os.Getenv("ALLOWED_SANDBOX_REGISTRIES")),

--- a/components/ambient-control-plane/internal/openshell/gateway_client.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 	"sync"
 
 	inferencepb "github.com/ambient-code/platform/components/ambient-control-plane/internal/openshell/grpc/openshell/inference/v1"
@@ -12,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -23,17 +26,35 @@ type GatewayClient struct {
 	serviceName string
 	grpcPort    int
 	resolveCred CredentialResolver
+	saTokenPath string
 	logger      zerolog.Logger
 }
 
-func NewGatewayClient(serviceName string, grpcPort int, resolveCred CredentialResolver, logger zerolog.Logger) *GatewayClient {
+func NewGatewayClient(serviceName string, grpcPort int, resolveCred CredentialResolver, saTokenPath string, logger zerolog.Logger) *GatewayClient {
 	return &GatewayClient{
 		conns:       make(map[string]*grpc.ClientConn),
 		serviceName: serviceName,
 		grpcPort:    grpcPort,
 		resolveCred: resolveCred,
+		saTokenPath: saTokenPath,
 		logger:      logger.With().Str("component", "openshell-gateway").Logger(),
 	}
+}
+
+func (g *GatewayClient) authContext(ctx context.Context) context.Context {
+	if g.saTokenPath == "" {
+		return ctx
+	}
+	raw, err := os.ReadFile(g.saTokenPath)
+	if err != nil {
+		g.logger.Warn().Err(err).Str("path", g.saTokenPath).Msg("failed to read SA token file")
+		return ctx
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return ctx
+	}
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+token))
 }
 
 func (g *GatewayClient) clientForNamespace(ctx context.Context, namespace string) (pb.OpenShellClient, error) {
@@ -99,6 +120,7 @@ func (g *GatewayClient) shouldEvict(err error) bool {
 }
 
 func (g *GatewayClient) CreateSandbox(ctx context.Context, namespace string, req *pb.CreateSandboxRequest) (*pb.SandboxResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -111,6 +133,7 @@ func (g *GatewayClient) CreateSandbox(ctx context.Context, namespace string, req
 }
 
 func (g *GatewayClient) GetSandbox(ctx context.Context, namespace string, name string) (*pb.SandboxResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -123,6 +146,7 @@ func (g *GatewayClient) GetSandbox(ctx context.Context, namespace string, name s
 }
 
 func (g *GatewayClient) DeleteSandbox(ctx context.Context, namespace string, name string) error {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return err
@@ -135,6 +159,7 @@ func (g *GatewayClient) DeleteSandbox(ctx context.Context, namespace string, nam
 }
 
 func (g *GatewayClient) CreateProvider(ctx context.Context, namespace string, req *pb.CreateProviderRequest) (*pb.ProviderResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -147,6 +172,7 @@ func (g *GatewayClient) CreateProvider(ctx context.Context, namespace string, re
 }
 
 func (g *GatewayClient) UpdateProvider(ctx context.Context, namespace string, req *pb.UpdateProviderRequest) (*pb.ProviderResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -159,6 +185,7 @@ func (g *GatewayClient) UpdateProvider(ctx context.Context, namespace string, re
 }
 
 func (g *GatewayClient) GetProvider(ctx context.Context, namespace string, name string) (*pb.ProviderResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -177,6 +204,7 @@ type ExecResult struct {
 }
 
 func (g *GatewayClient) ExecSandbox(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (*ExecResult, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -219,6 +247,7 @@ func (g *GatewayClient) inferenceClientForNamespace(ctx context.Context, namespa
 }
 
 func (g *GatewayClient) SetClusterInference(ctx context.Context, namespace string, req *inferencepb.SetClusterInferenceRequest) (*inferencepb.SetClusterInferenceResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.inferenceClientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -231,6 +260,7 @@ func (g *GatewayClient) SetClusterInference(ctx context.Context, namespace strin
 }
 
 func (g *GatewayClient) ConfigureProviderRefresh(ctx context.Context, namespace string, req *pb.ConfigureProviderRefreshRequest) (*pb.ConfigureProviderRefreshResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -243,6 +273,7 @@ func (g *GatewayClient) ConfigureProviderRefresh(ctx context.Context, namespace 
 }
 
 func (g *GatewayClient) RotateProviderCredential(ctx context.Context, namespace string, req *pb.RotateProviderCredentialRequest) (*pb.RotateProviderCredentialResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -257,6 +288,7 @@ func (g *GatewayClient) RotateProviderCredential(ctx context.Context, namespace 
 const maxLogChunkSize = 512
 
 func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) error {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return err
@@ -304,6 +336,7 @@ func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace stri
 }
 
 func (g *GatewayClient) UpdateConfig(ctx context.Context, namespace string, req *pb.UpdateConfigRequest) (*pb.UpdateConfigResponse, error) {
+	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err

--- a/components/ambient-control-plane/internal/openshell/gateway_client_test.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client_test.go
@@ -3,6 +3,8 @@ package openshell
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -10,6 +12,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -28,7 +31,7 @@ func TestGatewayEndpoint(t *testing.T) {
 		{"gw", 9090, "prod-ns", "dns:///gw.prod-ns.svc.cluster.local:9090"},
 	}
 	for _, tt := range tests {
-		g := NewGatewayClient(tt.service, tt.port, nil, zerolog.Nop())
+		g := NewGatewayClient(tt.service, tt.port, nil, "", zerolog.Nop())
 		got := g.gatewayEndpoint(tt.namespace)
 		if got != tt.want {
 			t.Errorf("gatewayEndpoint(%q) = %q, want %q", tt.namespace, got, tt.want)
@@ -37,7 +40,7 @@ func TestGatewayEndpoint(t *testing.T) {
 }
 
 func TestShouldEvict(t *testing.T) {
-	g := NewGatewayClient("gw", 8443, nil, zerolog.Nop())
+	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop())
 
 	tests := []struct {
 		name string
@@ -62,7 +65,7 @@ func TestShouldEvict(t *testing.T) {
 }
 
 func TestGetOrCreateConn_CacheHit(t *testing.T) {
-	g := NewGatewayClient("gw", 8443, insecureResolver, zerolog.Nop())
+	g := NewGatewayClient("gw", 8443, insecureResolver, "", zerolog.Nop())
 	t.Cleanup(func() { g.Close() })
 
 	ctx := context.Background()
@@ -91,7 +94,7 @@ func TestGetOrCreateConn_CredResolverError(t *testing.T) {
 	resolveErr := fmt.Errorf("vault is sealed")
 	g := NewGatewayClient("gw", 8443, func(_ context.Context, _ string) (credentials.TransportCredentials, error) {
 		return nil, resolveErr
-	}, zerolog.Nop())
+	}, "", zerolog.Nop())
 
 	_, err := g.getOrCreateConn(context.Background(), "ns-a")
 	if err == nil {
@@ -100,7 +103,7 @@ func TestGetOrCreateConn_CredResolverError(t *testing.T) {
 }
 
 func TestEvictConn(t *testing.T) {
-	g := NewGatewayClient("gw", 8443, insecureResolver, zerolog.Nop())
+	g := NewGatewayClient("gw", 8443, insecureResolver, "", zerolog.Nop())
 	t.Cleanup(func() { g.Close() })
 
 	ctx := context.Background()
@@ -127,7 +130,7 @@ func TestEvictConn(t *testing.T) {
 }
 
 func TestEvictConn_Noop(t *testing.T) {
-	g := NewGatewayClient("gw", 8443, nil, zerolog.Nop())
+	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop())
 	g.evictConn("nonexistent")
 }
 
@@ -139,7 +142,7 @@ func TestGetOrCreateConn_ConcurrentSameNamespace(t *testing.T) {
 		calls++
 		mu.Unlock()
 		return insecure.NewCredentials(), nil
-	}, zerolog.Nop())
+	}, "", zerolog.Nop())
 	t.Cleanup(func() { g.Close() })
 
 	ctx := context.Background()
@@ -197,7 +200,7 @@ func TestSandboxName(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	g := NewGatewayClient("gw", 8443, insecureResolver, zerolog.Nop())
+	g := NewGatewayClient("gw", 8443, insecureResolver, "", zerolog.Nop())
 
 	ctx := context.Background()
 	for _, ns := range []string{"a", "b", "c"} {
@@ -215,5 +218,41 @@ func TestClose(t *testing.T) {
 	g.mu.RUnlock()
 	if remaining != 0 {
 		t.Errorf("after Close(), %d connections remain, want 0", remaining)
+	}
+}
+
+func TestAuthContext_NoPath(t *testing.T) {
+	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop())
+	ctx := g.authContext(context.Background())
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if ok && len(md.Get("authorization")) > 0 {
+		t.Error("expected no authorization metadata when saTokenPath is empty")
+	}
+}
+
+func TestAuthContext_ValidToken(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("test-sa-token\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	g := NewGatewayClient("gw", 8443, nil, tokenFile, zerolog.Nop())
+	ctx := g.authContext(context.Background())
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("expected outgoing metadata")
+	}
+	vals := md.Get("authorization")
+	if len(vals) != 1 || vals[0] != "Bearer test-sa-token" {
+		t.Errorf("authorization = %v, want [Bearer test-sa-token]", vals)
+	}
+}
+
+func TestAuthContext_MissingFile(t *testing.T) {
+	g := NewGatewayClient("gw", 8443, nil, "/nonexistent/path/token", zerolog.Nop())
+	ctx := g.authContext(context.Background())
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if ok && len(md.Get("authorization")) > 0 {
+		t.Error("expected no authorization metadata when token file is missing")
 	}
 }

--- a/components/ambient-control-plane/internal/openshell/provider_mapping.go
+++ b/components/ambient-control-plane/internal/openshell/provider_mapping.go
@@ -3,7 +3,6 @@ package openshell
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 )
 
 var providerTypeMapping = map[string]string{
@@ -89,15 +88,15 @@ func ExtractServiceAccountJWTMaterial(saKeyJSON string) (*ServiceAccountJWTMater
 	}, nil
 }
 
-func ProviderConfig(ambientProvider string) map[string]string {
+func ProviderConfig(ambientProvider, vertexProjectID, vertexRegion string) map[string]string {
 	switch ambientProvider {
 	case "vertex":
 		cfg := map[string]string{}
-		if v := os.Getenv("ANTHROPIC_VERTEX_PROJECT_ID"); v != "" {
-			cfg["VERTEX_AI_PROJECT_ID"] = v
+		if vertexProjectID != "" {
+			cfg["VERTEX_AI_PROJECT_ID"] = vertexProjectID
 		}
-		if v := os.Getenv("CLOUD_ML_REGION"); v != "" {
-			cfg["VERTEX_AI_REGION"] = v
+		if vertexRegion != "" {
+			cfg["VERTEX_AI_REGION"] = vertexRegion
 		}
 		return cfg
 	default:

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -335,7 +335,10 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	}
 
 	if err := r.configureInference(ctx, namespace, project.Name, session.LlmModel, credentialIDs); err != nil {
-		return fmt.Errorf("configuring inference: %w", err)
+		r.logger.Warn().Err(err).
+			Str("namespace", namespace).
+			Str("session_id", session.ID).
+			Msg("inference configuration failed; sandbox will be created without inference routing")
 	}
 
 	env := r.buildSandboxEnv(ctx, session, project.Name, sdk, providerNames)
@@ -540,7 +543,7 @@ func (r *SimpleKubeReconciler) ensureGatewayProviders(ctx context.Context, names
 			},
 			Type:        osType,
 			Credentials: openshell.ProviderCredentials(ambientProvider, tokenResp.Token),
-			Config:      openshell.ProviderConfig(ambientProvider),
+			Config:      openshell.ProviderConfig(ambientProvider, r.cfg.VertexProjectID, r.cfg.VertexRegion),
 		}
 
 		_, err = r.gateway.GetProvider(ctx, namespace, provName)
@@ -568,7 +571,10 @@ func (r *SimpleKubeReconciler) ensureGatewayProviders(ctx context.Context, names
 
 		if ambientProvider == "vertex" {
 			if err := r.ensureVertexCredentialRefresh(ctx, namespace, provName, tokenResp.Token); err != nil {
-				return nil, fmt.Errorf("configuring credential refresh for provider %s: %w", provName, err)
+				r.logger.Warn().Err(err).
+					Str("provider", provName).
+					Str("namespace", namespace).
+					Msg("vertex credential refresh setup failed; provider created without auto-refresh")
 			}
 		}
 

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler_test.go
@@ -295,6 +295,7 @@ func TestResolveSandboxImage_AllowedRegistry(t *testing.T) {
 	r := &SimpleKubeReconciler{
 		cfg: KubeReconcilerConfig{
 			RunnerImage:              "quay.io/ambient_code/ambient_runner_openshell:latest",
+			OpenShellRunnerImage:     "quay.io/ambient_code/ambient_runner_openshell:latest",
 			AllowedSandboxRegistries: []string{"quay.io/ambient_code/", "ghcr.io/nvidia/"},
 		},
 	}


### PR DESCRIPTION
## Summary

- **Gateway SA token auth**: Injects the pod's Kubernetes service account token as a `Bearer` header on all 12 gRPC methods in `GatewayClient`, fixing `Unauthenticated` errors when the OpenShell gateway enforces auth.
- **Resilient provisioning**: Converts `configureInference` and `ensureVertexCredentialRefresh` from fatal errors to warnings, so sandbox creation proceeds even when credential types are incompatible (e.g. `authorized_user` vs `service_account`).
- **Gateway inference env fix**: `ACP_OPENSHELL_INFERENCE=true` is now set in gateway mode regardless of `VertexEnabled`, since the gateway's inference proxy handles routing transparently.
- **Kind setup fixes**: `sandboxImagePullPolicy=IfNotPresent` for locally-loaded images; `ClusterRoleBinding` patched to include all tenant gateway SAs for `TokenReview` access.

## Changes

 < /dev/null |  File | Change |
|------|--------|
| `gateway_client.go` | `authContext()` reads SA token, injects Bearer header on all RPCs |
| `gateway_client_test.go` | 3 new tests: no-path, valid-token, missing-file |
| `config.go` | `OpenShellGatewaySATokenPath` field (default: SA mount path) |
| `main.go` | Pass SA token path to `NewGatewayClient` |
| `kube_reconciler.go` | Non-fatal inference config + credential refresh; always set `ACP_OPENSHELL_INFERENCE` in gateway mode |
| `setup-kind-openshell.sh` | `sandboxImagePullPolicy`, multi-tenant CRB patch |

## Test plan

- [x] `go vet ./...` passes
- [x] `gofmt -l .` clean
- [x] `go test ./...` passes (including 3 new auth tests)
- [x] End-to-end Kind validation: session → sandbox provisioning → runner exec → AG-UI server ready
- [x] Verified sandbox lifecycle completes with non-fatal inference config warning
- [x] Verified multi-tenant CRB patch allows TokenReview for all tenant gateway SAs

🤖 Generated with [Claude Code](https://claude.ai/code)