### PR TITLE
fix(control-plane): use OpenShell runner image when gateway is enabled

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -1129,6 +1129,9 @@ func (r *SimpleKubeReconciler) ensurePod(ctx context.Context, namespace string, 
 	saName := serviceAccountName(session.ID)
 
 	runnerImage := r.cfg.RunnerImage
+	if r.cfg.OpenShellUseGateway && r.cfg.OpenShellRunnerImage != "" {
+		runnerImage = r.cfg.OpenShellRunnerImage
+	}
 	imagePullPolicy := "Always"
 	if strings.HasPrefix(runnerImage, "localhost/") {
 		imagePullPolicy = "IfNotPresent"


### PR DESCRIPTION
## Summary
- When `OPENSHELL_USE_GATEWAY=true`, the `ensurePod` path unconditionally used the default runner image (`acp_claude_runner`) instead of the configured OpenShell runner image (`acp_runner_openshell`)
- The sandbox creation path (`CreateSandbox`) already used `OpenShellRunnerImage` correctly — only the pod spec was missing the conditional
- Adds a 3-line check: if gateway mode is enabled and `OpenShellRunnerImage` is set, use it for the pod container image

## Test plan
- [ ] `make kind-up OPENSHELL_USE_GATEWAY=true` and create a session — verify the runner pod uses `acp_runner_openshell`
- [ ] Without `OPENSHELL_USE_GATEWAY`, verify default `acp_claude_runner` is still used
- [ ] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)