### PR TITLE
fix(gateway): ADC credential support, vertex provisioning, and runner entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -913,6 +913,9 @@ kind-up: preflight-cluster ## Start kind cluster and deploy the platform (LOCAL_
 		NAMESPACE=$(NAMESPACE) \
 		OPENSHELL_TENANTS="$(OPENSHELL_TENANTS)" \
 		AGENT_SANDBOX_VERSION="$(AGENT_SANDBOX_VERSION)" \
+		GOOGLE_APPLICATION_CREDENTIALS="$(GOOGLE_APPLICATION_CREDENTIALS)" \
+		ANTHROPIC_VERTEX_PROJECT_ID="$(ANTHROPIC_VERTEX_PROJECT_ID)" \
+		CLOUD_ML_REGION="$(CLOUD_ML_REGION)" \
 		./scripts/setup-kind-openshell.sh; \
 	fi
 	@# Vertex AI setup if requested

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 .PHONY: preflight-cluster preflight dev-env dev
 .PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift
 .PHONY: unleash-port-forward unleash-status
+.PHONY: kind-port-forward kind-port-forward-stop _kind-start-port-forward kind-acpctl-login
 .PHONY: setup-minio minio-console minio-logs minio-status
 .PHONY: validate-makefile lint-makefile check-shell makefile-health benchmark benchmark-ci
 .PHONY: _create-operator-config _auto-port-forward _show-access-info _kind-load-images
@@ -928,15 +929,15 @@ kind-up: preflight-cluster ## Start kind cluster and deploy the platform (LOCAL_
 		./scripts/bootstrap-workspace.sh || \
 		echo "$(COLOR_YELLOW)⚠$(COLOR_RESET)  Bootstrap failed (non-fatal). Run 'make dev-bootstrap' manually."; \
 	fi
+	@$(MAKE) --no-print-directory _kind-start-port-forward
 	@echo ""
 	@echo "$(COLOR_BOLD)Access the platform:$(COLOR_RESET)"
 	@echo "  Cluster:  $(KIND_CLUSTER_NAME) (slug: $(CLUSTER_SLUG))"
-	@echo "  Run in another terminal: $(COLOR_BLUE)make kind-port-forward$(COLOR_RESET)"
 	@echo ""
-	@echo "  Then access:"
-	@echo "  Frontend: http://localhost:$(KIND_FWD_AMBIENT_UI_PORT)"
-	@echo "  Backend:  http://localhost:$(KIND_FWD_BACKEND_PORT)"
-	@echo "  Keycloak: http://localhost:$(KIND_FWD_KEYCLOAK_PORT)"
+	@echo "  Frontend:   http://localhost:$(KIND_FWD_FRONTEND_PORT)"
+	@echo "  Backend:    http://localhost:$(KIND_FWD_BACKEND_PORT)"
+	@echo "  Ambient UI: http://localhost:$(KIND_FWD_AMBIENT_UI_PORT)"
+	@echo "  Keycloak:   http://localhost:$(KIND_FWD_KEYCLOAK_PORT)"
 	@echo ""
 	@echo "$(COLOR_BOLD)Default SSO users:$(COLOR_RESET)"
 	@echo "  Developer: developer / developer (ambient-users group)"
@@ -944,8 +945,9 @@ kind-up: preflight-cluster ## Start kind cluster and deploy the platform (LOCAL_
 	@echo ""
 	@echo "  Get test token: kubectl get secret test-user-token -n ambient-code -o jsonpath='{.data.token}' | base64 -d"
 	@echo ""
-	@echo "Run tests:"
-	@echo "  make test-e2e"
+	@echo "  Configure CLI:      $(COLOR_BOLD)make kind-acpctl-login$(COLOR_RESET)"
+	@echo "  Stop port-forwards: $(COLOR_BOLD)make kind-port-forward-stop$(COLOR_RESET)"
+	@echo "  Run tests:          $(COLOR_BOLD)make test-e2e$(COLOR_RESET)"
 
 kind-down: ## Stop and delete kind cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Cleaning up kind cluster '$(KIND_CLUSTER_NAME)'..."
@@ -989,7 +991,32 @@ kind-login: check-kubectl check-local-context ## Set kubectl context, port-forwa
 		echo "$$TOKEN"; \
 	fi
 
