### PR TITLE
fix(gateway): patch resolv.conf ndots and set inference env vars at sandbox level

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -475,13 +475,34 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				Msg("sandbox is ready, executing entrypoint")
 
 			execCtx := context.Background()
+
 			// Patch ndots before starting the runner. The OpenShell supervisor is
 			// statically linked with musl libc, whose getaddrinfo sends A+AAAA
 			// queries simultaneously. With Kubernetes' default ndots:5, external
 			// FQDNs get expanded through all search domains first, causing musl's
 			// DNS resolver to mishandle the many concurrent responses and return
-			// zero usable addresses (manifests as 503 "inference service unavailable").
+			// zero usable addresses (manifests as NET:FAIL on inference.local).
 			// Setting ndots:1 makes musl resolve FQDNs directly.
+			//
+			// This must run before the runner entrypoint so the supervisor
+			// picks up the patched resolv.conf on its first DNS lookup for
+			// the upstream inference endpoint.
+			patchResult, patchErr := r.gateway.ExecSandbox(execCtx, namespace, &openshellpb.ExecSandboxRequest{
+				SandboxId: sandboxID,
+				Command:   []string{"sed", "-i", "s/ndots:[0-9]*/ndots:1/", "/etc/resolv.conf"},
+			})
+			if patchErr != nil {
+				r.logger.Warn().Err(patchErr).Str("sandbox", sbxName).Msg("failed to patch ndots in resolv.conf, continuing anyway")
+			} else if patchResult.ExitCode != 0 {
+				r.logger.Warn().
+					Str("sandbox", sbxName).
+					Int32("exit_code", patchResult.ExitCode).
+					Str("stderr", string(patchResult.Stderr)).
+					Msg("ndots patch returned non-zero exit, continuing anyway")
+			} else {
+				r.logger.Info().Str("sandbox", sbxName).Msg("patched resolv.conf ndots:1")
+			}
+
 			err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
 				SandboxId: sandboxID,
 				Command:   entrypoint,
