### PR TITLE
fix(runner): prevent infinite recursion in openshell claude wrapper and move inference env vars to sandbox level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: local-dev-token
 .PHONY: local-logs local-logs-api-server local-logs-ui local-logs-control-plane local-shell-api-server local-shell-ui
 .PHONY: local-test local-test-dev local-test-quick test-all local-troubleshoot local-port-forward local-stop-port-forward
-.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-reload-ambient-control-plane kind-reload-ambient-api-server kind-status kind-login kind-sso-toggle kind-setup-vertex
+.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-reload-ambient-control-plane kind-reload-ambient-api-server kind-reload-runner-openshell kind-status kind-login kind-sso-toggle kind-setup-vertex
 .PHONY: preflight-cluster preflight dev-env dev
 .PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift
 .PHONY: unleash-port-forward unleash-status
@@ -1094,13 +1094,10 @@ screenshots-clean: ## Remove generated screenshots
 	@rm -rf e2e/cypress/screenshots/output/
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Screenshot output cleaned"
 
-kind-rebuild: check-kind check-kubectl check-local-context _kind-require-cluster build-all ## Rebuild, reload, and restart all components in kind
-	@$(MAKE) --no-print-directory _kind-load-images
-	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Applying kind-local manifests..."
-	@kubectl apply --validate=false -k components/manifests/overlays/kind-local/ $(QUIET_REDIRECT)
-	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Restarting deployments..."
-	@kubectl rollout restart deployment -n $(NAMESPACE) $(QUIET_REDIRECT)
-	@kubectl rollout status deployment -n $(NAMESPACE) --timeout=120s $(QUIET_REDIRECT)
+kind-rebuild: check-kind check-kubectl check-local-context _kind-require-cluster ## Rebuild, reload, and restart all components in kind
+	@$(MAKE) --no-print-directory kind-reload-ambient-ui
+	@$(MAKE) --no-print-directory kind-reload-ambient-control-plane
+	@$(MAKE) --no-print-directory kind-reload-ambient-api-server
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) All components rebuilt and restarted"
 
 kind-reload-ambient-ui: check-kind check-kubectl check-local-context ## Rebuild and reload ambient-ui only (kind)
@@ -1131,6 +1128,24 @@ kind-reload-ambient-api-server: check-kind check-kubectl check-local-context ## 
 	@_IMG=$$(kubectl get deployment ambient-api-server -n $(NAMESPACE) -o jsonpath='{.spec.template.spec.containers[0].image}') && \
 		kubectl set image deployment/ambient-api-server -n $(NAMESPACE) migration=$$_IMG $(QUIET_REDIRECT) && \
 		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Migration init container updated to $$_IMG"
+
+kind-reload-runner-openshell: check-kind check-kubectl check-local-context ## Rebuild and reload OpenShell runner only (kind)
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Rebuilding OpenShell runner..."
+	@cd components/runners/ambient-runner && $(CONTAINER_ENGINE) build $(PLATFORM_FLAG) $(BUILD_FLAGS) \
+		-f Dockerfile.openshell \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
+		-t $(RUNNER_OPENSHELL_IMAGE) . $(QUIET_REDIRECT) || \
+		{ echo "$(COLOR_RED)✗$(COLOR_RESET) Build failed. Run without QUIET=1 for full output."; exit 1; }
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Loading OpenShell runner into kind cluster..."
+	@_IMG=$$(echo "$(RUNNER_OPENSHELL_IMAGE)" | cut -d: -f1) && \
+		$(CONTAINER_ENGINE) tag $(RUNNER_OPENSHELL_IMAGE) localhost/$$_IMG:latest && \
+		kind load docker-image localhost/$$_IMG:latest --name $(KIND_CLUSTER_NAME) && \
+		echo "$(COLOR_GREEN)✓$(COLOR_RESET) OpenShell runner image loaded as localhost/$$_IMG:latest"
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Updating control plane env vars to use localhost/acp_runner_openshell:latest..."
+	@kubectl set env deployment/ambient-control-plane -n $(NAMESPACE) \
+		OPENSHELL_RUNNER_IMAGE=localhost/acp_runner_openshell:latest $(QUIET_REDIRECT)
+	@kubectl rollout status deployment/ambient-control-plane -n $(NAMESPACE) --timeout=60s
+	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) OpenShell runner reloaded — new sessions will use the updated image"
 
 kind-sso-toggle: check-kubectl ## Toggle SSO auth on/off in Kind (affects both frontend and backend)
 	@UNLEASH_ADMIN_TOKEN=$$(kubectl get secret unleash-credentials -n $(NAMESPACE) -o jsonpath='{.data.admin-api-token}' | base64 -d); \