-kind-port-forward: check-kubectl check-local-context ## Port-forward kind services (for remote Podman)
+kind-acpctl-login: check-kubectl ## Configure acpctl CLI against the kind cluster
+	@TOKEN=$$(kubectl get secret test-user-token -n $(NAMESPACE) -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null); \
+	if [ -z "$$TOKEN" ]; then \
+		echo "$(COLOR_RED)\u2717$(COLOR_RESET) test-user-token not found in namespace $(NAMESPACE)"; \
+		exit 1; \
+	fi; \
+	ACPCTL=""; \
+	if command -v acpctl >/dev/null 2>&1; then \
+		ACPCTL=acpctl; \
+	elif [ -x components/ambient-cli/acpctl ]; then \
+		ACPCTL=components/ambient-cli/acpctl; \
+	elif [ -x ./acpctl ]; then \
+		ACPCTL=./acpctl; \
+	fi; \
+	if [ -n "$$ACPCTL" ]; then \
+		$$ACPCTL login --url http://localhost:$(KIND_FWD_BACKEND_PORT) --token "$$TOKEN" && \
+		echo "$(COLOR_GREEN)\u2713$(COLOR_RESET) acpctl configured: http://localhost:$(KIND_FWD_BACKEND_PORT)"; \
+	else \
+		echo "$(COLOR_YELLOW)acpctl not found — build it first: make build-cli$(COLOR_RESET)"; \
+		echo "  Then run manually:"; \
+		echo "  acpctl login --url http://localhost:$(KIND_FWD_BACKEND_PORT) --token $$TOKEN"; \
+	fi
+
+KIND_PF_DIR := /tmp/ambient-code
+
+kind-port-forward: check-kubectl check-local-context ## Port-forward kind services in background (stop with: make kind-port-forward-stop)
 	@echo "$(COLOR_BOLD)Port forwarding kind services ($(KIND_CLUSTER_NAME))$(COLOR_RESET)"
 	@echo ""
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Configuring SSO for port-forwarded URLs..."
@@ -998,6 +1025,9 @@ kind-port-forward: check-kubectl check-local-context ## Port-forward kind servic
 	@kubectl rollout restart deployment/ambient-ui -n $(NAMESPACE) >/dev/null 2>&1
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for ambient-ui to be ready..."
 	@kubectl wait --for=condition=ready pod -l app=ambient-ui -n $(NAMESPACE) --timeout=60s >/dev/null 2>&1
+	@$(MAKE) --no-print-directory _kind-start-port-forward
+	@echo ""
+	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Port forwarding started in background"
 	@echo ""
 	@echo "  Frontend:   http://localhost:$(KIND_FWD_FRONTEND_PORT)"
 	@echo "  Backend:    http://localhost:$(KIND_FWD_BACKEND_PORT)"
@@ -1008,14 +1038,48 @@ kind-port-forward: check-kubectl check-local-context ## Port-forward kind servic
 	@echo "  Developer: developer / developer"
 	@echo "  Admin:     admin / admin"
 	@echo ""