@@ -688,6 +709,10 @@ func (r *SimpleKubeReconciler) buildSandboxEnv(ctx context.Context, session type
 		// The runner must activate inference routing mode so requests go
 		// through the proxy instead of directly to the provider API.
 		env["ACP_OPENSHELL_INFERENCE"] = "true"
+		// Set at sandbox level so every tool (claude, opencode, etc.) gets
+		// them — not just processes launched through a specific wrapper.
+		env["ANTHROPIC_BASE_URL"] = "https://inference.local"
+		env["ANTHROPIC_API_KEY"] = "unused-for-inference-routing"
 	} else if r.cfg.VertexEnabled {
 		env["USE_VERTEX"] = "1"
 		env["CLAUDE_CODE_USE_VERTEX"] = "1"

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/auth.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/auth.py
@@ -84,45 +84,19 @@ async def setup_sdk_authentication(context: RunnerContext) -> tuple[str, bool, s
     DEFAULT_VERTEX_MODEL = "claude-sonnet-4-6@default"
 
     if inference_routing:
-        # OpenShell inference routing: the supervisor runs an HTTP CONNECT
-        # proxy at 10.200.0.1:3128 inside the sandbox network namespace.
-        # "inference.local" is a virtual hostname the proxy intercepts and
-        # routes to the upstream inference provider (Vertex, Anthropic, etc).
-        # The proxy terminates TLS using a self-signed CA whose cert lives at
-        # /etc/openshell-tls/openshell-ca.pem.
-        os.environ["ANTHROPIC_API_KEY"] = "inference-routing"
-        os.environ["ANTHROPIC_BASE_URL"] = "https://inference.local"
-
-        # HTTPS_PROXY: directs all HTTPS traffic through the supervisor's
-        # CONNECT proxy. Required so inference.local resolves — there's no
-        # DNS entry for it; the proxy intercepts the CONNECT request by
-        # hostname. Also needed when the runner process lands outside the
-        # sandbox network namespace (setns can silently fail in rootless
-        # container runtimes without CAP_SYS_ADMIN).
-        os.environ["HTTPS_PROXY"] = "http://10.200.0.1:3128"
-
-        # SSL_CERT_FILE: tells Python's ssl module (used by urllib3/requests)
-        # to trust the OpenShell self-signed CA for inference.local TLS.
-        os.environ["SSL_CERT_FILE"] = "/etc/openshell-tls/openshell-ca.pem"
-
-        # REQUESTS_CA_BUNDLE: same CA, but for the requests library which
-        # checks this var independently of SSL_CERT_FILE.
-        os.environ["REQUESTS_CA_BUNDLE"] = "/etc/openshell-tls/openshell-ca.pem"
-
-        # NODE_EXTRA_CA_CERTS: Claude Code CLI is a Node.js process; Node
-        # ignores SSL_CERT_FILE and uses this var to append extra CAs to
-        # the built-in trust store.
-        os.environ["NODE_EXTRA_CA_CERTS"] = "/etc/openshell-tls/openshell-ca.pem"
-
-        # Vertex flags must be cleared — inference routing replaces direct
-        # Vertex API access with the proxy-mediated path.
+        # OpenShell inference routing: ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY,
+        # HTTPS_PROXY, and TLS CA vars are set at the sandbox level by the
+        # control plane reconciler and the OpenShell supervisor. The runner
+        # only needs to read them and clear any Vertex flags that would cause
+        # the SDK to bypass the proxy.
         for key in ("USE_VERTEX", "CLAUDE_CODE_USE_VERTEX"):
             os.environ.pop(key, None)
         configured_model = model or DEFAULT_MODEL
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "inference-routing")
         logger.info(
             f"Using OpenShell inference routing via inference.local (model={configured_model})"
         )
-        return "inference-routing", False, configured_model
+        return api_key, False, configured_model
 
     if api_key and not use_vertex:
         os.environ["ANTHROPIC_API_KEY"] = api_key

--- a/components/runners/ambient-runner/entrypoint.sh
+++ b/components/runners/ambient-runner/entrypoint.sh
@@ -1,16 +1,3 @@
 #!/bin/bash
-# ACP Runner entrypoint for OpenShell sandbox containers.
-#
-# Patches /etc/resolv.conf to work around a musl libc DNS issue:
-# the OpenShell supervisor is statically linked with musl, whose getaddrinfo
-# sends simultaneous A+AAAA queries on one socket. Combined with Kubernetes'
-# default ndots:5, external domains like aiplatform.googleapis.com get expanded
-# through all search domains first (60+ queries), causing response mismatching
-# and zero usable addresses. Setting ndots:1 makes musl resolve FQDNs directly.
-
-if [ -f /etc/resolv.conf ] && ! grep -q 'ndots:1' /etc/resolv.conf 2>/dev/null; then
-    sed -i 's/ndots:[0-9]*/ndots:1/' /etc/resolv.conf 2>/dev/null || true
-fi
-
 cd /sandbox/runner/ambient-runner
 exec uvicorn main:app --host 0.0.0.0 --port 8001

--- a/components/runners/ambient-runner/openshell-claude-wrapper.sh
+++ b/components/runners/ambient-runner/openshell-claude-wrapper.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
+# Claude-specific wrapper for OpenShell sandboxes.
+#
+# ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY, HTTPS_PROXY, NODE_EXTRA_CA_CERTS,
+# and other proxy/TLS vars are set at the sandbox level by the control plane
+# reconciler and the OpenShell supervisor — they apply to all tools, not just
+# Claude. This wrapper only handles Claude Code-specific setup.
 export HOME=/sandbox
-export ANTHROPIC_BASE_URL=https://inference.local
-# Sentinel value: the gateway proxy intercepts requests before reaching Anthropic.
-# The actual API key is managed by the gateway's credential provider, not the runner.
-export ANTHROPIC_API_KEY=gateway
 export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
-
-# Supervisor proxy — all sandbox traffic routes through it; inference.local
-# is a virtual hostname the proxy intercepts (no DNS entry exists).
-export HTTPS_PROXY=http://10.200.0.1:3128
-export NO_PROXY=127.0.0.1,localhost
-
-# Trust the OpenShell self-signed CA so Node.js accepts inference.local TLS.
-if [ -f /etc/openshell-tls/openshell-ca.pem ]; then
-    export NODE_EXTRA_CA_CERTS=/etc/openshell-tls/openshell-ca.pem
-fi
 
 # Bootstrap Claude config if /sandbox is fresh (e.g. per-instance overlay mount).
 # Without this, the trust-folder prompt appears on every new sandbox instance.


### PR DESCRIPTION
## Summary
- Patch `/etc/resolv.conf` to `ndots:1` via `ExecSandbox` before the runner entrypoint starts, fixing the musl libc DNS resolution failure that causes `inference.local` to hang with `NET:FAIL`
- Move `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` from the Claude-specific wrapper to the sandbox environment so all tools (claude, opencode, etc.) get them automatically
- Remove redundant proxy/TLS env var setup from `auth.py` and the wrapper — the OpenShell supervisor already injects these

## Test plan
- [ ] Rebuild control plane and runner images, deploy to kind with `OPENSHELL_USE_GATEWAY=true`
- [ ] Create a sandbox session and verify `resolv.conf` has `ndots:1`
- [ ] Run `claude` interactively via `openshell sandbox connect` — should reach inference.local without hanging
- [ ] Verify `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` are present in sandbox env for all processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)