### PR TITLE
Docs: Update README to reflect current platform specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,25 @@
 [![Unit Tests](https://github.com/openshift-online/agent-control-plane/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/openshift-online/agent-control-plane/actions/workflows/unit-tests.yml)
 [![Docs](https://github.com/openshift-online/agent-control-plane/actions/workflows/docs.yml/badge.svg)](https://openshift-online.github.io/agent-control-plane/)
 
-> AI automation platform for orchestrating agentic sessions on Kubernetes
+> Kubernetes-native AI automation platform for orchestrating agentic sessions through containerized microservices
 
 ## Overview
 
-The Agent Control Plane (ACP) lets teams create and manage AI agentic sessions - automated tasks that clone repos, run AI agents, and push results. Sessions are stored in PostgreSQL and reconciled into Kubernetes pods via gRPC.
+The Agent Control Plane (ACP) lets teams create and manage AI agentic sessions — automated tasks that clone repos, run AI agents, and push results. Sessions are stored in PostgreSQL and reconciled into Kubernetes Jobs via gRPC watch streams.
 
 ### Key Capabilities
 
 - **Agentic Sessions**: AI-powered automation for code review, bug fixes, research, and development tasks
-- **Multi-Agent Workflows**: Specialized AI agents with configurable prompts, models, and repos
-- **Git Provider Support**: GitHub and GitLab (SaaS and self-hosted) via credential sidecars
-- **Kubernetes Execution**: Sessions run as pods with RBAC, resource limits, and namespace isolation
+- **Multi-Agent Workflows**: Agents organized in projects with inter-agent messaging via persistent inbox queues
+- **Scheduled Sessions**: Cron-based recurring agent triggers with overlap policies and timezone support
+- **GitOps Fleet Management**: Argo CD-style Applications that continuously sync agent fleet definitions from git repositories
+- **AG-UI Event Streaming**: Real-time event streaming via the [AG-UI protocol](https://github.com/anthropics/ag-ui) with dual APIs (human-readable Messages API + comprehensive Events API with compression)
+- **Credential Provider Support**: GitHub, GitLab, Jira, Google, Vertex AI, and Kubeconfig via isolated credential sidecars
+- **SSO Authentication**: OpenID Connect with Red Hat SSO / Keycloak, BFF token relay, and Kubernetes user impersonation
+- **RBAC**: Scope-aware authorization (global, project, agent, session, credential) with role bindings and permission matrix
+- **Sandbox Isolation**: OpenShell-based defense-in-depth (network namespace, TLS proxy, Landlock, seccomp-BPF, OPA policy) for runner pods
 - **CLI and SDK**: `acpctl` CLI and generated SDKs (Go, Python, TypeScript) for automation
+- **MCP Integration**: Model Context Protocol server exposing platform resources as tools, deployed as sidecar or public endpoint
 
 ## Quick Start
 
@@ -50,36 +56,70 @@ See [OpenShell Sandbox Provisioning Spec](specs/platform/openshell-sandbox-provi
 
 ## Architecture
 
-| Component | Technology | Description |
-|-----------|------------|-------------|
-| **API Server** (`ambient-api-server`) | Go + rh-trex-ai | REST + gRPC API, PostgreSQL-backed. Source of truth. |
-| **Control Plane** (`ambient-control-plane`) | Go | Watches API server via gRPC streams, creates K8s pods |
-| **UI** (`ambient-ui`) | NextJS + Shadcn | Web interface for managing sessions and agents |
-| **Runner** (`ambient-runner`) | Python | Executes AI agents inside pods (Claude, Gemini, LangGraph bridges) |
-| **MCP Server** (`ambient-mcp`) | Go | MCP tool definitions, deployed as credential sidecars |
-
 ```
 User Creates Session → API Server Persists to DB → Control Plane Creates Pod →
 Runner Executes AI Agent → Results Stream to API Server → UI Displays Progress
 ```
 
+### Components
+
+| Component | Technology | Description |
+|-----------|------------|-------------|
+| **API Server** (`ambient-api-server`) | Go + rh-trex-ai | REST + gRPC API, PostgreSQL-backed. Source of truth for all platform state. |
+| **Control Plane** (`ambient-control-plane`) | Go | Watches API server via gRPC streams, reconciles sessions into K8s Jobs, manages gateway provisioning |
+| **UI** (`ambient-ui`) | NextJS + Shadcn | BFF-pattern web application with OIDC authentication for session management and agent authoring |
+| **Runner** (`ambient-runner`) | Python + FastAPI | Executes AI agents inside pods; bridges AG-UI protocol to gRPC message store |
+| **MCP Server** (`ambient-mcp`) | Go | MCP tool definitions for platform resources, deployed as credential sidecar or public API endpoint |
+| **CLI** (`ambient-cli`) | Go | `acpctl` command-line tool with declarative `apply -f/-k` for fleet management |
+| **SDK** (`ambient-sdk`) | Go, Python, TypeScript | Generated from the OpenAPI spec |
+| **Credential Sidecars** | Per-provider containers | Isolated credential containers for GitHub, GitLab, Jira, Google, Kubernetes |
+| **Manifests** | Kustomize | Deployment manifests with base and overlay structure |
+
+### Data Model
+
+The core domain model stored in PostgreSQL:
+
+- **Project** — workspace grouping agents with shared context prompt
+- **Agent** — project-scoped, mutable definition with configurable prompt, LLM model, repo, and sandbox settings
+- **Session** — ephemeral Kubernetes execution run, created via agent start (one active per agent)
+- **SessionMessage** — human-readable conversation summary (Messages API)
+- **SessionEvent** — comprehensive AG-UI event stream with compression (Events API)
+- **Inbox** — persistent message queue on agents, surviving across sessions
+- **Credential** — global encrypted secret store for external provider tokens (GitHub, GitLab, Jira, Google, Vertex AI, Kubeconfig)
+- **RoleBinding** — scope-aware RBAC binding (global, project, agent, session, credential)
+- **ScheduledSession** — project-scoped cron trigger for recurring agent runs
+- **Application** — GitOps binding that syncs agent fleet definitions from git (Argo CD pattern)
+
+See [Data Model Spec](specs/platform/data-model.spec.md) for the full entity relationship diagram and field reference.
+
+### Runner Bridges
+
+The runner uses a bridge abstraction (`PlatformBridge` ABC) to support multiple AI backends:
+
+| Bridge | Status | Description |
+|--------|--------|-------------|
+| `ClaudeBridge` | Production | Claude Code CLI via Claude Agent SDK subprocess |
+| `GeminiCLIBridge` | Implemented | Gemini CLI bridge |
+| `LangGraphBridge` | Stub | LangGraph bridge |
+
+### Security
+
+- **Identity Boundaries**: Six identity types — control plane SA, per-session SAs, user SSO tokens, global credentials, project-scoped build agents, pipeline SAs
+- **SSO Authentication**: OIDC with Keycloak/Red Hat SSO, JWT validation, BFF token relay
+- **RBAC Enforcement**: Scope-aware authorization on all API endpoints (HTTP and gRPC)
+- **Credential Encryption**: AES-256-GCM at rest for all credential tokens in PostgreSQL
+- **Credential Isolation**: Integration credentials confined to sidecar containers; runner never holds external provider tokens
+- **Sandbox Isolation**: Five defense-in-depth layers via OpenShell Supervisor (network namespace, TLS proxy, Landlock LSM, seccomp-BPF, OPA policy)
+
+See [Security Spec](specs/security/) for full details.
+
 ## Documentation
 
-- **[Documentation site](https://openshift-online.github.io/agent-control-plane/)** - user-facing docs (Astro Starlight)
-- **[docs/internal/](docs/internal/)** - developer and architecture docs
-- **[CLAUDE.md](CLAUDE.md)** - development standards and conventions
-- **[BOOKMARKS.md](BOOKMARKS.md)** - developer reference index
-
-## Components
-
-- [API Server](components/ambient-api-server/) - REST + gRPC API (rh-trex-ai, PostgreSQL)
-- [Control Plane](components/ambient-control-plane/) - gRPC-driven session reconciler
-- [UI](components/ambient-ui/) - NextJS web application
-- [Runner](components/runners/ambient-runner/) - AI agent execution
-- [MCP Server](components/ambient-mcp/) - MCP tool integration
-- [CLI](components/ambient-cli/) - `acpctl` command-line tool
-- [SDK](components/ambient-sdk/) - generated from the OpenAPI spec (Go, Python, TypeScript)
-- [Manifests](components/manifests/) - Kustomize deployment resources
+- **[Documentation site](https://openshift-online.github.io/agent-control-plane/)** — user-facing docs (Astro Starlight)
+- **[docs/internal/](docs/internal/)** — developer and architecture docs
+- **[CLAUDE.md](CLAUDE.md)** — development standards and conventions
+- **[BOOKMARKS.md](BOOKMARKS.md)** — developer reference index
+- **[specs/](specs/)** — desired state specifications (platform, security, UI, standards)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Expanded Key Capabilities from 5 to 11 items to cover scheduled sessions, GitOps Applications, AG-UI event streaming, RBAC, SSO/OIDC, sandbox isolation, and MCP integration
- Restructured Architecture section with subsections for Components (expanded from 5 to 9), Data Model (10 core entities), Runner Bridges (3 implementations), and Security (6 layers)
- Updated credential provider list to include all supported providers (GitHub, GitLab, Jira, Google, Vertex AI, Kubeconfig)
- Added links to specs directory in Documentation section

## Test plan

- [ ] Verify all internal links resolve (specs/, CONTRIBUTING.md, BOOKMARKS.md, LICENSE)
- [ ] Confirm README content matches specs in `specs/platform/data-model.spec.md`, `specs/security/index.spec.md`, and `specs/platform/runner.spec.md`
- [ ] Review rendered markdown on GitHub for formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)