--- a/components/ambient-control-plane/internal/gateway/manifests.go
+++ b/components/ambient-control-plane/internal/gateway/manifests.go
@@ -173,6 +173,35 @@ func ApplyConfigOverrides(obj *unstructured.Unstructured, config GatewayConfig) 
 		}
 	}
 
+	// Add image_pull_policy for LOCAL_IMAGES=true (kind-local development)
+	if kind == "ConfigMap" && obj.GetName() == "openshell-gateway-config" && os.Getenv("LOCAL_IMAGES") == "true" && config.Config == "" {
+		data, found, err := unstructured.NestedMap(obj.Object, "data")
+		if err != nil || !found {
+			return fmt.Errorf("configmap data not found")
+		}
+
+		toml, ok := data["gateway.toml"].(string)
+		if !ok {
+			return fmt.Errorf("gateway.toml not found in configmap")
+		}
+
+		// Append image_pull_policy to [openshell.drivers.kubernetes] section
+		lines := strings.Split(toml, "\n")
+		for i, line := range lines {
+			// Find the last line of the kubernetes drivers section
+			if strings.Contains(line, `app_armor_profile`) {
+				// Insert image_pull_policy right after
+				lines = append(lines[:i+1], append([]string{`    image_pull_policy            = "IfNotPresent"`}, lines[i+1:]...)...)
+				break
+			}
+		}
+		data["gateway.toml"] = strings.Join(lines, "\n")
+
+		if err := unstructured.SetNestedMap(obj.Object, data, "data"); err != nil {
+			return fmt.Errorf("set configmap data: %w", err)
+		}
+	}
+
 	// Update certgen Job serverDnsNames if provided
 	if kind == "Job" && strings.Contains(obj.GetName(), "certgen") && len(config.ServerDnsNames) > 0 {
 		containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -688,6 +688,10 @@ func (r *SimpleKubeReconciler) buildSandboxEnv(ctx context.Context, session type
 		// The runner must activate inference routing mode so requests go
 		// through the proxy instead of directly to the provider API.
 		env["ACP_OPENSHELL_INFERENCE"] = "true"
+		// Set at sandbox level so every tool (claude, opencode, etc.) gets
+		// them — not just processes launched through a specific wrapper.
+		env["ANTHROPIC_BASE_URL"] = "https://inference.local"
+		env["ANTHROPIC_API_KEY"] = "unused-for-inference-routing"
 	} else if r.cfg.VertexEnabled {
 		env["USE_VERTEX"] = "1"
 		env["CLAUDE_CODE_USE_VERTEX"] = "1"

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -475,34 +475,13 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				Msg("sandbox is ready, executing entrypoint")
 
 			execCtx := context.Background()
-
 			// Patch ndots before starting the runner. The OpenShell supervisor is
 			// statically linked with musl libc, whose getaddrinfo sends A+AAAA
 			// queries simultaneously. With Kubernetes' default ndots:5, external
 			// FQDNs get expanded through all search domains first, causing musl's
 			// DNS resolver to mishandle the many concurrent responses and return
-			// zero usable addresses (manifests as NET:FAIL on inference.local).
+			// zero usable addresses (manifests as 503 "inference service unavailable").
 			// Setting ndots:1 makes musl resolve FQDNs directly.
-			//
-			// This must run before the runner entrypoint so the supervisor
-			// picks up the patched resolv.conf on its first DNS lookup for
-			// the upstream inference endpoint.
-			patchResult, patchErr := r.gateway.ExecSandbox(execCtx, namespace, &openshellpb.ExecSandboxRequest{
-				SandboxId: sandboxID,
-				Command:   []string{"sh", "-c", "sed 's/ndots:[0-9]*/ndots:1/' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf && rm /tmp/resolv.conf"},
-			})
-			if patchErr != nil {
-				r.logger.Warn().Err(patchErr).Str("sandbox", sbxName).Msg("failed to patch ndots in resolv.conf, continuing anyway")
-			} else if patchResult.ExitCode != 0 {
-				r.logger.Warn().
-					Str("sandbox", sbxName).
-					Int32("exit_code", patchResult.ExitCode).
-					Str("stderr", string(patchResult.Stderr)).
-					Msg("ndots patch returned non-zero exit, continuing anyway")
-			} else {
-				r.logger.Info().Str("sandbox", sbxName).Msg("patched resolv.conf ndots:1")
-			}
-
 			err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
 				SandboxId: sandboxID,
 				Command:   entrypoint,
@@ -709,10 +688,6 @@ func (r *SimpleKubeReconciler) buildSandboxEnv(ctx context.Context, session type
 		// The runner must activate inference routing mode so requests go
 		// through the proxy instead of directly to the provider API.
 		env["ACP_OPENSHELL_INFERENCE"] = "true"
-		// Set at sandbox level so every tool (claude, opencode, etc.) gets
-		// them — not just processes launched through a specific wrapper.
-		env["ANTHROPIC_BASE_URL"] = "https://inference.local"
-		env["ANTHROPIC_API_KEY"] = "unused-for-inference-routing"
 	} else if r.cfg.VertexEnabled {
 		env["USE_VERTEX"] = "1"
 		env["CLAUDE_CODE_USE_VERTEX"] = "1"

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -475,13 +475,34 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				Msg("sandbox is ready, executing entrypoint")
 
 			execCtx := context.Background()
+
 			// Patch ndots before starting the runner. The OpenShell supervisor is
 			// statically linked with musl libc, whose getaddrinfo sends A+AAAA
 			// queries simultaneously. With Kubernetes' default ndots:5, external
 			// FQDNs get expanded through all search domains first, causing musl's
 			// DNS resolver to mishandle the many concurrent responses and return
-			// zero usable addresses (manifests as 503 "inference service unavailable").
+			// zero usable addresses (manifests as NET:FAIL on inference.local).
 			// Setting ndots:1 makes musl resolve FQDNs directly.
+			//
+			// This must run before the runner entrypoint so the supervisor
+			// picks up the patched resolv.conf on its first DNS lookup for
+			// the upstream inference endpoint.
+			patchResult, patchErr := r.gateway.ExecSandbox(execCtx, namespace, &openshellpb.ExecSandboxRequest{
+				SandboxId: sandboxID,
+				Command:   []string{"sh", "-c", "sed 's/ndots:[0-9]*/ndots:1/' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf && rm /tmp/resolv.conf"},
+			})
+			if patchErr != nil {
+				r.logger.Warn().Err(patchErr).Str("sandbox", sbxName).Msg("failed to patch ndots in resolv.conf, continuing anyway")
+			} else if patchResult.ExitCode != 0 {
+				r.logger.Warn().
+					Str("sandbox", sbxName).
+					Int32("exit_code", patchResult.ExitCode).
+					Str("stderr", string(patchResult.Stderr)).
+					Msg("ndots patch returned non-zero exit, continuing anyway")
+			} else {
+				r.logger.Info().Str("sandbox", sbxName).Msg("patched resolv.conf ndots:1")
+			}
+
 			err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
 				SandboxId: sandboxID,
 				Command:   entrypoint,
@@ -688,6 +709,10 @@ func (r *SimpleKubeReconciler) buildSandboxEnv(ctx context.Context, session type
 		// The runner must activate inference routing mode so requests go
 		// through the proxy instead of directly to the provider API.
 		env["ACP_OPENSHELL_INFERENCE"] = "true"
+		// Set at sandbox level so every tool (claude, opencode, etc.) gets
+		// them — not just processes launched through a specific wrapper.
+		env["ANTHROPIC_BASE_URL"] = "https://inference.local"
+		env["ANTHROPIC_API_KEY"] = "unused-for-inference-routing"
 	} else if r.cfg.VertexEnabled {
 		env["USE_VERTEX"] = "1"
 		env["CLAUDE_CODE_USE_VERTEX"] = "1"

--- a/components/ambient-control-plane/manifests/gateway/configmap.yaml
+++ b/components/ambient-control-plane/manifests/gateway/configmap.yaml
@@ -47,4 +47,3 @@ data:
     supervisor_sideload_method   = "image-volume"
     sa_token_ttl_secs            = 3600
     app_armor_profile            = "Unconfined"
-    image_pull_policy            = "IfNotPresent"

--- a/components/ambient-control-plane/manifests/gateway/configmap.yaml
+++ b/components/ambient-control-plane/manifests/gateway/configmap.yaml
@@ -47,3 +47,4 @@ data:
     supervisor_sideload_method   = "image-volume"
     sa_token_ttl_secs            = 3600
     app_armor_profile            = "Unconfined"
+    image_pull_policy            = "IfNotPresent"

--- a/components/manifests/overlays/kind-local/control-plane-local-images-patch.yaml
+++ b/components/manifests/overlays/kind-local/control-plane-local-images-patch.yaml
@@ -1,6 +1,6 @@
 # Override runner image references in control plane env vars for kind-local
 # Sets imagePullPolicy to IfNotPresent via localhost/ prefix (see kube_reconciler.go:1190)
-# Gateway also configured with image_pull_policy = "IfNotPresent" in configmap.yaml
+# Gateway image_pull_policy is set by LOCAL_IMAGES env var (see gateway/manifests.go)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/components/manifests/overlays/kind-local/control-plane-local-images-patch.yaml
+++ b/components/manifests/overlays/kind-local/control-plane-local-images-patch.yaml
@@ -1,0 +1,19 @@
+# Override runner image references in control plane env vars for kind-local
+# Sets imagePullPolicy to IfNotPresent via localhost/ prefix (see kube_reconciler.go:1190)
+# Gateway also configured with image_pull_policy = "IfNotPresent" in configmap.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-control-plane
+spec:
+  template:
+    spec:
+      containers:
+        - name: ambient-control-plane
+          env:
+            - name: RUNNER_IMAGE
+              value: "localhost/acp_claude_runner:latest"
+            - name: OPENSHELL_RUNNER_IMAGE
+              value: "localhost/acp_runner_openshell:latest"
+            - name: MCP_IMAGE
+              value: "localhost/acp_mcp:latest"

--- a/components/manifests/overlays/kind-local/kustomization.yaml
+++ b/components/manifests/overlays/kind-local/kustomization.yaml
@@ -13,6 +13,12 @@ patches:
     version: v1
     kind: Deployment
     name: ambient-api-server
+- path: control-plane-local-images-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: ambient-control-plane
 
 # Override imagePullPolicy to IfNotPresent for all deployments
 - path: image-pull-policy-patch.yaml

--- a/components/manifests/overlays/kind/control-plane-env-patch.yaml
+++ b/components/manifests/overlays/kind/control-plane-env-patch.yaml
@@ -26,3 +26,5 @@ spec:
               value: "false"
             - name: OPENSHELL_USE_GATEWAY
               value: "true"
+            - name: LOCAL_IMAGES
+              value: "true"

--- a/components/runners/ambient-runner/Dockerfile.openshell
+++ b/components/runners/ambient-runner/Dockerfile.openshell
@@ -119,7 +119,8 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
     && ln -sf /usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe /opt/claude/bin/claude \
     && mkdir -p /sandbox/.local/bin \
     && ln -sf /opt/claude/bin/claude /sandbox/.local/bin/claude \
-    && chown -R sandbox:sandbox /sandbox/.local
+    && chown -R sandbox:sandbox /sandbox/.local \
+    && rm -f /usr/local/bin/claude
 
 COPY --chmod=755 openshell-claude-wrapper.sh /usr/local/bin/claude
 

--- a/components/runners/ambient-runner/openshell-claude-wrapper.sh
+++ b/components/runners/ambient-runner/openshell-claude-wrapper.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Guard against infinite recursion: this script is installed as /usr/local/bin/claude,
+# so when Claude Code spawns subagents that invoke `claude` by name, PATH resolves
+# back here. Skip the wrapper setup on re-entry and exec the real binary directly.
+if [ -n "$_CLAUDE_WRAPPER_ACTIVE" ]; then
+    exec /opt/claude/bin/claude "$@"
+fi
+export _CLAUDE_WRAPPER_ACTIVE=1
+
 export HOME=/sandbox
 export ANTHROPIC_BASE_URL=https://inference.local
 # Sentinel value: the gateway proxy intercepts requests before reaching Anthropic.

--- a/components/runners/ambient-runner/openshell-claude-wrapper.sh
+++ b/components/runners/ambient-runner/openshell-claude-wrapper.sh
@@ -16,21 +16,7 @@ fi
 touch "$GUARD"
 
 export HOME=/sandbox
-export ANTHROPIC_BASE_URL=https://inference.local
-# Sentinel value: the gateway proxy intercepts requests before reaching Anthropic.
-# The actual API key is managed by the gateway's credential provider, not the runner.
-export ANTHROPIC_API_KEY=gateway
 export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
-
-# Supervisor proxy — all sandbox traffic routes through it; inference.local
-# is a virtual hostname the proxy intercepts (no DNS entry exists).
-export HTTPS_PROXY=http://10.200.0.1:3128
-export NO_PROXY=127.0.0.1,localhost
-
-# Trust the OpenShell self-signed CA so Node.js accepts inference.local TLS.
-if [ -f /etc/openshell-tls/openshell-ca.pem ]; then
-    export NODE_EXTRA_CA_CERTS=/etc/openshell-tls/openshell-ca.pem
-fi
 
 # Bootstrap Claude config if /sandbox is fresh (e.g. per-instance overlay mount).
 # Without this, the trust-folder prompt appears on every new sandbox instance.

--- a/components/runners/ambient-runner/openshell-claude-wrapper.sh
+++ b/components/runners/ambient-runner/openshell-claude-wrapper.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
+# Claude-specific wrapper for OpenShell sandboxes.
+#
+# ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY, HTTPS_PROXY, NODE_EXTRA_CA_CERTS,
+# and other proxy/TLS vars are set at the sandbox level by the control plane
+# reconciler and the OpenShell supervisor — they apply to all tools, not just
+# Claude. This wrapper only handles Claude Code-specific setup.
 # Guard against infinite recursion: this script is installed as /usr/local/bin/claude,
 # so when Claude Code spawns subagents that invoke `claude` by name, PATH resolves
-# back here. Skip the wrapper setup on re-entry and exec the real binary directly.
-if [ -n "$_CLAUDE_WRAPPER_ACTIVE" ]; then
+# back here. A file-based guard is used instead of an env var because the sandbox
+# supervisor spawns each command in a clean environment that does not inherit exports.
+GUARD="/tmp/.claude-wrapper-initialized"
+if [ -f "$GUARD" ]; then
     exec /opt/claude/bin/claude "$@"
 fi
-export _CLAUDE_WRAPPER_ACTIVE=1
+touch "$GUARD"
 
 export HOME=/sandbox
 export ANTHROPIC_BASE_URL=https://inference.local

--- a/components/runners/ambient-runner/openshell-claude-wrapper.sh
+++ b/components/runners/ambient-runner/openshell-claude-wrapper.sh
@@ -28,4 +28,4 @@ if [ ! -f /sandbox/.claude/settings.json ]; then
     printf '{"theme":"dark"}\n' > /sandbox/.claude/settings.json
 fi
 
-exec /opt/claude/bin/claude --bare "$@"
+exec /usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe --bare "$@"


### PR DESCRIPTION
## Summary
- The openshell claude wrapper is installed as `/usr/local/bin/claude`, so when Claude Code spawns subagents that invoke `claude` by name, PATH resolves back to the wrapper causing infinite recursion
- Adds a file-based re-entry guard (`/tmp/.claude-wrapper-initialized`) that skips wrapper setup on subsequent invocations within the same sandbox instance — env vars can't be used because the sandbox supervisor spawns each command in a clean environment
- Moves `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` from the wrapper into the reconciler's `buildSandboxEnv` so every tool in the sandbox gets them, not just Claude

## Test plan
- [ ] Deploy OpenShell runner and verify subagent spawning works without recursion
- [ ] Verify single-agent sessions still work correctly
- [ ] Verify inference routing works with env vars set at sandbox level

🤖 Generated with [Claude Code](https://claude.com/claude-code)