-	@echo "$(COLOR_YELLOW)Press Ctrl+C to stop$(COLOR_RESET)"
-	@echo ""
-	@trap 'echo ""; echo "$(COLOR_GREEN)✓$(COLOR_RESET) Port forwarding stopped"; kill 0; exit 0' INT TERM; \
-	kubectl port-forward -n ambient-code svc/ambient-ui-service $(KIND_FWD_FRONTEND_PORT):3000 >/dev/null 2>&1 & \
-	kubectl port-forward -n ambient-code svc/ambient-api-server $(KIND_FWD_BACKEND_PORT):8000 >/dev/null 2>&1 & \
-	kubectl port-forward -n ambient-code svc/ambient-ui-service $(KIND_FWD_AMBIENT_UI_PORT):3000 >/dev/null 2>&1 & \
-	kubectl port-forward -n ambient-code svc/keycloak-service $(KIND_FWD_KEYCLOAK_PORT):8080 >/dev/null 2>&1 & \
-	wait
+	@echo "  Stop with: $(COLOR_BOLD)make kind-port-forward-stop$(COLOR_RESET)"
+
+_kind-start-port-forward:
+	@$(MAKE) --no-print-directory kind-port-forward-stop 2>/dev/null || true
+	@mkdir -p $(KIND_PF_DIR)
+	@kubectl port-forward -n $(NAMESPACE) svc/ambient-ui-service $(KIND_FWD_FRONTEND_PORT):3000 >$(KIND_PF_DIR)/kind-pf-frontend.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-frontend.pid
+	@kubectl port-forward -n $(NAMESPACE) svc/ambient-api-server $(KIND_FWD_BACKEND_PORT):8000 >$(KIND_PF_DIR)/kind-pf-backend.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-backend.pid
+	@kubectl port-forward -n $(NAMESPACE) svc/ambient-ui-service $(KIND_FWD_AMBIENT_UI_PORT):3000 >$(KIND_PF_DIR)/kind-pf-ambient-ui.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-ambient-ui.pid
+	@kubectl port-forward -n $(NAMESPACE) svc/keycloak-service $(KIND_FWD_KEYCLOAK_PORT):8080 >$(KIND_PF_DIR)/kind-pf-keycloak.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-keycloak.pid
+	@sleep 1
+	@FAILED=0; \
+	for svc in frontend backend ambient-ui keycloak; do \
+		PID_FILE="$(KIND_PF_DIR)/kind-pf-$$svc.pid"; \
+		if [ -f "$$PID_FILE" ] && ps -p $$(cat "$$PID_FILE") >/dev/null 2>&1; then \
+			true; \
+		else \
+			echo "$(COLOR_RED)✗$(COLOR_RESET) $$svc port-forward failed to start (check $(KIND_PF_DIR)/kind-pf-$$svc.log)"; \
+			FAILED=1; \
+		fi; \
+	done; \
+	if [ "$$FAILED" -ne 0 ]; then exit 1; fi
+
+kind-port-forward-stop: ## Stop background kind port-forwarding
+	@STOPPED=0; \
+	for svc in frontend backend ambient-ui keycloak; do \
+		PID_FILE="$(KIND_PF_DIR)/kind-pf-$$svc.pid"; \
+		if [ -f "$$PID_FILE" ]; then \
+			PID=$$(cat "$$PID_FILE"); \
+			if ps -p "$$PID" >/dev/null 2>&1; then \
+				kill "$$PID" 2>/dev/null || true; \
+				echo "  Stopped $$svc port-forward (PID $$PID)"; \
+				STOPPED=1; \
+			fi; \
+			rm -f "$$PID_FILE"; \
+		fi; \
+		rm -f "$(KIND_PF_DIR)/kind-pf-$$svc.log"; \
+	done; \
+	if [ "$$STOPPED" -eq 1 ]; then \
+		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Port forwarding stopped"; \
+	else \
+		echo "$(COLOR_YELLOW)No active kind port-forwards found$(COLOR_RESET)"; \
+	fi
 
 dev-bootstrap: check-kubectl check-local-context ## Bootstrap developer workspace with API key and integrations
 	@if [ -f ./scripts/bootstrap-workspace.sh ]; then \

