### PR TITLE
chore(deps): upgrade rh-trex-ai v0.0.30 → v0.0.31

### DIFF
--- a/components/ambient-api-server/go.mod
+++ b/components/ambient-api-server/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/onsi/gomega v1.35.1
 	github.com/openshift-online/ocm-sdk-go v0.1.503
-	github.com/openshift-online/rh-trex-ai v0.0.30
+	github.com/openshift-online/rh-trex-ai v0.0.31
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/components/ambient-api-server/go.sum
+++ b/components/ambient-api-server/go.sum
@@ -277,8 +277,8 @@ github.com/openshift-online/ocm-api-model/model v0.0.459 h1:pGOc+kGrEfDxOPw6PXZO
 github.com/openshift-online/ocm-api-model/model v0.0.459/go.mod h1:PQIoq6P8Vlb7goOdRMLK8nJY+B7HH0RTqYAa4kyidTE=
 github.com/openshift-online/ocm-sdk-go v0.1.503 h1:QN0PUvucEGHLXwjiMEI7nuoa2H6N/SUiA4aRYh6sZ2M=
 github.com/openshift-online/ocm-sdk-go v0.1.503/go.mod h1:SM9x+/m+JAigXnGzb/dY+tMbbgx5f5Oq9Nj5Grg1LVk=
-github.com/openshift-online/rh-trex-ai v0.0.30 h1:fgd/5XozbOb7wtkXzMQcOrO7TL1bbluLzP1GrASZCWY=
-github.com/openshift-online/rh-trex-ai v0.0.30/go.mod h1:5NVw/etu4mOCO1N8A8656vE6yvt0N2tjO1yT6gjHblc=
+github.com/openshift-online/rh-trex-ai v0.0.31 h1:umke089LGgtydxUDeebyiGRMZuLt7I0Vw8DjMPmk1ns=
+github.com/openshift-online/rh-trex-ai v0.0.31/go.mod h1:5NVw/etu4mOCO1N8A8656vE6yvt0N2tjO1yT6gjHblc=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/skills/RECONCILE.md
+++ b/skills/RECONCILE.md
@@ -40,7 +40,8 @@ skills/
 │   └── pr-test/           # Deploy PR images to OpenShift for integration testing
 └── tooling/
     ├── align/             # Convention compliance scoring
