### PR TITLE
fix(gateway): stop overriding OpenShell runner image with localhost reference

### DIFF
--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -122,8 +122,7 @@ fi
 
 # 4. Patch control plane with the gateway flag
 kubectl set env deployment/ambient-control-plane -n "$NAMESPACE" \
-  OPENSHELL_USE_GATEWAY=true \
-  OPENSHELL_RUNNER_IMAGE=localhost/acp_runner_openshell:latest >/dev/null
-echo "  Patched ambient-control-plane with OPENSHELL_USE_GATEWAY=true OPENSHELL_RUNNER_IMAGE=localhost/acp_runner_openshell:latest"
+  OPENSHELL_USE_GATEWAY=true >/dev/null
+echo "  Patched ambient-control-plane with OPENSHELL_USE_GATEWAY=true"
 
 echo "OpenShell gateway setup complete (${TENANTS[*]})."


### PR DESCRIPTION
## Summary
- The kind setup script hardcoded `OPENSHELL_RUNNER_IMAGE=localhost/acp_runner_openshell:latest`, overriding the correct default in config.go (`quay.io/ambient_code/acp_runner_openshell:latest`)
- Pods failed with ErrImagePull since there is no local registry at localhost:443
- Remove the override so the Go default is used

## Test plan
- [ ] `make kind-up OPENSHELL_USE_GATEWAY=true` — create a session, verify runner pod uses `quay.io/ambient_code/acp_runner_openshell:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)