--- a/components/ambient-control-plane/internal/openshell/provider_mapping.go
+++ b/components/ambient-control-plane/internal/openshell/provider_mapping.go
@@ -66,6 +66,30 @@ func ProviderCredentials(ambientProvider, token string) map[string]string {
 
 const VertexAIRefreshCredentialKey = "GOOGLE_VERTEX_AI_SERVICE_ACCOUNT_TOKEN"
 
+type GoogleCredentialType int
+
+const (
+	GoogleCredentialServiceAccount GoogleCredentialType = iota
+	GoogleCredentialAuthorizedUser
+)
+
+func DetectGoogleCredentialType(credJSON string) (GoogleCredentialType, error) {
+	var header struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(credJSON), &header); err != nil {
+		return GoogleCredentialServiceAccount, fmt.Errorf("parsing credential JSON: %w", err)
+	}
+	switch header.Type {
+	case "authorized_user":
+		return GoogleCredentialAuthorizedUser, nil
+	case "service_account", "":
+		return GoogleCredentialServiceAccount, nil
+	default:
+		return GoogleCredentialServiceAccount, fmt.Errorf("unsupported Google credential type: %s", header.Type)
+	}
+}
+
 type ServiceAccountJWTMaterial struct {
 	ClientEmail string
 	PrivateKey  string
@@ -85,6 +109,43 @@ func ExtractServiceAccountJWTMaterial(saKeyJSON string) (*ServiceAccountJWTMater
 	return &ServiceAccountJWTMaterial{
 		ClientEmail: parsed.ClientEmail,
 		PrivateKey:  parsed.PrivateKey,
+	}, nil
+}
+
+const DefaultGoogleTokenURI = "https://oauth2.googleapis.com/token"
+
+type OAuth2RefreshMaterial struct {
+	ClientID     string
+	ClientSecret string
+	RefreshToken string
+	TokenURI     string
+	Account      string
+}
+
+func ExtractOAuth2RefreshMaterial(credJSON string) (*OAuth2RefreshMaterial, error) {
+	var parsed struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+		RefreshToken string `json:"refresh_token"`
+		TokenURI     string `json:"token_uri"`
+		Account      string `json:"account"`
+	}
+	if err := json.Unmarshal([]byte(credJSON), &parsed); err != nil {
+		return nil, err
+	}
+	if parsed.ClientID == "" || parsed.ClientSecret == "" || parsed.RefreshToken == "" {
+		return nil, fmt.Errorf("authorized_user JSON missing client_id, client_secret, or refresh_token")
+	}
+	tokenURI := parsed.TokenURI
+	if tokenURI == "" {
+		tokenURI = DefaultGoogleTokenURI
+	}
+	return &OAuth2RefreshMaterial{
+		ClientID:     parsed.ClientID,
+		ClientSecret: parsed.ClientSecret,
+		RefreshToken: parsed.RefreshToken,
+		TokenURI:     tokenURI,
+		Account:      parsed.Account,
 	}, nil
 }
 

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -391,7 +391,7 @@ func (r *SimpleKubeReconciler) resolveEntrypoint(agent *types.Agent) []string {
 	if agent != nil && agent.Entrypoint != "" {
 		return []string{agent.Entrypoint}
 	}
-	return []string{"claude"}
+	return []string{"/sandbox/runner/entrypoint.sh"}
 }
 
 func (r *SimpleKubeReconciler) resolveSandboxImage(agent *types.Agent) string {
@@ -584,24 +584,63 @@ func (r *SimpleKubeReconciler) ensureGatewayProviders(ctx context.Context, names
 	return providerNames, nil
 }
 
-func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context, namespace, provName, saKeyJSON string) error {
-	material, err := openshell.ExtractServiceAccountJWTMaterial(saKeyJSON)
+func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context, namespace, provName, credJSON string) error {
+	credType, err := openshell.DetectGoogleCredentialType(credJSON)
 	if err != nil {
-		return fmt.Errorf("parsing service account key: %w", err)
+		return fmt.Errorf("detecting credential type: %w", err)
 	}
 
 	credKey := openshell.VertexAIRefreshCredentialKey
+	var refreshReq *openshellpb.ConfigureProviderRefreshRequest
 
-	if _, err := r.gateway.ConfigureProviderRefresh(ctx, namespace, &openshellpb.ConfigureProviderRefreshRequest{
-		Provider:      provName,
-		CredentialKey: credKey,
-		Strategy:      openshellpb.ProviderCredentialRefreshStrategy_PROVIDER_CREDENTIAL_REFRESH_STRATEGY_GOOGLE_SERVICE_ACCOUNT_JWT,
-		Material: map[string]string{
-			"client_email": material.ClientEmail,
-			"private_key":  material.PrivateKey,
-		},
-		SecretMaterialKeys: []string{"private_key"},
-	}); err != nil {
+	switch credType {
+	case openshell.GoogleCredentialServiceAccount:
+		material, err := openshell.ExtractServiceAccountJWTMaterial(credJSON)
+		if err != nil {
+			return fmt.Errorf("parsing service account key: %w", err)
+		}
+		refreshReq = &openshellpb.ConfigureProviderRefreshRequest{
+			Provider:      provName,
+			CredentialKey: credKey,
+			Strategy:      openshellpb.ProviderCredentialRefreshStrategy_PROVIDER_CREDENTIAL_REFRESH_STRATEGY_GOOGLE_SERVICE_ACCOUNT_JWT,
+			Material: map[string]string{
+				"client_email": material.ClientEmail,
+				"private_key":  material.PrivateKey,
+			},
+			SecretMaterialKeys: []string{"private_key"},
+		}
+		r.logger.Info().
+			Str("provider", provName).
+			Msg("using service account JWT strategy for vertex credential refresh")
+
+	case openshell.GoogleCredentialAuthorizedUser:
+		material, err := openshell.ExtractOAuth2RefreshMaterial(credJSON)
+		if err != nil {
+			return fmt.Errorf("parsing authorized_user credential: %w", err)
+		}
+		clientEmail := material.Account
+		if clientEmail == "" {
+			clientEmail = "authorized-user@adc.local"
+		}
+		refreshReq = &openshellpb.ConfigureProviderRefreshRequest{
+			Provider:      provName,
+			CredentialKey: credKey,
+			Strategy:      openshellpb.ProviderCredentialRefreshStrategy_PROVIDER_CREDENTIAL_REFRESH_STRATEGY_OAUTH2_REFRESH_TOKEN,
+			Material: map[string]string{
+				"client_id":     material.ClientID,
+				"client_secret": material.ClientSecret,
+				"refresh_token": material.RefreshToken,
+				"client_email":  clientEmail,
+				"private_key":   "unused-for-oauth2-refresh",
+			},
+			SecretMaterialKeys: []string{"client_secret", "refresh_token", "private_key"},
+		}
+		r.logger.Info().
+			Str("provider", provName).
+			Msg("using OAuth2 refresh token strategy for vertex credential refresh")
+	}
+
+	if _, err := r.gateway.ConfigureProviderRefresh(ctx, namespace, refreshReq); err != nil {
 		return fmt.Errorf("configuring refresh: %w", err)
 	}
 

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -631,13 +631,15 @@ func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context
 				"client_secret": material.ClientSecret,
 				"refresh_token": material.RefreshToken,
 				"client_email":  clientEmail,
-				"private_key":   "unused-for-oauth2-refresh",
 			},
-			SecretMaterialKeys: []string{"client_secret", "refresh_token", "private_key"},
+			SecretMaterialKeys: []string{"client_secret", "refresh_token"},
 		}
 		r.logger.Info().
 			Str("provider", provName).
 			Msg("using OAuth2 refresh token strategy for vertex credential refresh")
