### PR TITLE
fix(gateway): multi-tenant CRB subjects and missing JWT config

### DIFF
--- a/components/ambient-control-plane/internal/gateway/reconciler.go
+++ b/components/ambient-control-plane/internal/gateway/reconciler.go
@@ -378,6 +378,11 @@ func reconcileResource(ctx context.Context, dynamicClient dynamic.Interface, obj
 			Msg("added restart annotation to StatefulSet (DNS or config changed)")
 	}
 
+	// For ClusterRoleBindings, merge subjects from existing to support multi-tenant
+	if gvk.Kind == "ClusterRoleBinding" {
+		mergeClusterRoleBindingSubjects(existing, obj)
+	}
+
 	// Preserve resourceVersion for optimistic concurrency
 	obj.SetResourceVersion(existing.GetResourceVersion())
 
@@ -436,4 +441,40 @@ func setOwnerReference(obj *unstructured.Unstructured, platformConfigCM *v1.Conf
 			// BlockOwnerDeletion omitted per project convention
 		},
 	})
+}
+
+// mergeClusterRoleBindingSubjects merges subjects from an existing ClusterRoleBinding
+// into the desired one, ensuring all tenant namespaces are represented. Without this,
+// the last tenant reconciled would overwrite subjects from earlier tenants.
+func mergeClusterRoleBindingSubjects(existing, desired *unstructured.Unstructured) {
+	existingSubjects, _, _ := unstructured.NestedSlice(existing.Object, "subjects")
+	desiredSubjects, _, _ := unstructured.NestedSlice(desired.Object, "subjects")
+
+	// Build a set of subjects already in the desired spec (keyed by SA name + namespace)
+	seen := make(map[string]bool)
+	for _, s := range desiredSubjects {
+		sub, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := sub["name"].(string)
+		ns, _ := sub["namespace"].(string)
+		seen[name+"/"+ns] = true
+	}
+
+	// Add any existing subjects not already present
+	for _, s := range existingSubjects {
+		sub, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := sub["name"].(string)
+		ns, _ := sub["namespace"].(string)
+		if !seen[name+"/"+ns] {
+			desiredSubjects = append(desiredSubjects, s)
+			seen[name+"/"+ns] = true
+		}
+	}
+
+	_ = unstructured.SetNestedSlice(desired.Object, desiredSubjects, "subjects")
 }

--- a/components/ambient-control-plane/manifests/gateway/configmap.yaml
+++ b/components/ambient-control-plane/manifests/gateway/configmap.yaml
@@ -34,9 +34,16 @@ data:
     [openshell.gateway.auth]
     allow_unauthenticated_users = true
 
+    [openshell.gateway.gateway_jwt]
+    signing_key_path = "/etc/openshell-jwt/signing.pem"
+    public_key_path  = "/etc/openshell-jwt/public.pem"
+    kid_path         = "/etc/openshell-jwt/kid"
+    gateway_id       = "openshell-gateway"
+    ttl_secs         = 3600
+
     [openshell.drivers.kubernetes]
     grpc_endpoint                = "https://openshell-gateway.NAMESPACE_PLACEHOLDER.svc.cluster.local:8080"
     service_account_name         = "openshell-gateway-sandbox"
-    supervisor_sideload_method   = "init-container"
+    supervisor_sideload_method   = "image-volume"
     sa_token_ttl_secs            = 3600
     app_armor_profile            = "Unconfined"


### PR DESCRIPTION
## Summary
- **Merge ClusterRoleBinding subjects across tenants**: The gateway reconciler does a full replace on updates, so when tenant-b reconciles the shared `openshell-gateway-node-reader` ClusterRoleBinding, it overwrites tenant-a's ServiceAccount subject. The tenant-a gateway then loses TokenReview permission and `IssueSandboxToken` fails. `mergeClusterRoleBindingSubjects` preserves subjects from all tenants.
- **Add missing `[openshell.gateway.gateway_jwt]` section**: The configmap template was missing the JWT signing key config needed for sandbox token issuance. Without it, `IssueSandboxToken` returns an empty gRPC error instantly (0ms). Matched to upstream Helm chart.
- **Correct `supervisor_sideload_method`**: Changed from `init-container` to `image-volume` to match upstream Helm chart defaults.

## Test plan
- [x] Deployed to Kind with `OPENSHELL_USE_GATEWAY=true`
- [x] Both tenant-a and tenant-b gateways have updated configmap with JWT section
- [x] Created session in tenant-a — sandbox successfully bootstraps (no more `IssueSandboxToken bootstrap exchange failed`)
- [x] Sandbox makes inference calls through gateway loopback proxy
- [x] Compared running gateway.toml against upstream Helm chart template — configs now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)