### PR TITLE
fix: deliver initial prompt via file upload and increase sandbox timeout

### DIFF
--- a/components/ambient-api-server/plugins/sessions/grpc_handler.go
+++ b/components/ambient-api-server/plugins/sessions/grpc_handler.go
@@ -308,10 +308,6 @@ func (h *sessionGRPCHandler) PushSessionMessage(ctx context.Context, req *pb.Pus
 	if req.GetEventType() == "" {
 		return nil, status.Error(codes.InvalidArgument, "event_type is required")
 	}
-	if middleware.IsServiceCaller(ctx) && req.GetEventType() == "user" {
-		return nil, status.Error(codes.PermissionDenied, "service token may not push event_type=user")
-	}
-
 	if !middleware.IsServiceCaller(ctx) {
 		session, svcErr := h.service.Get(ctx, req.GetSessionId())
 		if svcErr != nil {

--- a/components/ambient-api-server/plugins/sessions/grpc_handler.go
+++ b/components/ambient-api-server/plugins/sessions/grpc_handler.go
@@ -308,6 +308,9 @@ func (h *sessionGRPCHandler) PushSessionMessage(ctx context.Context, req *pb.Pus
 	if req.GetEventType() == "" {
 		return nil, status.Error(codes.InvalidArgument, "event_type is required")
 	}
+	// Service callers (runner, control plane) are trusted components authenticated
+	// via SA tokens scoped to the session namespace. They need to push event_type=user
+	// for the initial prompt so it appears in the UI chat history.
 	if !middleware.IsServiceCaller(ctx) {
 		session, svcErr := h.service.Get(ctx, req.GetSessionId())
 		if svcErr != nil {

--- a/components/ambient-control-plane/cmd/ambient-control-plane/main.go
+++ b/components/ambient-control-plane/cmd/ambient-control-plane/main.go
@@ -171,7 +171,8 @@ func runKubeMode(ctx context.Context, cfg *config.ControlPlaneConfig) error {
 		OpenShellPolicyName:      cfg.OpenShellPolicyName,
 		ServiceIdentity:          cfg.ServiceIdentity,
 		CACertFile:               cfg.CACertFile,
-		AllowedSandboxRegistries: cfg.AllowedSandboxRegistries,
+		AllowedSandboxRegistries:       cfg.AllowedSandboxRegistries,
+		SandboxReadinessTimeoutSeconds: cfg.SandboxReadinessTimeoutSeconds,
 	}
 
 	conn, err := grpc.NewClient(cfg.GRPCServerAddr, grpc.WithTransportCredentials(grpcCredentials(cfg.GRPCUseTLS)))

--- a/components/ambient-control-plane/internal/config/config.go
+++ b/components/ambient-control-plane/internal/config/config.go
@@ -60,6 +60,7 @@ type ControlPlaneConfig struct {
 	ServiceIdentity                 string
 	CACertFile                      string
 	AllowedSandboxRegistries        []string
+	SandboxReadinessTimeoutSeconds  int
 }
 
 func Load() (*ControlPlaneConfig, error) {
@@ -116,6 +117,7 @@ func Load() (*ControlPlaneConfig, error) {
 		ServiceIdentity:                 strings.TrimSpace(os.Getenv("GRPC_SERVICE_ACCOUNT")),
 		CACertFile:                      envOrDefault("CA_CERT_FILE", "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"),
 		AllowedSandboxRegistries:        parseAllowedRegistries(os.Getenv("ALLOWED_SANDBOX_REGISTRIES")),
+		SandboxReadinessTimeoutSeconds:  envOrDefaultInt("SANDBOX_READINESS_TIMEOUT_SECONDS", 600),
 	}
 
 	if cfg.MCPAPIServerURL == "" {

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -533,7 +533,7 @@ func (r *SimpleKubeReconciler) mergeAgentEnvironment(env map[string]string, agen
 }
 
 func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID string, entrypoint []string, sdk *sdkclient.Client, execEnv map[string]string, payloads []types.Payload) {
-	pollCtx, pollCancel := context.WithTimeout(context.Background(), 120*time.Second)
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 600*time.Second)
 	defer pollCancel()
 
 	failSession := func(reason string) {
@@ -561,7 +561,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				Str("sandbox", sbxName).
 				Str("session_id", sessionID).
 				Msg("timed out waiting for sandbox to become ready")
-			failSession("sandbox did not become ready within 120s")
+			failSession("sandbox did not become ready within 600s")
 			return
 		case <-ticker.C:
 			resp, err := r.gateway.GetSandbox(pollCtx, namespace, sbxName)

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -348,12 +348,14 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 			r.logger.Warn().Err(err).Str("sandbox", sbxName).Msg("failed to patch sandbox dnsConfig; DNS resolution for external FQDNs may fail")
 		}
 		execEnv := r.inferenceExecEnv()
-		execEntrypoint := r.appendPromptToEntrypoint(ctx, entrypoint, session, sdk)
 		var payloads []types.Payload
 		if agent != nil {
 			payloads = agent.Payloads
 		}
-		go r.execAfterReady(namespace, sbxName, session.ID, execEntrypoint, sdk, execEnv, payloads)
+		if prompt := r.assembleInitialPrompt(ctx, session, sdk); prompt != "" {
+			payloads = append(payloads, types.Payload{SandboxPath: "/tmp/initial_prompt.txt", Content: prompt})
+		}
+		go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads)
 		r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
 		return nil
 	}
@@ -409,12 +411,14 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 		Msg("sandbox created via gateway")
 
 	execEnv := r.inferenceExecEnv()
-	execEntrypoint := r.appendPromptToEntrypoint(ctx, entrypoint, session, sdk)
 	var payloads []types.Payload
 	if agent != nil {
 		payloads = agent.Payloads
 	}
-	go r.execAfterReady(namespace, sbxName, session.ID, execEntrypoint, sdk, execEnv, payloads)
+	if prompt := r.assembleInitialPrompt(ctx, session, sdk); prompt != "" {
+		payloads = append(payloads, types.Payload{SandboxPath: "/tmp/initial_prompt.txt", Content: prompt})
+	}
+	go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads)
 
 	r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
 	return nil
@@ -1013,9 +1017,6 @@ func (r *SimpleKubeReconciler) buildSandboxEnv(ctx context.Context, session type
 		env["GCE_METADATA_TIMEOUT"] = "1"
 	}
 
-	if prompt := r.assembleInitialPrompt(ctx, session, sdk); prompt != "" {
-		env["INITIAL_PROMPT"] = prompt
-	}
 	if session.LlmModel != "" {
 		env["LLM_MODEL"] = session.LlmModel
 	}

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -42,8 +42,9 @@ func validateTSLValue(value string) error {
 }
 
 const (
-	mcpSidecarPort = int64(8090)
-	mcpSidecarURL  = "http://localhost:8090"
+	mcpSidecarPort   = int64(8090)
+	mcpSidecarURL    = "http://localhost:8090"
+	initialPromptPath = "/tmp/initial_prompt.txt"
 )
 
 type credentialSidecarSpec struct {
@@ -104,7 +105,8 @@ type KubeReconcilerConfig struct {
 	OpenShellPolicyName      string
 	ServiceIdentity          string
 	CACertFile               string
-	AllowedSandboxRegistries []string
+	AllowedSandboxRegistries       []string
+	SandboxReadinessTimeoutSeconds int
 }
 
 type SimpleKubeReconciler struct {
@@ -352,9 +354,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 		if agent != nil {
 			payloads = agent.Payloads
 		}
-		if prompt := r.assembleInitialPrompt(ctx, session, sdk); prompt != "" {
-			payloads = append(payloads, types.Payload{SandboxPath: "/tmp/initial_prompt.txt", Content: prompt})
-		}
+		payloads = r.appendInitialPromptPayload(ctx, session, sdk, payloads)
 		go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads)
 		r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
 		return nil
@@ -415,9 +415,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	if agent != nil {
 		payloads = agent.Payloads
 	}
-	if prompt := r.assembleInitialPrompt(ctx, session, sdk); prompt != "" {
-		payloads = append(payloads, types.Payload{SandboxPath: "/tmp/initial_prompt.txt", Content: prompt})
-	}
+	payloads = r.appendInitialPromptPayload(ctx, session, sdk, payloads)
 	go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads)
 
 	r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
@@ -532,8 +530,23 @@ func (r *SimpleKubeReconciler) mergeAgentEnvironment(env map[string]string, agen
 	}
 }
 
+func (r *SimpleKubeReconciler) appendInitialPromptPayload(ctx context.Context, session types.Session, sdk *sdkclient.Client, payloads []types.Payload) []types.Payload {
+	if prompt := r.assembleInitialPrompt(ctx, session, sdk); prompt != "" {
+		return append(payloads, types.Payload{SandboxPath: initialPromptPath, Content: prompt})
+	}
+	return payloads
+}
+
+func (r *SimpleKubeReconciler) sandboxReadinessTimeout() time.Duration {
+	if r.cfg.SandboxReadinessTimeoutSeconds > 0 {
+		return time.Duration(r.cfg.SandboxReadinessTimeoutSeconds) * time.Second
+	}
+	return 600 * time.Second
+}
+
 func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID string, entrypoint []string, sdk *sdkclient.Client, execEnv map[string]string, payloads []types.Payload) {
-	pollCtx, pollCancel := context.WithTimeout(context.Background(), 600*time.Second)
+	timeout := r.sandboxReadinessTimeout()
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), timeout)
 	defer pollCancel()
 
 	failSession := func(reason string) {
@@ -553,6 +566,8 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
+	pollStart := time.Now()
+	lastProgressLog := pollStart
 
 	for {
 		select {
@@ -560,10 +575,19 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 			r.logger.Error().
 				Str("sandbox", sbxName).
 				Str("session_id", sessionID).
+				Dur("elapsed", time.Since(pollStart)).
 				Msg("timed out waiting for sandbox to become ready")
-			failSession("sandbox did not become ready within 600s")
+			failSession(fmt.Sprintf("sandbox did not become ready within %ds", int(timeout.Seconds())))
 			return
 		case <-ticker.C:
+			if time.Since(lastProgressLog) >= 30*time.Second {
+				r.logger.Info().
+					Str("sandbox", sbxName).
+					Str("session_id", sessionID).
+					Dur("elapsed", time.Since(pollStart)).
+					Msg("still waiting for sandbox readiness")
+				lastProgressLog = time.Now()
+			}
 			resp, err := r.gateway.GetSandbox(pollCtx, namespace, sbxName)
 			if err != nil {
 				r.logger.Debug().Err(err).Str("sandbox", sbxName).Msg("polling sandbox status")

--- a/components/runners/ambient-runner/ambient_runner/app.py
+++ b/components/runners/ambient-runner/ambient_runner/app.py
@@ -422,33 +422,15 @@ async def _push_initial_prompt_via_grpc(prompt: str, session_id: str) -> None:
     The gRPC push is synchronous (blocking I/O) and is offloaded to a thread
     pool so it does not block the asyncio event loop.
     """
-    import json as _json
-
     from ambient_runner._grpc_client import AmbientGRPCClient
 
     def _do_push() -> None:
         client = AmbientGRPCClient.from_env()
         try:
-            payload = {
-                "threadId": session_id,
-                "runId": str(uuid.uuid4()),
-                "messages": [
-                    {
-                        "id": str(uuid.uuid4()),
-                        "role": "user",
-                        "content": prompt,
-                        "metadata": {
-                            "hidden": True,
-                            "autoSent": True,
-                            "source": "runner_initial_prompt",
-                        },
-                    }
-                ],
-            }
             result = client.session_messages.push(
                 session_id,
                 event_type="user",
-                payload=_json.dumps(payload),
+                payload=prompt,
             )
             if result is not None:
                 logger.info(

--- a/components/runners/ambient-runner/ambient_runner/app.py
+++ b/components/runners/ambient-runner/ambient_runner/app.py
@@ -49,6 +49,8 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+_INITIAL_PROMPT_FILE = "/tmp/initial_prompt.txt"
+
 
 def _log_auto_exec_failure(task: asyncio.Task) -> None:
     """Callback for the auto-execution task — logs unhandled exceptions."""
@@ -161,7 +163,7 @@ def create_ambient_app(
         if not is_resume:
             # Fetch workflow startupPrompt independently
             workflow_startup_prompt = _get_workflow_startup_prompt()
-            user_initial_prompt = _read_initial_prompt_file("/tmp/initial_prompt.txt")
+            user_initial_prompt = _read_initial_prompt_file(_INITIAL_PROMPT_FILE)
             if not user_initial_prompt:
                 user_initial_prompt = os.getenv("INITIAL_PROMPT", "").strip()
 
@@ -198,7 +200,7 @@ def create_ambient_app(
         else:
             has_workflow = bool(os.getenv("ACTIVE_WORKFLOW_GIT_URL", "").strip())
             has_user_prompt = bool(
-                _read_initial_prompt_file("/tmp/initial_prompt.txt")
+                _read_initial_prompt_file(_INITIAL_PROMPT_FILE)
                 or os.getenv("INITIAL_PROMPT", "").strip()
             )
             if has_workflow or has_user_prompt:
@@ -394,6 +396,9 @@ def _read_initial_prompt_file(path: str) -> str:
         with open(path, "r") as f:
             return f.read().strip()
     except FileNotFoundError:
+        return ""
+    except OSError:
+        logger.warning("Failed to read initial prompt file %s, falling back to env var", path, exc_info=True)
         return ""
 
 

--- a/components/runners/ambient-runner/ambient_runner/app.py
+++ b/components/runners/ambient-runner/ambient_runner/app.py
@@ -161,7 +161,9 @@ def create_ambient_app(
         if not is_resume:
             # Fetch workflow startupPrompt independently
             workflow_startup_prompt = _get_workflow_startup_prompt()
-            user_initial_prompt = os.getenv("INITIAL_PROMPT", "").strip()
+            user_initial_prompt = _read_initial_prompt_file("/tmp/initial_prompt.txt")
+            if not user_initial_prompt:
+                user_initial_prompt = os.getenv("INITIAL_PROMPT", "").strip()
 
             # Combine prompts: workflow first, then user initial prompt
             combined_prompt = ""
@@ -194,9 +196,11 @@ def create_ambient_app(
                 )
                 task.add_done_callback(_log_auto_exec_failure)
         else:
-            # Log but don't execute on resume (avoid filesystem I/O, just check env vars)
             has_workflow = bool(os.getenv("ACTIVE_WORKFLOW_GIT_URL", "").strip())
-            has_user_prompt = bool(os.getenv("INITIAL_PROMPT", "").strip())
+            has_user_prompt = bool(
+                _read_initial_prompt_file("/tmp/initial_prompt.txt")
+                or os.getenv("INITIAL_PROMPT", "").strip()
+            )
             if has_workflow or has_user_prompt:
                 logger.info("Prompts detected but not auto-executing (resumed session)")
 
@@ -385,6 +389,14 @@ def _get_workflow_startup_prompt() -> str:
 # ------------------------------------------------------------------
 
 
+def _read_initial_prompt_file(path: str) -> str:
+    try:
+        with open(path, "r") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return ""
+
+
 _AUTO_PROMPT_MAX_RETRIES = 8
 _AUTO_PROMPT_INITIAL_DELAY = 2.0
 _AUTO_PROMPT_MAX_DELAY = 30.0
@@ -393,30 +405,13 @@ _AUTO_PROMPT_MAX_DELAY = 30.0
 async def _auto_execute_initial_prompt(
     prompt: str, session_id: str, grpc_url: str = ""
 ) -> None:
-    """Auto-execute INITIAL_PROMPT on session startup.
-
-    When AMBIENT_GRPC_URL is set, pushes the initial prompt as a DB Message
-    via PushSessionMessage so the GRPCSessionListener picks it up and triggers
-    the run directly. The prompt is then observable to API consumers and
-    visible in the frontend session history.
-
-    When AMBIENT_GRPC_URL is not set, falls back to the original HTTP POST
-    path with exponential-backoff retry (for DNS propagation races).
-    """
+    """Push the initial prompt as a user message and trigger the run."""
     delay_seconds = float(os.getenv("INITIAL_PROMPT_DELAY_SECONDS", "2"))
     logger.info(f"Waiting {delay_seconds}s before auto-executing INITIAL_PROMPT...")
     await asyncio.sleep(delay_seconds)
 
     if grpc_url:
-        # gRPC mode: the initial prompt was already stored in the DB when the session
-        # was created via the HTTP API (acpctl create session). The GRPCSessionListener's
-        # WatchSessionMessages stream will deliver it to the runner automatically.
-        # Pushing here would use the SA token which cannot push event_type=user,
-        # causing a harmless but noisy PERMISSION_DENIED warning. Skip it.
-        logger.debug(
-            "gRPC mode: skipping INITIAL_PROMPT push — message already in DB via session creation: session=%s",
-            session_id,
-        )
+        await _push_initial_prompt_via_grpc(prompt, session_id)
     else:
         await _push_initial_prompt_via_http(prompt, session_id)
 

--- a/components/runners/ambient-runner/architecture.md
+++ b/components/runners/ambient-runner/architecture.md
@@ -55,10 +55,10 @@ There are two delivery modes. The **HTTP path** is the original design: the back
    - Builds `RunnerContext` from `SESSION_ID` / `WORKSPACE_PATH` env vars
    - Calls `bridge.set_context(context)`
    - If `AMBIENT_GRPC_ENABLED=true` and `AMBIENT_GRPC_URL` are set: calls `bridge.start_grpc_listener(url)` and awaits `listener.ready` (10s timeout) before proceeding — ensures the watch stream is open before the initial prompt fires
-   - If `IS_RESUME` is not set and a prompt exists: fires `_auto_execute_initial_prompt()` as a background `asyncio.Task`
+   - If `IS_RESUME` is not set: reads initial prompt from `/tmp/initial_prompt.txt` (gateway file upload) or `INITIAL_PROMPT` env var (operator Job fallback). If a prompt exists, fires `_auto_execute_initial_prompt()` as a background `asyncio.Task`
    - On shutdown: calls `bridge.shutdown()`
 3. **Auto-prompt** (`_auto_execute_initial_prompt`):
-   - **gRPC mode**: calls `_push_initial_prompt_via_grpc()` — pushes a `PushSessionMessage(event_type="user")` to the control plane; the listener picks it up and drives `bridge.run()` directly
+   - **gRPC mode**: calls `_push_initial_prompt_via_grpc()` — pushes a `PushSessionMessage(event_type="user")` to the API server; the listener picks it up and drives `bridge.run()` directly. The prompt is visible in the UI chat history.
    - **HTTP mode**: calls `_push_initial_prompt_via_http()` — POSTs to `BACKEND_API_URL/projects/{project}/agentic-sessions/{session}/agui/run` with exponential backoff (8 retries, 2s→30s) because K8s DNS may not propagate before the pod is ready
 
 ---

--- a/components/runners/ambient-runner/tests/test_app_initial_prompt.py
+++ b/components/runners/ambient-runner/tests/test_app_initial_prompt.py
@@ -1,6 +1,7 @@
 """Unit tests for app.py initial prompt dispatch functions.
 
 Coverage targets:
+- _read_initial_prompt_file: file exists, file missing
 - _push_initial_prompt_via_grpc: happy path, push raises (client still closed),
   None result, from_env error, offloaded to executor (non-blocking)
 - _push_initial_prompt_via_http: happy path, missing env vars bail, bot token,
@@ -22,7 +23,23 @@ from ambient_runner.app import (
     _auto_execute_initial_prompt,
     _push_initial_prompt_via_grpc,
     _push_initial_prompt_via_http,
+    _read_initial_prompt_file,
 )
+
+
+# ---------------------------------------------------------------------------
+# _read_initial_prompt_file
+# ---------------------------------------------------------------------------
+
+
+class TestReadInitialPromptFile:
+    def test_reads_existing_file(self, tmp_path):
+        f = tmp_path / "prompt.txt"
+        f.write_text("  hello world  \n")
+        assert _read_initial_prompt_file(str(f)) == "hello world"
+
+    def test_returns_empty_when_missing(self):
+        assert _read_initial_prompt_file("/nonexistent/path.txt") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -338,7 +355,7 @@ class TestPushInitialPromptViaHTTP:
 
 @pytest.mark.asyncio
 class TestAutoExecuteInitialPrompt:
-    async def test_skips_push_when_grpc_url_set(self):
+    async def test_pushes_via_grpc_when_grpc_url_set(self):
         with (
             patch(
                 "ambient_runner.app._push_initial_prompt_via_grpc",
@@ -354,7 +371,7 @@ class TestAutoExecuteInitialPrompt:
                 "hello", "sess-1", grpc_url="localhost:9000"
             )
 
-        mock_grpc.assert_not_awaited()
+        mock_grpc.assert_awaited_once_with("hello", "sess-1")
         mock_http.assert_not_awaited()
 
     async def test_routes_to_http_when_no_grpc_url(self):

--- a/components/runners/ambient-runner/tests/test_app_initial_prompt.py
+++ b/components/runners/ambient-runner/tests/test_app_initial_prompt.py
@@ -1,7 +1,7 @@
 """Unit tests for app.py initial prompt dispatch functions.
 
 Coverage targets:
-- _read_initial_prompt_file: file exists, file missing
+- _read_initial_prompt_file: file exists, file missing, file unreadable (OSError)
 - _push_initial_prompt_via_grpc: happy path, push raises (client still closed),
   None result, from_env error, offloaded to executor (non-blocking)
 - _push_initial_prompt_via_http: happy path, missing env vars bail, bot token,
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ambient_runner.app import (
+    _INITIAL_PROMPT_FILE,
     _auto_execute_initial_prompt,
     _push_initial_prompt_via_grpc,
     _push_initial_prompt_via_http,
@@ -39,6 +40,12 @@ class TestReadInitialPromptFile:
 
     def test_returns_empty_when_missing(self):
         assert _read_initial_prompt_file("/nonexistent/path.txt") == ""
+
+    def test_returns_empty_when_unreadable(self, tmp_path):
+        f = tmp_path / "prompt.txt"
+        f.write_text("hello")
+        f.chmod(0o000)
+        assert _read_initial_prompt_file(str(f)) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/components/runners/ambient-runner/tests/test_app_initial_prompt.py
+++ b/components/runners/ambient-runner/tests/test_app_initial_prompt.py
@@ -13,7 +13,6 @@ Coverage targets:
 """
 
 import asyncio
-import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -67,12 +66,7 @@ class TestPushInitialPromptViaGRPC:
         call = mock_client.session_messages.push.call_args
         assert call[0][0] == "sess-1"
         assert call[1]["event_type"] == "user"
-        payload = json.loads(call[1]["payload"])
-        assert payload["threadId"] == "sess-1"
-        assert "runId" in payload
-        assert len(payload["messages"]) == 1
-        assert payload["messages"][0]["role"] == "user"
-        assert payload["messages"][0]["content"] == "hello world"
+        assert call[1]["payload"] == "hello world"
 
     async def test_closes_client_after_push(self):
         mock_result = MagicMock()

--- a/specs/platform/agent-sandbox-config.spec.md
+++ b/specs/platform/agent-sandbox-config.spec.md
@@ -610,7 +610,8 @@ The control plane SHALL start the runner process inside the sandbox by calling t
 
 - GIVEN a sandbox was just created
 - WHEN the control plane polls `GetSandbox` for readiness
-- THEN it SHALL poll every 2 seconds with a 600-second timeout
+- THEN it SHALL poll every 2 seconds with a configurable timeout (default 600 seconds, set via `SANDBOX_READINESS_TIMEOUT_SECONDS` env var)
+- AND the control plane SHALL log a progress message every 30 seconds during polling, including sandbox name, session ID, and elapsed time
 - AND if the sandbox enters `SANDBOX_PHASE_ERROR`, the control plane SHALL log an error, stop polling, and transition the session to `Failed`
 - AND if the timeout expires before `SANDBOX_PHASE_READY`, the control plane SHALL log an error and transition the session to `Failed`
 

--- a/specs/platform/agent-sandbox-config.spec.md
+++ b/specs/platform/agent-sandbox-config.spec.md
@@ -610,7 +610,7 @@ The control plane SHALL start the runner process inside the sandbox by calling t
 
 - GIVEN a sandbox was just created
 - WHEN the control plane polls `GetSandbox` for readiness
-- THEN it SHALL poll every 2 seconds with a 120-second timeout
+- THEN it SHALL poll every 2 seconds with a 600-second timeout
 - AND if the sandbox enters `SANDBOX_PHASE_ERROR`, the control plane SHALL log an error, stop polling, and transition the session to `Failed`
 - AND if the timeout expires before `SANDBOX_PHASE_READY`, the control plane SHALL log an error and transition the session to `Failed`
 

--- a/specs/platform/control-plane.spec.md
+++ b/specs/platform/control-plane.spec.md
@@ -92,7 +92,7 @@ The CP binds the `system:image-builder` ClusterRole to `session-{id}-sa` via a n
 
 ### Start Context Assembly
 
-`assembleInitialPrompt` builds `INITIAL_PROMPT` from four sources in order:
+`assembleInitialPrompt` builds the initial prompt from four sources in order:
 
 ```
 1. Project.prompt        — workspace-level context (shared by all agents in this project)
@@ -101,7 +101,11 @@ The CP binds the `system:image-builder` ClusterRole to `session-{id}-sa` via a n
 4. Session.prompt        — what this specific run should do
 ```
 
-Each section is joined with `\n\n`. Empty sections are omitted. If all four are empty, `INITIAL_PROMPT` is not set and the runner waits for a user message via gRPC.
+Each section is joined with `\n\n`. Empty sections are omitted. If all four are empty, the prompt is not delivered and the runner waits for a user message via gRPC.
+
+**Delivery mechanism varies by runtime:**
+- **Gateway (OpenShell) sandboxes:** The assembled prompt is written to `/tmp/initial_prompt.txt` via SSH payload upload before the runner entrypoint executes. The `INITIAL_PROMPT` env var is NOT set — OpenShell strips env vars containing newlines, which the assembled prompt always contains.
+- **Operator (Job) pods:** The assembled prompt is set as the `INITIAL_PROMPT` env var on the Job container spec.
 
 ### Environment Variables Injected into Runner Pod
 
@@ -115,7 +119,7 @@ Each section is joined with `\n\n`. Empty sections are omitted. If all four are 
 | `AMBIENT_GRPC_URL` | CP config | api-server gRPC address |
 | `AMBIENT_GRPC_USE_TLS` | CP config | TLS flag for gRPC |
 | `AMBIENT_CP_TOKEN_URL` | CP config | CP token endpoint URL (e.g. `http://ambient-control-plane.{ns}.svc:8080/token`) |
-| `INITIAL_PROMPT` | assembled prompt | Auto-execute on startup |
+| `INITIAL_PROMPT` | assembled prompt | Auto-execute on startup (operator Job path only; gateway sandboxes receive the prompt via `/tmp/initial_prompt.txt` file upload) |
 | `IS_RESUME` | `"true"` | Set when `session.StartTime != nil` (session has been started before); tells the runner to skip `INITIAL_PROMPT` auto-execute |
 | `RESUME_AFTER_SEQ` | max `seq` from session_messages | Set alongside `IS_RESUME` when messages exist; runner's gRPC listener starts watching from this seq to prevent replay of historical messages |
 | `USE_VERTEX` / `ANTHROPIC_VERTEX_PROJECT_ID` / `CLOUD_ML_REGION` | CP config | Vertex AI config (when enabled) |
@@ -205,7 +209,10 @@ When `AMBIENT_GRPC_URL` is set (standard deployment):
        → listener.ready asyncio.Event set
 5. await bridge._grpc_listener.ready.wait()
    (blocks until WatchSessionMessages stream is confirmed open)
-6. If INITIAL_PROMPT set and not IS_RESUME:
+6. If not IS_RESUME, read initial prompt:
+     a. Try /tmp/initial_prompt.txt (gateway file upload)
+     b. Fall back to INITIAL_PROMPT env var (operator Job path)
+   If prompt found:
      _auto_execute_initial_prompt(prompt, session_id, grpc_url)
      → _push_initial_prompt_via_grpc()
        → PushSessionMessage(event_type="user", payload=prompt)

--- a/specs/platform/openshell-sandbox-provisioning.spec.md
+++ b/specs/platform/openshell-sandbox-provisioning.spec.md
@@ -337,7 +337,7 @@ The `ExecSandbox` RPC is a server-streaming call that returns stdout, stderr, an
 - THEN the control plane SHALL call `ExecSandbox` with the command `["/bin/bash", "-c", "cd /runner/ambient-runner && PATH=/sandbox/.venv/bin:$PATH uvicorn main:app --host 0.0.0.0 --port 8001"]`
 - AND the `SandboxId` SHALL be the gateway's internal UUID obtained from `GetSandbox` response metadata
 - AND the exec SHALL run asynchronously (fire-and-forget) — the control plane launches a goroutine that consumes the exec stream but does not block reconciliation
-- AND the exec goroutine SHALL use a separate context from the readiness-polling context — the polling context has a 600-second timeout suitable for provisioning, but the exec context must remain open for the lifetime of the uvicorn process (which runs until session completion)
+- AND the exec goroutine SHALL use a separate context from the readiness-polling context — the polling context has a configurable timeout (default 600s via `SANDBOX_READINESS_TIMEOUT_SECONDS`) suitable for provisioning, but the exec context must remain open for the lifetime of the uvicorn process (which runs until session completion)
 - AND the exec goroutine SHALL NOT accumulate stdout/stderr in memory — it SHALL discard or stream output to the logger to avoid unbounded memory growth for long-running processes
 
 #### Scenario: Gateway image runner path
@@ -353,7 +353,8 @@ The `ExecSandbox` RPC is a server-streaming call that returns stdout, stderr, an
 
 - GIVEN a sandbox was just created
 - WHEN the control plane polls `GetSandbox` for readiness
-- THEN it SHALL poll every 2 seconds with a 600-second timeout
+- THEN it SHALL poll every 2 seconds with a configurable timeout (default 600 seconds, set via `SANDBOX_READINESS_TIMEOUT_SECONDS` env var)
+- AND the control plane SHALL log a progress message every 30 seconds during polling, including sandbox name, session ID, and elapsed time
 - AND if the sandbox enters `SANDBOX_PHASE_ERROR`, the control plane SHALL log an error and stop polling
 - AND if the timeout expires before `SANDBOX_PHASE_READY`, the control plane SHALL log an error
 
@@ -809,6 +810,7 @@ The control plane SHALL expose configuration for OpenShell gateway mode alongsid
 | `OPENSHELL_GATEWAY_CLIENT_TLS_SECRET` | `openshell-client-tls` | Name of the Kubernetes TLS Secret (per project namespace) containing `tls.crt`, `tls.key`, and `ca.crt` for mTLS client authentication |
 | `OPENSHELL_GATEWAY_TLS_SERVER_NAME` | (empty — uses actual DNS name) | Override TLS ServerName for certificate verification; set when the gateway's server certificate SANs don't match the Service DNS name |
 | `OPENSHELL_RUNNER_IMAGE` | `quay.io/ambient_code/acp_runner_openshell:latest` | Container image used for gateway-mode sandboxes (built from `Dockerfile.openshell`); separate from `RUNNER_IMAGE` which is used for direct pod creation |
+| `SANDBOX_READINESS_TIMEOUT_SECONDS` | `600` | Maximum seconds to wait for a sandbox to reach `SANDBOX_PHASE_READY` before failing the session |
 
 #### Scenario: Mode interaction
 
@@ -842,7 +844,7 @@ The control plane SHALL expose configuration for OpenShell gateway mode alongsid
 | `provisionSessionGateway()` | Bypasses the provisioner for session provisioning — uses a direct `GetNamespace` check so no provisioner implementation can inadvertently create the namespace. Namespace labeling is handled separately during gateway initialization via `ensureProject` |
 | `cleanupSessionGateway()` | Does not call `DeprovisionNamespace` — namespace lifecycle is fully external in gateway mode |
 | [openshell-sandbox.spec.md] | Unchanged — file-mode spec remains authoritative when `OPENSHELL_USE_GATEWAY=false` |
-| Runner pod | Same image and env vars, but the runner process is started via `ExecSandbox` with `["/bin/bash", "-c", "cd /runner/ambient-runner && PATH=/sandbox/.venv/bin:$PATH uvicorn main:app --host 0.0.0.0 --port 8001"]` after the sandbox reaches Ready — the gateway overrides the container entrypoint to the supervisor binary with `sleep infinity`, so the image's CMD is never executed directly. The exec goroutine must use a long-lived context (not the 600s polling context) and must not accumulate stdout/stderr in memory |
+| Runner pod | Same image and env vars, but the runner process is started via `ExecSandbox` with `["/bin/bash", "-c", "cd /runner/ambient-runner && PATH=/sandbox/.venv/bin:$PATH uvicorn main:app --host 0.0.0.0 --port 8001"]` after the sandbox reaches Ready — the gateway overrides the container entrypoint to the supervisor binary with `sleep infinity`, so the image's CMD is never executed directly. The exec goroutine must use a long-lived context (not the configurable polling timeout context) and must not accumulate stdout/stderr in memory |
 | `GatewayClient.ExecSandbox()` | Current implementation blocks on the full stream and accumulates output — must be updated to support fire-and-forget semantics for long-running processes (discard/stream output, use caller-provided context) |
 | `GatewayClient.UpdateConfig()` | New method — calls the `UpdateConfig` gRPC RPC; used by `enableProvidersV2` to set `providers_v2_enabled=true` globally on the gateway |
 | `GatewayClient.SetClusterInference()` | New method — calls the `SetClusterInference` gRPC RPC on the `openshell.inference.v1.Inference` service; used by `configureInference` to set provider and model for inference routing |

--- a/specs/platform/openshell-sandbox-provisioning.spec.md
+++ b/specs/platform/openshell-sandbox-provisioning.spec.md
@@ -306,10 +306,11 @@ The control plane SHALL pass session configuration to the sandbox as environment
 
 #### Scenario: Environment variable translation
 
-- GIVEN a session with LLM model, prompt, repo URL, and proxy settings
+- GIVEN a session with LLM model, repo URL, and proxy settings
 - WHEN the sandbox is created
-- THEN all environment variables from `buildEnv()` that have literal string values SHALL be included
+- THEN all environment variables from `buildSandboxEnv()` that have literal string values SHALL be included
 - AND Kubernetes-specific `valueFrom` / `fieldRef` entries (e.g., `POD_IP`) SHALL be omitted
+- AND `INITIAL_PROMPT` SHALL NOT be included in the gateway environment — the assembled prompt contains newlines which OpenShell strips; the prompt is delivered via file upload instead (see [Payload Upload via SSH](#requirement-payload-upload-via-ssh))
 
 #### Scenario: Provider-injected environment variable protection
 
@@ -593,9 +594,17 @@ The control plane SHALL upload payload files into the sandbox filesystem via SSH
 - AND `sandbox_path` SHALL be validated: must be an absolute path, must not contain `..` traversal, must match `^/[a-zA-Z0-9/_.\-]+$`
 - AND invalid paths SHALL be rejected before the SSH command is executed
 
+#### Scenario: Initial prompt delivered as file payload
+
+- GIVEN a session with a non-empty assembled prompt (from project, agent, inbox, or session prompt)
+- WHEN the control plane prepares payloads for the sandbox
+- THEN it SHALL append a synthetic payload with `SandboxPath="/tmp/initial_prompt.txt"` and `Content=<assembled prompt>` to the payload list
+- AND this payload SHALL be uploaded via SSH alongside any agent-defined payloads before `ExecSandbox`
+- AND the runner SHALL read this file on startup and push it as a `PushSessionMessage(event_type="user")` via gRPC so the prompt is visible in the UI chat history
+
 #### Scenario: No payloads — upload skipped
 
-- GIVEN an agent with no inline content payloads (or no agent associated with the session)
+- GIVEN an agent with no inline content payloads (or no agent associated with the session) AND no initial prompt
 - WHEN the sandbox reaches `SANDBOX_PHASE_READY`
 - THEN the control plane SHALL skip the SSH upload step entirely
 - AND proceed directly to `ExecSandbox`

--- a/specs/platform/openshell-sandbox-provisioning.spec.md
+++ b/specs/platform/openshell-sandbox-provisioning.spec.md
@@ -337,7 +337,7 @@ The `ExecSandbox` RPC is a server-streaming call that returns stdout, stderr, an
 - THEN the control plane SHALL call `ExecSandbox` with the command `["/bin/bash", "-c", "cd /runner/ambient-runner && PATH=/sandbox/.venv/bin:$PATH uvicorn main:app --host 0.0.0.0 --port 8001"]`
 - AND the `SandboxId` SHALL be the gateway's internal UUID obtained from `GetSandbox` response metadata
 - AND the exec SHALL run asynchronously (fire-and-forget) — the control plane launches a goroutine that consumes the exec stream but does not block reconciliation
-- AND the exec goroutine SHALL use a separate context from the readiness-polling context — the polling context has a 120-second timeout suitable for provisioning, but the exec context must remain open for the lifetime of the uvicorn process (which runs until session completion)
+- AND the exec goroutine SHALL use a separate context from the readiness-polling context — the polling context has a 600-second timeout suitable for provisioning, but the exec context must remain open for the lifetime of the uvicorn process (which runs until session completion)
 - AND the exec goroutine SHALL NOT accumulate stdout/stderr in memory — it SHALL discard or stream output to the logger to avoid unbounded memory growth for long-running processes
 
 #### Scenario: Gateway image runner path
@@ -353,7 +353,7 @@ The `ExecSandbox` RPC is a server-streaming call that returns stdout, stderr, an
 
 - GIVEN a sandbox was just created
 - WHEN the control plane polls `GetSandbox` for readiness
-- THEN it SHALL poll every 2 seconds with a 120-second timeout
+- THEN it SHALL poll every 2 seconds with a 600-second timeout
 - AND if the sandbox enters `SANDBOX_PHASE_ERROR`, the control plane SHALL log an error and stop polling
 - AND if the timeout expires before `SANDBOX_PHASE_READY`, the control plane SHALL log an error
 
@@ -842,7 +842,7 @@ The control plane SHALL expose configuration for OpenShell gateway mode alongsid
 | `provisionSessionGateway()` | Bypasses the provisioner for session provisioning — uses a direct `GetNamespace` check so no provisioner implementation can inadvertently create the namespace. Namespace labeling is handled separately during gateway initialization via `ensureProject` |
 | `cleanupSessionGateway()` | Does not call `DeprovisionNamespace` — namespace lifecycle is fully external in gateway mode |
 | [openshell-sandbox.spec.md] | Unchanged — file-mode spec remains authoritative when `OPENSHELL_USE_GATEWAY=false` |
-| Runner pod | Same image and env vars, but the runner process is started via `ExecSandbox` with `["/bin/bash", "-c", "cd /runner/ambient-runner && PATH=/sandbox/.venv/bin:$PATH uvicorn main:app --host 0.0.0.0 --port 8001"]` after the sandbox reaches Ready — the gateway overrides the container entrypoint to the supervisor binary with `sleep infinity`, so the image's CMD is never executed directly. The exec goroutine must use a long-lived context (not the 120s polling context) and must not accumulate stdout/stderr in memory |
+| Runner pod | Same image and env vars, but the runner process is started via `ExecSandbox` with `["/bin/bash", "-c", "cd /runner/ambient-runner && PATH=/sandbox/.venv/bin:$PATH uvicorn main:app --host 0.0.0.0 --port 8001"]` after the sandbox reaches Ready — the gateway overrides the container entrypoint to the supervisor binary with `sleep infinity`, so the image's CMD is never executed directly. The exec goroutine must use a long-lived context (not the 600s polling context) and must not accumulate stdout/stderr in memory |
 | `GatewayClient.ExecSandbox()` | Current implementation blocks on the full stream and accumulates output — must be updated to support fire-and-forget semantics for long-running processes (discard/stream output, use caller-provided context) |
 | `GatewayClient.UpdateConfig()` | New method — calls the `UpdateConfig` gRPC RPC; used by `enableProvidersV2` to set `providers_v2_enabled=true` globally on the gateway |
 | `GatewayClient.SetClusterInference()` | New method — calls the `SetClusterInference` gRPC RPC on the `openshell.inference.v1.Inference` service; used by `configureInference` to set provider and model for inference routing |

--- a/specs/platform/runner.spec.md
+++ b/specs/platform/runner.spec.md
@@ -149,7 +149,7 @@ ambient_runner/
      d. Pre-register SSE queue for SESSION_ID (prevents race with backend)
 
 6. If not IS_RESUME, read initial prompt:
-     a. Try /tmp/initial_prompt.txt (gateway file upload path)
+     a. Try /tmp/initial_prompt.txt (gateway file upload path); on any OS-level read error (permissions, I/O), log a warning and fall back
      b. Fall back to INITIAL_PROMPT env var (operator Job path)
    If prompt found:
      _auto_execute_initial_prompt(prompt, session_id, grpc_url)

--- a/specs/platform/runner.spec.md
+++ b/specs/platform/runner.spec.md
@@ -148,7 +148,10 @@ ambient_runner/
      c. await listener.ready.wait()  ← blocks until stream confirmed open
      d. Pre-register SSE queue for SESSION_ID (prevents race with backend)
 
-6. If INITIAL_PROMPT set and not IS_RESUME:
+6. If not IS_RESUME, read initial prompt:
+     a. Try /tmp/initial_prompt.txt (gateway file upload path)
+     b. Fall back to INITIAL_PROMPT env var (operator Job path)
+   If prompt found:
      _auto_execute_initial_prompt(prompt, session_id, grpc_url)
        In gRPC mode: push via PushSessionMessage("user", prompt)
          → listener receives its own push → triggers bridge.run()


### PR DESCRIPTION
## Summary

- **Remove `IsServiceCaller` restriction** on `PushSessionMessage` `event_type=user` — allows the runner to push the initial prompt as a user message via gRPC
- **Control plane**: deliver assembled prompt as `/tmp/initial_prompt.txt` via SSH payload upload instead of `INITIAL_PROMPT` env var (gateway path only; operator Job path unchanged)
- **Runner**: read prompt from file (falling back to env var for operator compat), call `_push_initial_prompt_via_grpc` instead of skipping in gRPC mode
- **Increase sandbox readiness timeout** from 120s to 600s (10 minutes) to accommodate large image pulls that exceeded the previous timeout

OpenShell strips env vars containing newlines, which silently dropped `INITIAL_PROMPT`. The runner started idle with no prompt to execute and no messages appeared in the UI. Additionally, large sandbox images can take several minutes to pull, causing timeout failures before the sandbox is ready.

## Test plan

- [ ] `make kind-rebuild` to deploy all three components
- [ ] Create a session via the UI
- [ ] Confirm CP logs show payload upload for `/tmp/initial_prompt.txt`
- [ ] Confirm runner logs show `INITIAL_PROMPT pushed via gRPC`
- [ ] Verify UI chat tab shows both user prompt and assistant response
- [ ] Verify operator (non-gateway) Job path still works via `INITIAL_PROMPT` env var
- [ ] Verify sandbox with large image does not time out during image pull
- [ ] Runner tests pass: `cd components/runners/ambient-runner && python -m pytest tests/ -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)