+
+	default:
+		return fmt.Errorf("unsupported Google credential type %q", credType)
 	}
 
 	if _, err := r.gateway.ConfigureProviderRefresh(ctx, namespace, refreshReq); err != nil {

--- a/e2e/scripts/setup-kind.sh
+++ b/e2e/scripts/setup-kind.sh
@@ -42,9 +42,10 @@ fi
 
 # Check if kind cluster already exists
 if kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER_NAME}$"; then
-  echo "Kind cluster '${KIND_CLUSTER_NAME}' already exists"
-  echo "   Run 'make kind-down' or delete manually: kind delete cluster --name ${KIND_CLUSTER_NAME}"
-  exit 1
+  echo "Kind cluster '${KIND_CLUSTER_NAME}' already exists — skipping creation"
+  kubectl config use-context "kind-${KIND_CLUSTER_NAME}" >/dev/null 2>&1 || true
+  echo "Returning control to the Makefile for platform deployment..."
+  exit 0
 fi
 
 echo ""

--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -25,26 +25,30 @@ echo "Setting up OpenShell gateway prerequisites (tenants: ${TENANTS[*]})..."
 #    resolver tries IPv6 first and fails without falling back to IPv4, causing
 #    503 on inference calls (Vertex AI) and DENIED on api.anthropic.com, github.com, etc.
 echo "  Patching CoreDNS to suppress AAAA records (IPv4-only)..."
-kubectl get configmap coredns -n kube-system -o json \
-  | python3 -c '
+COREFILE=$(kubectl get configmap coredns -n kube-system -o jsonpath='{.data.Corefile}')
+if echo "$COREFILE" | grep -q "template IN AAAA"; then
+  echo "  CoreDNS already patched — skipping restart"
+else
+  kubectl get configmap coredns -n kube-system -o json \
+    | python3 -c '
 import json, sys, re
 cm = json.load(sys.stdin)
 corefile = cm["data"]["Corefile"]
-if "template IN AAAA" not in corefile:
-    corefile = re.sub(
-        r"([ \t]+forward \. /etc/resolv\.conf)",
-        "        template IN AAAA {\n"
-        "            rcode NOERROR\n"
-        "        }\n"
-        r"\1",
-        corefile,
-    )
-    cm["data"]["Corefile"] = corefile
+corefile = re.sub(
+    r"([ \t]+forward \. /etc/resolv\.conf)",
+    "        template IN AAAA {\n"
+    "            rcode NOERROR\n"
+    "        }\n"
+    r"\1",
+    corefile,
+)
+cm["data"]["Corefile"] = corefile
 json.dump(cm, sys.stdout)
 ' | kubectl apply -f - >/dev/null 2>&1
-kubectl rollout restart deployment coredns -n kube-system >/dev/null 2>&1
-kubectl rollout status deployment coredns -n kube-system --timeout=60s >/dev/null 2>&1
-echo "  CoreDNS patched (IPv4-only for all external domains)"
+  kubectl rollout restart deployment coredns -n kube-system >/dev/null 2>&1
+  kubectl rollout status deployment coredns -n kube-system --timeout=60s >/dev/null 2>&1
+  echo "  CoreDNS patched (IPv4-only for all external domains)"
+fi
 
 # 1. Install Agent Sandbox CRD + controller (once, cluster-scoped)
 echo "  Installing agent-sandbox CRD ${AGENT_SANDBOX_VERSION}..."
@@ -97,12 +101,13 @@ else
   else
     for TENANT in "${TENANTS[@]}"; do
       # Check whether a project with this name already exists
