### PR TITLE
fix(runner): fix openshell sandbox trust prompts and inference routing compat

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -691,7 +691,7 @@ func (r *SimpleKubeReconciler) buildSandboxEnv(ctx context.Context, session type
 		// Set at sandbox level so every tool (claude, opencode, etc.) gets
 		// them — not just processes launched through a specific wrapper.
 		env["ANTHROPIC_BASE_URL"] = "https://inference.local"
-		env["ANTHROPIC_API_KEY"] = "unused-for-inference-routing"
+		env["ANTHROPIC_API_KEY"] = "notused"
 	} else if r.cfg.VertexEnabled {
 		env["USE_VERTEX"] = "1"
 		env["CLAUDE_CODE_USE_VERTEX"] = "1"

--- a/components/runners/ambient-runner/openshell-claude-wrapper.sh
+++ b/components/runners/ambient-runner/openshell-claude-wrapper.sh
@@ -9,19 +9,21 @@
 # so when Claude Code spawns subagents that invoke `claude` by name, PATH resolves
 # back here. A file-based guard is used instead of an env var because the sandbox
 # supervisor spawns each command in a clean environment that does not inherit exports.
-GUARD="/tmp/.claude-wrapper-initialized"
-if [ -f "$GUARD" ]; then
-    exec /opt/claude/bin/claude "$@"
-fi
-touch "$GUARD"
-
 export HOME=/sandbox
 export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
 
+GUARD="/tmp/.claude-wrapper-initialized"
+if [ -f "$GUARD" ]; then
+    exec /opt/claude/bin/claude --bare "$@"
+fi
+touch "$GUARD"
+
 # Bootstrap Claude config if /sandbox is fresh (e.g. per-instance overlay mount).
 # Without this, the trust-folder prompt appears on every new sandbox instance.
+# The customApiKeyResponses pre-approves the dummy key suffix used for inference
+# routing so Claude Code does not prompt or reject it.
 if [ ! -f /sandbox/.claude.json ]; then
-    printf '{"trustedFolders":["/sandbox"],"hasCompletedOnboarding":true}\n' > /sandbox/.claude.json
+    printf '{"trustedFolders":["/sandbox","/sandbox/runner"],"hasCompletedOnboarding":true,"projects":{"/sandbox":{"hasTrustDialogAccepted":true},"/sandbox/runner":{"hasTrustDialogAccepted":true}}}\n' > /sandbox/.claude.json
 fi
 if [ ! -f /sandbox/.claude/settings.json ]; then
     mkdir -p /sandbox/.claude

--- a/skills/build/openshell-gateway/SKILL.md
+++ b/skills/build/openshell-gateway/SKILL.md
@@ -23,7 +23,7 @@ chart is involved.
 
 ## Full Workflow: Cluster → Credential → Sandbox
 
-### Step 1 — Deploy the Kind Cluster
+### Step 1 — Deploy the Kind Cluster (REQUIRED)
 
 ```bash
 make kind-up OPENSHELL_USE_GATEWAY=true
@@ -70,7 +70,7 @@ This is the most common failure when `kind-up` appears to succeed but sessions
 fail with `openshell-client-tls not found`. Always check and fix before
 proceeding.
 
-### Step 2 — Login with acpctl
+### Step 2 — Login with acpctl (REQUIRED)
 
 The `acpctl` binary lives at `components/ambient-cli/acpctl` (prebuilt).
 
@@ -83,7 +83,13 @@ components/ambient-cli/acpctl login --url http://localhost:$API_PORT --token "$T
 Get `$API_PORT` from `make kind-status` (the "backend" port, typically 12856 on
 the main branch).
 
-### Step 3 — Create and Bind a Credential
+### Step 3 — Create and Bind a Credential (REQUIRED)
+
+Without this step the gateway will have **zero providers** and sandboxes will
+fail with no inference routing. Do NOT skip this — `make kind-setup-vertex`
+only sets up the K8s-level operator-config; it does NOT register the credential
+in ACP. You must create the credential through `acpctl` and bind it to the
+tenant via the API.
 
 #### Create
 
@@ -136,7 +142,7 @@ curl -s -X POST \
   }"
 ```
 
-### Step 3b — Set Vertex AI Config on Control Plane
+### Step 3b — Set Vertex AI Config on Control Plane (REQUIRED)
 
 The gateway requires `VERTEX_AI_PROJECT_ID` and `CLOUD_ML_REGION` for inference
 routing. Set these on the control plane deployment:
@@ -144,14 +150,19 @@ routing. Set these on the control plane deployment:
 ```bash
 kubectl set env deployment/ambient-control-plane -n ambient-code \
   ANTHROPIC_VERTEX_PROJECT_ID=<your-gcp-project-id> \
-  CLOUD_ML_REGION=us-east5
+  CLOUD_ML_REGION=global
 kubectl rollout status deployment/ambient-control-plane -n ambient-code --timeout=60s
 ```
 
 The `project_id` value comes from your service account JSON file. The region
 must match where your Vertex AI API is enabled.
 
-### Step 4 — Create a Session
+### Step 4 — Create a Session (This Creates the Sandbox) (REQUIRED)
+
+Sandboxes are created **through the control plane** by creating a session. The
+control plane reconciler watches for new sessions and provisions sandboxes via
+the gateway automatically. **Do NOT use `openshell sandbox create`** — that
+bypasses the platform and creates an unmanaged sandbox.
 
 ```bash
 components/ambient-cli/acpctl create session \
@@ -159,6 +170,12 @@ components/ambient-cli/acpctl create session \
   --name "gateway-test" \
   --prompt "Say hello and list your current working directory"
 ```
+
+The control plane will:
+1. Detect the new session
+2. Call the gateway's gRPC API to create a `Sandbox` CR in the tenant namespace
+3. Copy the vertex credential secret into the tenant namespace
+4. Configure inference routing on the gateway
 
 ### Step 5 — Verify Sandbox Reaches Ready
 


### PR DESCRIPTION
## Summary
- Move `HOME` and `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` exports above the guard check in the openshell claude wrapper so they apply on every invocation, not just the first
- Bootstrap `.claude.json` with per-project `hasTrustDialogAccepted` for `/sandbox` and `/sandbox/runner` to prevent trust dialog on manual `claude` runs
- Shorten dummy `ANTHROPIC_API_KEY` from `unused-for-inference-routing` to `notused` to avoid Claude Code custom API key rejection prompt
- Add `--bare` flag to the guard's exec path for consistency
- Update openshell-gateway skill: mark credential steps as REQUIRED, document that sandboxes must be created through the control plane (not `openshell sandbox create`)

## Test plan
- [ ] Deploy kind cluster with `OPENSHELL_USE_GATEWAY=true`
- [ ] Create credential and bind to tenant-a per skill Step 3
- [ ] Create session via `acpctl create session` and verify sandbox provisions with `providers:1`
- [ ] Connect to sandbox and run `claude` — should not prompt for trust or API key approval
- [ ] Verify `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` is set in env on subsequent `claude` invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)