-    └── memory/            # Project memory management
+    ├── memory/            # Project memory management
+    └── upgrade-upstream/  # rh-trex-ai framework dependency upgrades
 ```
 
 **SDLC flow**: `/reconcile` → `/spec` → `/full-stack-pipeline` → `/dev-cluster` → `/pr-test` → `/deploy-cluster`

--- a/skills/tooling/upgrade-upstream/SKILL.md
+++ b/skills/tooling/upgrade-upstream/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: upgrade-upstream
+description: >
+  Upgrade the rh-trex-ai upstream framework dependency in ambient-api-server.
+  Handles version bump, compilation verification, breaking change detection,
+  test execution, and go.sum cleanup. Use when: "upgrade rh-trex-ai",
+  "bump upstream", "update trex", "new upstream version", "upgrade framework",
+  "pull in upstream changes", "update rh-trex-ai to latest".
+---
+
+# Upgrade Upstream (rh-trex-ai)
+
+Upgrade the `github.com/openshift-online/rh-trex-ai` framework dependency
+used by `components/ambient-api-server/`.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Parse `$ARGUMENTS` for:
+- A target version (e.g. `v0.0.31`, `latest`, a commit SHA, or a branch name)
+- `--dry-run` flag: analyze only, do not modify files
+- If empty, default to `latest` (the newest tagged release)
+
+## Scope
+
+`rh-trex-ai` is consumed exclusively by `ambient-api-server`. No other
+component (control-plane, CLI, SDK, MCP, runners, credential-sidecars)
+depends on it. The upgrade is confined to:
+
+```
+components/ambient-api-server/
+  go.mod     # version pin
+  go.sum     # checksums
+  **/*.go    # ~160 files across 20 import paths
+```
+
+## Upstream Import Surface
+
+The API server imports 20 packages from `rh-trex-ai` across four groups:
+
+ < /dev/null |  Group | Packages |
+|-------|----------|
+| Core API & data | `pkg/api`, `pkg/api/presenters`, `pkg/db`, `pkg/db/db_session`, `pkg/errors` |
+| Server infra | `pkg/server`, `pkg/server/grpcutil`, `pkg/handlers`, `pkg/config`, `pkg/environments`, `pkg/auth`, `pkg/controllers`, `pkg/registry` |
+| Utilities | `pkg/logger`, `pkg/util`, `pkg/services`, `pkg/testutil` |
+| Plugins | `plugins/events`, `plugins/generic` |
+
+Breaking changes in any of these packages require code fixes in this repo.
+
+## Workflow
+
+### Phase 1 -- Resolve Target Version
+
+Record the current version, then resolve the target.
+
+```bash
+cd components/ambient-api-server
+grep 'rh-trex-ai' go.mod
+```
+
+For `latest` or empty args, query the newest tag:
+```bash
+go list -m -versions github.com/openshift-online/rh-trex-ai | tr ' ' '\n' | tail -1
+```
+
+For a commit SHA or branch, resolve to a pseudo-version:
+```bash
+GOPROXY=direct go list -m github.com/openshift-online/rh-trex-ai@<ref>
+```
+
+If current == target, report "already at target version" and stop.
+If `--dry-run`, proceed through Phase 2 only, then stop.
+
+### Phase 2 -- Analyze Upstream Changes
+
+Fetch the upstream commit log between versions to anticipate breakage:
+
+```bash
+gh api repos/openshift-online/rh-trex-ai/compare/<current>...<target> \
+  --jq '.commits[] | "\(.sha[0:8]) \(.commit.message | split("\n")[0])"'
+```
+
+Look for renamed/removed exports, changed function signatures, moved
+packages, new required config fields, or changed migration helpers.
+
+Produce a change summary with commit count, risk level (low/medium/high),
+affected upstream packages, and potential breakage notes.
+
+### Phase 3 -- Bump the Version
+
+```bash
+cd components/ambient-api-server
+go get github.com/openshift-online/rh-trex-ai@<target>
+go mod tidy
+grep 'rh-trex-ai' go.mod   # verify
+```
+
+### Phase 4 -- Verify Compilation
+
+```bash
+cd components/ambient-api-server && go build ./...
+```
+
+If compilation fails, read each error and fix it. Common patterns:
+
+- **Removed/renamed type**: find the new name upstream, update imports
+- **Changed signature**: adapt callers to the new signature
+- **New required interface method**: implement it on conforming types
+- **Moved package**: update import paths
+
+Rebuild until clean. Do not suppress errors with `//nolint` or unsafe casts.
+
+### Phase 5 -- Lint
+
+```bash
+cd components/ambient-api-server
+go vet ./...
+golangci-lint run
+```
+
+Fix any new lint issues introduced by the upgrade.
+
+### Phase 6 -- Run Tests
+
+```bash
+cd components/ambient-api-server && make test
+```
+
+Distinguish **upstream behavioral changes** (adapt the code) from
+**pre-existing failures** (note but do not block the upgrade).
+
+### Phase 7 -- Cross-Component Spot Check
+
+The API server's behavior affects all consumers. Quick checks:
+
+- **gRPC**: if `pkg/server/grpcutil` changed, verify the interceptor chain
+  still works (the control plane connects via gRPC)
+- **OpenAPI**: if `pkg/api/presenters` or `pkg/handlers` changed, run
+  `make generate` and verify no drift
+- **Migrations**: if `pkg/db` changed, verify `make run` still migrates
+
+### Phase 8 -- Report
+
+```
+UPGRADE COMPLETE: v0.0.30 -> v0.0.31
+-------------------------------------
+Files modified:     go.mod, go.sum [, any .go fixes]
+Compilation:        PASS
+Lint:               PASS
+Tests:              PASS (N passed, M skipped)
+Breaking changes:   none | <list>
+```
+
+## Rollback
+
+If the upgrade cannot be completed, restore the previous version:
+
+```bash
+cd components/ambient-api-server
+go get github.com/openshift-online/rh-trex-ai@<previous>
+go mod tidy && go build ./...
+```
+
+Never leave `go.mod` in a half-upgraded state.
+
+## Local Development Shortcut
+
+For testing against an unreleased upstream branch:
+
+```bash
+cd components/ambient-api-server
+go mod edit -replace github.com/openshift-online/rh-trex-ai=../../../openshift-online/rh-trex-ai
+go mod tidy
+```
+
+**Never commit the replace directive.** Remove before PR:
+
+```bash
+go mod edit -dropreplace github.com/openshift-online/rh-trex-ai
+go mod tidy
+```
+
+## Constraints
+
+- Only `components/ambient-api-server/` is affected
+- Never commit a `replace` directive for `rh-trex-ai`
+- Code changes must follow existing conventions (no `panic()`, proper `fmt.Errorf`)
+- `make test` and `golangci-lint run` must pass after upgrade
+- Prefer upstream replacements over local workarounds for removed functions

--- a/skills/tooling/upgrade-upstream/evals/evals.json
+++ b/skills/tooling/upgrade-upstream/evals/evals.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "upgrade-latest",
+    "prompt": "/upgrade-upstream",
+    "expected_behavior": "Resolves latest rh-trex-ai tag, compares with current version, bumps go.mod, runs go mod tidy, go build, go vet, golangci-lint run, and make test in ambient-api-server",
+    "passing_criteria": "go.mod updated to latest version, go build ./... succeeds, make test passes, lint clean"
+  },
+  {
+    "id": "upgrade-specific-version",
+    "prompt": "/upgrade-upstream v0.0.31",
+    "expected_behavior": "Bumps rh-trex-ai to v0.0.31, runs build and test cycle, reports results",
+    "passing_criteria": "go.mod shows v0.0.31, compilation succeeds, tests pass"
+  },
+  {
+    "id": "upgrade-commit-sha",
+    "prompt": "/upgrade-upstream abc1234",
+    "expected_behavior": "Resolves commit SHA to pseudo-version, bumps go.mod, runs verification",
+    "passing_criteria": "go.mod shows pseudo-version for the commit, compilation succeeds"
+  },
+  {
+    "id": "upgrade-dry-run",
+    "prompt": "/upgrade-upstream --dry-run",
+    "expected_behavior": "Analyzes upstream changes between current and latest without modifying any files, produces change summary with commit log and breaking risk assessment",
+    "passing_criteria": "No files modified, change summary displayed with commit count and risk level"
+  },
+  {
+    "id": "upgrade-already-current",
+    "prompt": "/upgrade-upstream v0.0.30",
+    "expected_behavior": "Detects current version equals target, reports already up to date, takes no action",
+    "passing_criteria": "Reports already at target version, no files modified"
+  },
+  {
+    "id": "upgrade-with-breaking-changes",
+    "prompt": "/upgrade-upstream v0.1.0",
+    "expected_behavior": "Detects compilation failures after bump, identifies the breaking upstream change, adapts API server code to new signatures, re-verifies build and tests",
+    "passing_criteria": "go build succeeds after fixes, adapted code follows existing conventions, no panic, proper error wrapping"
+  },
+  {
+    "id": "upgrade-rollback",
+    "prompt": "/upgrade-upstream v0.0.99-broken",
+    "expected_behavior": "Attempts upgrade, encounters unresolvable failure, rolls back to previous version, confirms go.mod is restored",
+    "passing_criteria": "go.mod restored to original version, go build succeeds, no half-upgraded state"
+  }
+]


### PR DESCRIPTION
## Summary

- Upgrades `github.com/openshift-online/rh-trex-ai` from v0.0.30 to v0.0.31 in `components/ambient-api-server/`
- Adds `/upgrade-upstream` skill under `skills/tooling/` for repeatable rh-trex-ai framework upgrades
- Updates `skills/RECONCILE.md` skill directory listing

### Upstream changes (2 commits)

 < /dev/null |  SHA | Description |
|-----|-------------|
| `747c0b84` | feat: add SDD infrastructure + fix HTTP multi-URL JWT key loading |
| `c7e0e94d` | feat: add release-tag skill for semver tagging workflow |

**Breaking change in upstream**: `WithKeysURL(string)` → `WithKeysURLs([]string)` — no impact on us (only used internally by upstream's `apiserver.go`).

## Test plan

- [x] `go build ./...` — clean compilation
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `make test` — 468 passed, 10 skipped, 0 failed
- [x] No references to old `WithKeysURL` singular API in our codebase
- [x] gRPC control-plane connection unaffected (uses bearer token, not JWT)

🤖 Generated with [Claude Code](https://claude.ai/code)