+      SEARCH_QUERY=$(printf "name = '%s'" "${TENANT}")
       EXISTING=$(curl -sf \
         -H "Authorization: Bearer ${TOKEN}" \
-        "http://localhost:${PF_PORT}/api/ambient/v1/projects?search=${TENANT}" 2>/dev/null || echo "")
+        --data-urlencode "search=${SEARCH_QUERY}" \
+        -G "http://localhost:${PF_PORT}/api/ambient/v1/projects" 2>/dev/null || echo "{}")
       MATCH_COUNT=$(echo "$EXISTING" \
-        | jq -r '[.items[] | select(.name == "'"${TENANT}"'")] | length' 2>/dev/null)
-      MATCH_COUNT="${MATCH_COUNT:-0}"
+        | jq -r '[(.items // [])[] | select(.name == "'"${TENANT}"'")] | length' 2>/dev/null || echo "0")
 
       if [ "${MATCH_COUNT}" -gt 0 ]; then
         echo "    ACP project '${TENANT}' already exists"
@@ -120,10 +125,16 @@ else
   kill "${PF_PID}" 2>/dev/null || true
 fi
 
-# 4. Patch control plane with the gateway flag
-kubectl set env deployment/ambient-control-plane -n "$NAMESPACE" \
-  OPENSHELL_USE_GATEWAY=true >/dev/null
-echo "  Patched ambient-control-plane with OPENSHELL_USE_GATEWAY=true"
+# 4. Patch control plane with the gateway flag (skip if already set)
+CURRENT_GW=$(kubectl get deployment ambient-control-plane -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSHELL_USE_GATEWAY")].value}' 2>/dev/null || echo "")
+if [ "$CURRENT_GW" = "true" ]; then
+  echo "  ambient-control-plane already has OPENSHELL_USE_GATEWAY=true — skipping"
+else
+  kubectl set env deployment/ambient-control-plane -n "$NAMESPACE" \
+    OPENSHELL_USE_GATEWAY=true >/dev/null
+  echo "  Patched ambient-control-plane with OPENSHELL_USE_GATEWAY=true"
+fi
 echo "  Note: ambient-ui gateway mode is baked in at build time via --build-arg OPENSHELL_USE_GATEWAY=true"
 
 echo "OpenShell gateway setup complete (${TENANTS[*]})."

--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -6,7 +6,9 @@
 #   1. Agent Sandbox CRD + controller (once, cluster-scoped)
 #   2. Tenant namespaces
 #   3. ACP project via the API
+#   3b. Vertex AI credentials bound to each project (if GOOGLE_APPLICATION_CREDENTIALS is set)
 #   4. Patches the control plane deployment with OPENSHELL_USE_GATEWAY=true
+#      and Vertex AI env vars (ANTHROPIC_VERTEX_PROJECT_ID, CLOUD_ML_REGION) if set
 #
 # The control plane reconciler handles gateway resource deployment via
 # the platform-config ConfigMap — no Helm chart needed.
@@ -122,21 +124,123 @@ else
     done
   fi
 
+  # 3b. Provision Vertex AI credentials for each tenant project (if available)
+  if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+    echo "  Provisioning Vertex AI credentials for tenant projects..."
+    SA_KEY_JSON=$(cat "$GOOGLE_APPLICATION_CREDENTIALS")
+
+    CREDENTIAL_VIEWER_ROLE_ID=$(curl -sf \
+      -H "Authorization: Bearer ${TOKEN}" \
+      "http://localhost:${PF_PORT}/api/ambient/v1/roles?page=1&size=100" 2>/dev/null \
+      | jq -r '.items[] | select(.name == "credential:viewer") | .id' 2>/dev/null || echo "")
+
+    if [ -z "$CREDENTIAL_VIEWER_ROLE_ID" ]; then
+      echo "  Warning: could not resolve credential:viewer role ID; skipping vertex credential binding"
+    else
+      for TENANT in "${TENANTS[@]}"; do
+        SEARCH_QUERY=$(printf "name = '%s'" "${TENANT}")
+        PROJECT_ID=$(curl -sf \
+          -H "Authorization: Bearer ${TOKEN}" \
+          --data-urlencode "search=${SEARCH_QUERY}" \
+          -G "http://localhost:${PF_PORT}/api/ambient/v1/projects" 2>/dev/null \
+          | jq -r '[(.items // [])[] | select(.name == "'"${TENANT}"'")] | .[0].id // empty' 2>/dev/null || echo "")
+
+        if [ -z "$PROJECT_ID" ]; then
+          echo "    Warning: project '${TENANT}' not found; skipping vertex credential"
+          continue
+        fi
+
+        VERTEX_CRED_NAME="vertex-${TENANT}"
+        EXISTING_CRED_ID=$(curl -sf \
+          -H "Authorization: Bearer ${TOKEN}" \
+          "http://localhost:${PF_PORT}/api/ambient/v1/credentials?search=name%3D'${VERTEX_CRED_NAME}'" 2>/dev/null \
+          | jq -r '[(.items // [])[] | select(.name == "'"${VERTEX_CRED_NAME}"'")] | .[0].id // empty' 2>/dev/null || echo "")
+
+        if [ -n "$EXISTING_CRED_ID" ]; then
+          echo "    Vertex credential '${VERTEX_CRED_NAME}' already exists (${EXISTING_CRED_ID})"
+        else
+          CRED_RESPONSE=$(curl -sf -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg name "$VERTEX_CRED_NAME" \
+              --arg token "$SA_KEY_JSON" \
+              '{name: $name, provider: "vertex", token: $token}')" \
+            "http://localhost:${PF_PORT}/api/ambient/v1/credentials" 2>/dev/null || echo "{}")
+          EXISTING_CRED_ID=$(echo "$CRED_RESPONSE" | jq -r '.id // empty' 2>/dev/null || echo "")
+
+          if [ -z "$EXISTING_CRED_ID" ]; then
+            echo "    Warning: failed to create vertex credential for '${TENANT}'"
+            continue
+          fi
+          echo "    Created vertex credential '${VERTEX_CRED_NAME}' (${EXISTING_CRED_ID})"
+        fi
+
+        EXISTING_BINDING=$(curl -sf \
+          -H "Authorization: Bearer ${TOKEN}" \
+          "http://localhost:${PF_PORT}/api/ambient/v1/role_bindings?search=scope%3D'credential'" 2>/dev/null \
+          | jq -r '[(.items // [])[] | select(.credential_id == "'"${EXISTING_CRED_ID}"'" and .project_id == "'"${PROJECT_ID}"'")] | length' 2>/dev/null || echo "0")
+
+        if [ "${EXISTING_BINDING}" -gt 0 ] 2>/dev/null; then
+          echo "    Vertex credential already bound to project '${TENANT}'"
+        else
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg role_id "$CREDENTIAL_VIEWER_ROLE_ID" \
+              --arg credential_id "$EXISTING_CRED_ID" \
+              --arg project_id "$PROJECT_ID" \
+              '{role_id: $role_id, scope: "credential", credential_id: $credential_id, project_id: $project_id}')" \
+            "http://localhost:${PF_PORT}/api/ambient/v1/role_bindings" >/dev/null 2>&1
+          echo "    Bound vertex credential to project '${TENANT}'"
+        fi
+      done
+    fi
+  else
+    echo "  Skipping Vertex AI credentials (GOOGLE_APPLICATION_CREDENTIALS not set)"
+  fi
+
   kill "${PF_PID}" 2>/dev/null || true
 fi
 
