### PR TITLE
fix(dev): show kind-setup-openshell-cli hint in kind-up output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -945,6 +945,7 @@ kind-up: preflight-cluster ## Start kind cluster and deploy the platform (LOCAL_
 	@echo "  Get test token: kubectl get secret test-user-token -n ambient-code -o jsonpath='{.data.token}' | base64 -d"
 	@echo ""
 	@echo "  Configure CLI:      $(COLOR_BOLD)make kind-acpctl-login$(COLOR_RESET)"
+	@echo "  Setup OpenShell:    $(COLOR_BOLD)make kind-setup-openshell-cli$(COLOR_RESET)"
 	@echo "  Stop port-forwards: $(COLOR_BOLD)make kind-port-forward-stop$(COLOR_RESET)"
 	@echo "  Run tests:          $(COLOR_BOLD)make test-e2e$(COLOR_RESET)"
 


### PR DESCRIPTION
## Summary
- Add `make kind-setup-openshell-cli` to the post-setup hints printed by `make kind-up`

## Test plan
- [ ] Run `make kind-up` and verify the new hint appears in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)