### PR TITLE
fix(gateway): deliver exec env and prompt to OpenShell sandboxes

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -333,7 +333,9 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	existing, err := r.gateway.GetSandbox(ctx, namespace, sbxName)
 	if err == nil && existing != nil && existing.Sandbox != nil {
 		r.logger.Debug().Str("sandbox", sbxName).Msg("sandbox already exists")
-		go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk)
+		execEnv := r.inferenceExecEnv()
+		execEntrypoint := r.appendPromptToEntrypoint(ctx, entrypoint, session, sdk)
+		go r.execAfterReady(namespace, sbxName, session.ID, execEntrypoint, sdk, execEnv)
 		r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
 		return nil
 	}
@@ -384,10 +386,40 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 		Int("providers", len(providerNames)).
 		Msg("sandbox created via gateway")
 
-	go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk)
+	execEnv := r.inferenceExecEnv()
+	execEntrypoint := r.appendPromptToEntrypoint(ctx, entrypoint, session, sdk)
+	go r.execAfterReady(namespace, sbxName, session.ID, execEntrypoint, sdk, execEnv)
 
 	r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
 	return nil
+}
+
+func (r *SimpleKubeReconciler) appendPromptToEntrypoint(ctx context.Context, entrypoint []string, session types.Session, sdk *sdkclient.Client) []string {
+	prompt := r.assembleInitialPrompt(ctx, session, sdk)
+	if prompt == "" {
+		return entrypoint
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(prompt))
+	shellCmd := fmt.Sprintf("echo %s | base64 -d | %s --print -", encoded, strings.Join(entrypoint, " "))
+	return []string{"/bin/sh", "-c", shellCmd}
+}
+
+func (r *SimpleKubeReconciler) inferenceExecEnv() map[string]string {
+	if !r.cfg.OpenShellUseGateway {
+		return nil
+	}
+	return map[string]string{
+		"ANTHROPIC_BASE_URL":                     "https://inference.local",
+		"ANTHROPIC_API_KEY":                      "notused",
+		"HTTPS_PROXY":                            "http://10.200.0.1:3128",
+		"NO_PROXY":                               "127.0.0.1,localhost",
+		"NODE_EXTRA_CA_CERTS":                    "/etc/openshell-tls/openshell-ca.pem",
+		"SSL_CERT_FILE":                          "/etc/openshell-tls/openshell-ca.pem",
+		"REQUESTS_CA_BUNDLE":                     "/etc/openshell-tls/openshell-ca.pem",
+		"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+		"ACP_OPENSHELL_INFERENCE":                "true",
+		"HOME":                                   "/sandbox",
+	}
 }
 
 func (r *SimpleKubeReconciler) resolveEntrypoint(agent *types.Agent) []string {
@@ -428,7 +460,7 @@ func (r *SimpleKubeReconciler) mergeAgentEnvironment(env map[string]string, agen
 	}
 }
 
-func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID string, entrypoint []string, sdk *sdkclient.Client) {
+func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID string, entrypoint []string, sdk *sdkclient.Client, execEnv map[string]string) {
 	pollCtx, pollCancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer pollCancel()
 
@@ -523,8 +555,9 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 			}
 
 			err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
-				SandboxId: sandboxID,
-				Command:   entrypoint,
+				SandboxId:   sandboxID,
+				Command:     entrypoint,
+				Environment: execEnv,
 			})
 			if err != nil {
 				r.logger.Error().Err(err).Str("sandbox", sbxName).Str("session_id", sessionID).Msg("failed to start runner exec")


### PR DESCRIPTION
## Summary

- Pass inference routing env vars (`ANTHROPIC_BASE_URL`, `HTTPS_PROXY`, TLS certs, etc.) directly via `ExecSandboxRequest.Environment` to bypass the OpenShell supervisor's async env delivery race condition — the sandbox entrypoint was executing before env vars arrived
- Base64-encode the assembled prompt and pipe it via stdin (`echo <b64>  < /dev/null |  base64 -d | claude --print -`) to work around OpenShell's newline restrictions in both env vars and command arguments
- Add `inferenceExecEnv()` and `appendPromptToEntrypoint()` methods to `SimpleKubeReconciler`

## Test plan

- [x] Deployed to Kind cluster with `OPENSHELL_USE_GATEWAY=true`
- [x] Created session via `acpctl agent start hello-world`
- [x] Verified sandbox provisioned, inference routing configured, and vertex credentials rotated
- [x] Confirmed full LLM inference turn completed: Claude returned "Hello, World\!" with exit_code 0
- [x] `go vet ./...` and `gofmt` pass

> **Note:** The `ANTHROPIC_API_KEY: "notused"` in the diff is a dummy placeholder for inference routing — the real API key is never used in gateway mode. Inference traffic is proxied through the OpenShell supervisor.

🤖 Generated with [Claude Code](https://claude.ai/code)