-# 4. Patch control plane with gateway flag (skip if already set)
+# 4. Patch control plane with gateway flag and vertex env vars (idempotent)
 #    TLS is left at its default (true) — certgen-job creates openshell-client-tls
 #    and openshell-server-tls secrets so mTLS works out of the box in Kind.
+CP_ENV_ARGS="OPENSHELL_USE_GATEWAY=true"
+CP_NEEDS_PATCH=false
+
 CURRENT_GW=$(kubectl get deployment ambient-control-plane -n "$NAMESPACE" \
   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSHELL_USE_GATEWAY")].value}' 2>/dev/null || echo "")
-if [ "$CURRENT_GW" = "true" ]; then
-  echo "  ambient-control-plane already has OPENSHELL_USE_GATEWAY=true — skipping"
-else
-  kubectl set env deployment/ambient-control-plane -n "$NAMESPACE" \
-    OPENSHELL_USE_GATEWAY=true >/dev/null
+if [ "$CURRENT_GW" != "true" ]; then
+  CP_NEEDS_PATCH=true
+fi
+
+if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+  CURRENT_PROJECT=$(kubectl get deployment ambient-control-plane -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="ANTHROPIC_VERTEX_PROJECT_ID")].value}' 2>/dev/null || echo "")
+  if [ "$CURRENT_PROJECT" != "$ANTHROPIC_VERTEX_PROJECT_ID" ]; then
+    CP_NEEDS_PATCH=true
+  fi
+  CP_ENV_ARGS="$CP_ENV_ARGS ANTHROPIC_VERTEX_PROJECT_ID=${ANTHROPIC_VERTEX_PROJECT_ID}"
+fi
+
+if [ -n "${CLOUD_ML_REGION:-}" ]; then
+  CURRENT_REGION=$(kubectl get deployment ambient-control-plane -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CLOUD_ML_REGION")].value}' 2>/dev/null || echo "")
+  if [ "$CURRENT_REGION" != "$CLOUD_ML_REGION" ]; then
+    CP_NEEDS_PATCH=true
+  fi
+  CP_ENV_ARGS="$CP_ENV_ARGS CLOUD_ML_REGION=${CLOUD_ML_REGION}"
+fi
+
+if [ "$CP_NEEDS_PATCH" = "true" ]; then
+  # shellcheck disable=SC2086
+  kubectl set env deployment/ambient-control-plane -n "$NAMESPACE" $CP_ENV_ARGS >/dev/null
   kubectl rollout status deployment/ambient-control-plane -n "$NAMESPACE" --timeout=60s >/dev/null 2>&1
-  echo "  Patched ambient-control-plane with OPENSHELL_USE_GATEWAY=true (TLS enabled by default)"
+  echo "  Patched ambient-control-plane with: $CP_ENV_ARGS"
+else
+  echo "  ambient-control-plane env already up to date — skipping"
 fi
 echo "  Note: ambient-ui gateway mode is baked in at build time via --build-arg OPENSHELL_USE_GATEWAY=true"
 

--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -125,7 +125,9 @@ else
   kill "${PF_PID}" 2>/dev/null || true
 fi
 
-# 4. Patch control plane with the gateway flag (skip if already set)
+# 4. Patch control plane with gateway flag (skip if already set)
+#    TLS is left at its default (true) — certgen-job creates openshell-client-tls
+#    and openshell-server-tls secrets so mTLS works out of the box in Kind.
 CURRENT_GW=$(kubectl get deployment ambient-control-plane -n "$NAMESPACE" \
   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OPENSHELL_USE_GATEWAY")].value}' 2>/dev/null || echo "")
 if [ "$CURRENT_GW" = "true" ]; then
@@ -133,7 +135,8 @@ if [ "$CURRENT_GW" = "true" ]; then
 else
   kubectl set env deployment/ambient-control-plane -n "$NAMESPACE" \
     OPENSHELL_USE_GATEWAY=true >/dev/null
-  echo "  Patched ambient-control-plane with OPENSHELL_USE_GATEWAY=true"
+  kubectl rollout status deployment/ambient-control-plane -n "$NAMESPACE" --timeout=60s >/dev/null 2>&1
+  echo "  Patched ambient-control-plane with OPENSHELL_USE_GATEWAY=true (TLS enabled by default)"
 fi
 echo "  Note: ambient-ui gateway mode is baked in at build time via --build-arg OPENSHELL_USE_GATEWAY=true"
 


### PR DESCRIPTION
## Summary

- **ADC (Application Default Credentials) support**: Detects Google credential type (`authorized_user` vs `service_account`) and uses the appropriate gateway refresh strategy (OAuth2 refresh token vs SA JWT). Adds `DetectGoogleCredentialType`, `ExtractOAuth2RefreshMaterial`, and `ExtractServiceAccountJWTMaterial` functions in `provider_mapping.go`.
- **Runner entrypoint fix**: Changed `resolveEntrypoint()` default from `["claude"]` to `["/sandbox/runner/entrypoint.sh"]` — bare `claude` exits immediately with no TTY/prompt; the runner server (uvicorn) must start first to manage the Claude CLI lifecycle.
- **Vertex credential provisioning in Kind**: `setup-kind-openshell.sh` now creates `vertex-<tenant>` credentials via the API and binds them to projects with `credential:viewer` role when `GOOGLE_APPLICATION_CREDENTIALS` is set.
- **Makefile vertex env vars**: Passes `GOOGLE_APPLICATION_CREDENTIALS`, `ANTHROPIC_VERTEX_PROJECT_ID`, and `CLOUD_ML_REGION` to `setup-kind-openshell.sh`.
- **Idempotent kind-up**: Background port-forwards and acpctl login during `kind-up`.
- **mTLS for gateway connections in Kind**: TLS configuration for gateway gRPC connections.

## Known Issues (WIP)

- **502 Bad Gateway on `acpctl session send -f`**: `provisionSessionSandbox` does not call `ensureService()`, so no K8s Service is created for sandbox sessions. The API server SSE proxy cannot reach the runner.
- **400 context_management from Vertex AI**: Claude Code CLI sends request parameters that Vertex doesn't support (`context_management: Extra inputs are not permitted`).

## Test plan

- [x] `make kind-up OPENSHELL_USE_GATEWAY=true` with `GOOGLE_APPLICATION_CREDENTIALS` set to ADC file
- [x] Verify sandbox pods start with correct entrypoint (`/sandbox/runner/entrypoint.sh`)
- [x] Verify uvicorn + claude CLI processes running in sandbox
- [x] Verify inference routing (`ALLOWED inference.local:443`)
- [ ] End-to-end session message streaming (blocked by 502/Service issue)

🤖 Generated with [Claude Code](https://claude.ai/code)