### PR TITLE
fix(gateway): allow ConfigMapSyncer to bypass gateway mode restrictions

### DIFF
--- a/components/ambient-api-server/plugins/agents/handler.go
+++ b/components/ambient-api-server/plugins/agents/handler.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/gorilla/mux"
 
 	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
 	"github.com/ambient-code/platform/components/ambient-api-server/pkg/gateway"
 	"github.com/openshift-online/rh-trex-ai/pkg/api/presenters"
+	"github.com/openshift-online/rh-trex-ai/pkg/auth"
 	"github.com/openshift-online/rh-trex-ai/pkg/errors"
 	"github.com/openshift-online/rh-trex-ai/pkg/handlers"
 	"github.com/openshift-online/rh-trex-ai/pkg/services"
@@ -33,10 +35,20 @@ func NewAgentHandler(agent AgentService, generic services.GenericService) *agent
 
 func (h agentHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// Gateway mode gating — BEFORE HandlerConfig
+	// Allow control-plane service account to bypass for ConfigMap sync
 	if gateway.IsGatewayModeActive() {
-		handlers.HandleError(r.Context(), w, errors.Forbidden(
-			"Agent creation is not permitted in gateway mode. Agents are managed via GitOps ConfigMaps."))
-		return
+		username := auth.GetUsernameFromContext(r.Context())
+
+		// Allow control-plane (either via service account or dev-user token)
+		isControlPlane := username == "dev-user" ||
+			(strings.HasPrefix(username, "system:serviceaccount:") &&
+				strings.Contains(username, "ambient-control-plane"))
+
+		if !isControlPlane {
+			handlers.HandleError(r.Context(), w, errors.Forbidden(
+				"Agent creation is not permitted in gateway mode. Agents are managed via GitOps ConfigMaps."))
+			return
+		}
 	}
 
 	var agent openapi.Agent
@@ -64,10 +76,20 @@ func (h agentHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 func (h agentHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	// Gateway mode gating — BEFORE HandlerConfig
+	// Allow control-plane service account to bypass for ConfigMap sync
 	if gateway.IsGatewayModeActive() {
-		handlers.HandleError(r.Context(), w, errors.Forbidden(
-			"Agent updates are not permitted in gateway mode. Agents are managed via GitOps ConfigMaps."))
-		return
+		username := auth.GetUsernameFromContext(r.Context())
+
+		// Allow control-plane (either via service account or dev-user token)
+		isControlPlane := username == "dev-user" ||
+			(strings.HasPrefix(username, "system:serviceaccount:") &&
+				strings.Contains(username, "ambient-control-plane"))
+
+		if !isControlPlane {
+			handlers.HandleError(r.Context(), w, errors.Forbidden(
+				"Agent updates are not permitted in gateway mode. Agents are managed via GitOps ConfigMaps."))
+			return
+		}
 	}
 
 	var patch openapi.AgentPatchRequest
@@ -240,10 +262,20 @@ func (h agentHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 func (h agentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// Gateway mode gating — BEFORE HandlerConfig
+	// Allow control-plane service account to bypass for ConfigMap sync
 	if gateway.IsGatewayModeActive() {
-		handlers.HandleError(r.Context(), w, errors.Forbidden(
-			"Agent deletion is not permitted in gateway mode. Agents are managed via GitOps ConfigMaps."))
-		return
+		username := auth.GetUsernameFromContext(r.Context())
+
+		// Allow control-plane (either via service account or dev-user token)
+		isControlPlane := username == "dev-user" ||
+			(strings.HasPrefix(username, "system:serviceaccount:") &&
+				strings.Contains(username, "ambient-control-plane"))
+
+		if !isControlPlane {
+			handlers.HandleError(r.Context(), w, errors.Forbidden(
+				"Agent deletion is not permitted in gateway mode. Agents are managed via GitOps ConfigMaps."))
+			return
+		}
 	}
 
 	cfg := &handlers.HandlerConfig{

--- a/components/ambient-control-plane/internal/reconciler/configmap_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/configmap_reconciler.go
@@ -978,6 +978,11 @@ func (s *ConfigMapSyncer) createAPI(ctx context.Context, projectID, resource str
 		return "", fmt.Errorf("getting token: %w", err)
 	}
 
+	// Ensure project_id is in the body
+	if _, exists := body["project_id"]; !exists {
+		body["project_id"] = projectID
+	}
+
 	data, err := json.Marshal(body)
 	if err != nil {
 		return "", fmt.Errorf("marshalling body: %w", err)


### PR DESCRIPTION
This fixes two issues preventing ConfigMapSyncer from reconciling agents, providers, and policies from ConfigMaps to the API server in gateway mode:

1. **Missing project_id in request body**: Modified createAPI() in configmap_reconciler.go to automatically inject project_id into the request body when not present. Previously, provider and policy creation failed with HTTP 400 'no value given for required property project_id'.

2. **Gateway mode blocking ConfigMapSyncer**: Added bypass logic in plugins/agents/handler.go Create(), Patch(), and Delete() handlers to allow the control-plane service account (dev-user token) to bypass gateway mode restrictions. Previously all agent operations were rejected with HTTP 403.

After these fixes, ConfigMapSyncer successfully reconciles all resources (agents, providers, policies) from ConfigMaps with gateway mode enabled.