### PR TITLE
fix(dev): wait for postgresql before api-server in kind setup

### DIFF
--- a/e2e/scripts/wait-for-ready.sh
+++ b/e2e/scripts/wait-for-ready.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 echo "Waiting for all deployments to be ready..."
 echo ""
 
+# Wait for PostgreSQL first so the API server can connect on startup
+echo "⏳ Waiting for postgresql..."
+kubectl wait --for=condition=available --timeout=300s \
+  deployment/postgresql \
+  -n ambient-code
+
+# Restart the API server pod to break out of CrashLoopBackOff
+echo "⏳ Restarting ambient-api-server (DB is now ready)..."
+kubectl delete pod -l app=ambient-api-server -n ambient-code --wait=false 2>/dev/null || true
+
 # Wait for ambient-api-server
 echo "⏳ Waiting for ambient-api-server..."
 kubectl wait --for=condition=available --timeout=300s \


### PR DESCRIPTION
## Summary
- Wait for the `postgresql` deployment to be available before waiting on `ambient-api-server` during `kind-up`
- Once DB is ready, delete the api-server pod to break out of CrashLoopBackOff, then wait for it to come up healthy
- Fixes race condition where the API server starts before PostgreSQL is ready

## Test plan
- [ ] Run `make kind-up` and verify the API server does not enter CrashLoopBackOff
- [ ] Verify the wait output shows postgresql ready before api-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)