### PR TITLE
fix(ui): improve tool call result formatting in session logs

### DIFF
--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
@@ -139,28 +139,37 @@ describe('LogsTab', () => {
 
   it('renders messages that match active filters', async () => {
     const messages = [
-      makeMessage({ id: 'msg-1', eventType: 'tool_use', payload: 'git status' }),
+      makeMessage({
+        id: 'msg-1',
+        eventType: 'tool_use',
+        payload: JSON.stringify({ tool: 'Bash', arguments: { command: 'git status' } }),
+      }),
       makeMessage({ id: 'msg-2', eventType: 'error', payload: 'Command failed' }),
     ]
     const LogsTab = await loadWithMessages(messages)
 
     render(<LogsTab session={makeSession()} />, { wrapper: createWrapper() })
 
-    expect(await screen.findByText('git status')).toBeInTheDocument()
+    // tool_use rows are collapsed by default — only the tool name label is visible
+    expect(await screen.findByText('Bash')).toBeInTheDocument()
     expect(screen.getByText('Command failed')).toBeInTheDocument()
   })
 
   it('hides messages when their filter is toggled off', async () => {
     const messages = [
-      makeMessage({ id: 'msg-1', eventType: 'tool_use', payload: 'git status' }),
+      makeMessage({
+        id: 'msg-1',
+        eventType: 'tool_use',
+        payload: JSON.stringify({ tool: 'Bash', arguments: { command: 'git status' } }),
+      }),
       makeMessage({ id: 'msg-2', eventType: 'error', payload: 'Command failed' }),
     ]
     const LogsTab = await loadWithMessages(messages)
 
     render(<LogsTab session={makeSession()} />, { wrapper: createWrapper() })
 
-    // Wait for messages to load
-    expect(await screen.findByText('git status')).toBeInTheDocument()
+    // Wait for messages to load — tool_use rows show tool name when collapsed
+    expect(await screen.findByText('Bash')).toBeInTheDocument()
 
     // Toggle off 'Tool Call' filter -- scope to filter group to avoid
     // matching EventTypeBadge elements in message rows
@@ -168,21 +177,25 @@ describe('LogsTab', () => {
     fireEvent.click(within(filterGroup).getByText('Tool Call'))
 
     // tool_use message should be hidden
-    expect(screen.queryByText('git status')).not.toBeInTheDocument()
+    expect(screen.queryByText('Bash')).not.toBeInTheDocument()
     // error message should still be visible
     expect(screen.getByText('Command failed')).toBeInTheDocument()
   })
 
   it('shows "No events match" when all filters toggled off', async () => {
     const messages = [
-      makeMessage({ id: 'msg-1', eventType: 'tool_use', payload: 'some command' }),
+      makeMessage({
+        id: 'msg-1',
+        eventType: 'tool_use',
+        payload: JSON.stringify({ tool: 'Read', arguments: { path: '/workspace' } }),
+      }),
     ]
     const LogsTab = await loadWithMessages(messages)
 
     render(<LogsTab session={makeSession()} />, { wrapper: createWrapper() })
 
-    // Wait for data to load
-    expect(await screen.findByText('some command')).toBeInTheDocument()
+    // Wait for data to load — tool_use rows show tool name when collapsed
+    expect(await screen.findByText('Read')).toBeInTheDocument()
 
     // Toggle off all filters using the filter group buttons.
     // We must scope to the filter group because EventTypeBadge also

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
@@ -182,6 +182,75 @@ describe('LogsTab', () => {
     expect(screen.getByText('Command failed')).toBeInTheDocument()
   })
 
+  it('expands and collapses tool_use rows when clicked', async () => {
+    const messages = [
+      makeMessage({
+        id: 'msg-collapse',
+        eventType: 'tool_use',
+        payload: JSON.stringify({
+          tool: 'Bash',
+          arguments: { command: 'git status' },
+          tool_call_id: 'tc-collapse',
+        }),
+      }),
+    ]
+    const LogsTab = await loadWithMessages(messages)
+
+    render(<LogsTab session={makeSession()} />, { wrapper: createWrapper() })
+
+    // Collapsed by default — tool name visible, arguments hidden
+    const toolLabel = await screen.findByText('Bash')
+    expect(toolLabel).toBeInTheDocument()
+    expect(screen.queryByText('git status')).not.toBeInTheDocument()
+
+    // Expand
+    fireEvent.click(toolLabel)
+    expect(screen.getByText(/git status/)).toBeInTheDocument()
+
+    // Collapse again
+    fireEvent.click(toolLabel)
+    expect(screen.queryByText('git status')).not.toBeInTheDocument()
+  })
+
+  it('truncates tool_result to 4 lines with a Show more button', async () => {
+    const longResult = 'line 1\nline 2\nline 3\nline 4\nline 5\nline 6'
+    const messages = [
+      makeMessage({
+        id: 'msg-long-result',
+        eventType: 'tool_result',
+        payload: JSON.stringify({
+          tool_call_id: 'tc-long',
+          result: longResult,
+        }),
+      }),
+    ]
+    const LogsTab = await loadWithMessages(messages)
+
+    render(<LogsTab session={makeSession()} />, { wrapper: createWrapper() })
+
+    // Should show first 4 lines but not line 5/6
+    expect(await screen.findByText(/line 1/)).toBeInTheDocument()
+    expect(screen.getByText(/line 4/)).toBeInTheDocument()
+    expect(screen.queryByText(/line 5/)).not.toBeInTheDocument()
+
+    // "Show more" button should be present
+    const showMore = screen.getByText('Show more')
+    expect(showMore).toBeInTheDocument()
+
+    // Click to expand
+    fireEvent.click(showMore)
+    expect(screen.getByText(/line 5/)).toBeInTheDocument()
+    expect(screen.getByText(/line 6/)).toBeInTheDocument()
+
+    // "Show less" button should now be present
+    const showLess = screen.getByText('Show less')
+    expect(showLess).toBeInTheDocument()
+
+    // Collapse back
+    fireEvent.click(showLess)
+    expect(screen.queryByText(/line 5/)).not.toBeInTheDocument()
+  })
+
   it('shows "No events match" when all filters toggled off', async () => {
     const messages = [
       makeMessage({

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
@@ -251,6 +251,21 @@ describe('LogsTab', () => {
     expect(screen.queryByText(/line 5/)).not.toBeInTheDocument()
   })
 
+  it('shows "Unknown Tool" when tool_use payload is not parseable', async () => {
+    const messages = [
+      makeMessage({
+        id: 'msg-bad-tool',
+        eventType: 'tool_use',
+        payload: 'not valid json',
+      }),
+    ]
+    const LogsTab = await loadWithMessages(messages)
+
+    render(<LogsTab session={makeSession()} />, { wrapper: createWrapper() })
+
+    expect(await screen.findByText('Unknown Tool')).toBeInTheDocument()
+  })
+
   it('shows "No events match" when all filters toggled off', async () => {
     const messages = [
       makeMessage({

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
@@ -1,14 +1,20 @@
 'use client'
 
-import { useState, useCallback } from 'react'
-import { AlertTriangle } from 'lucide-react'
+import { useState } from 'react'
+import { AlertTriangle, ChevronRight, ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { deepUnwrapJson, tryFormatJson, tryParseToolPayload } from '@/components/chat-messages'
 import type { DomainSessionMessage } from '@/domain/types'
 import { formatRelativeTime } from '@/lib/format-timestamp'
 import { cn } from '@/lib/utils'
 import { EventTypeBadge } from './event-type-badge'
 
 const MAX_CONTENT_LENGTH = 300
+const MAX_RESULT_LINES = 4
+
+const COL_TIME = 'shrink-0 w-[100px] font-mono text-xs text-muted-foreground pt-0.5'
+const COL_BADGE = 'shrink-0 w-[90px] pt-0.5 flex items-center gap-1'
+const COL_CONTENT = 'min-w-0 flex-1'
 
 function truncateContent(content: string): { text: string; truncated: boolean } {
   if (content.length <= MAX_CONTENT_LENGTH) {
@@ -20,44 +26,104 @@ function truncateContent(content: string): { text: string; truncated: boolean } 
   }
 }
 
-type EventRowProps = {
-  message: DomainSessionMessage
-  isToolResultFollowingToolUse: boolean
+function truncateToLines(text: string, maxLines: number): { text: string; truncated: boolean } {
+  const lines = text.split('\n')
+  if (lines.length <= maxLines) {
+    return { text, truncated: false }
+  }
+  return {
+    text: lines.slice(0, maxLines).join('\n'),
+    truncated: true,
+  }
 }
 
-export function EventRow({ message, isToolResultFollowingToolUse }: EventRowProps) {
+function formatToolResultPayload(message: DomainSessionMessage): string {
+  try {
+    const parsed = JSON.parse(message.payload) as Record<string, unknown>
+    if (typeof parsed.result === 'string') {
+      return deepUnwrapJson(parsed.result)
+    }
+    return JSON.stringify(parsed, null, 2)
+  } catch {
+    return message.payload
+  }
+}
+
+// ---- Collapsible row: collapsed by default, shows a title label ----
+
+function CollapsibleRow({
+  message,
+  label,
+}: {
+  message: DomainSessionMessage
+  label: string
+}) {
   const [expanded, setExpanded] = useState(false)
-  const isError = message.eventType === 'error'
-  const { text, truncated } = truncateContent(message.payload)
-
-  const toggleExpanded = useCallback(() => {
-    setExpanded(prev => !prev)
-  }, [])
-
+  const formattedPayload = tryFormatJson(message.payload)
   const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
-  const ariaLabel = `${message.eventType === 'tool_use' ? 'Tool Call' : message.eventType === 'tool_result' ? 'Tool Result' : message.eventType} event, ${relativeTime}`
 
   return (
     <article
-      aria-label={ariaLabel}
-      className={cn(
-        'flex gap-3 px-3 py-2 text-sm',
-        isError && 'border-l-2 border-l-status-error-foreground bg-status-error/20',
-        isToolResultFollowingToolUse && 'mt-0 pt-1 border-l-2 border-l-border ml-4',
-      )}
+      aria-label={`${label}, ${relativeTime}`}
+      className="flex gap-3 px-3 py-2 text-sm"
     >
-      <span className="shrink-0 font-mono text-xs text-muted-foreground pt-0.5 min-w-[100px]">
-        {relativeTime}
-      </span>
-      <span className="shrink-0 pt-0.5 flex items-center gap-1">
-        {isError && (
-          <AlertTriangle className="h-3.5 w-3.5 text-status-error-foreground" aria-hidden="true" />
-        )}
+      <span className={COL_TIME}>{relativeTime}</span>
+      <span className={COL_BADGE}>
         <EventTypeBadge eventType={message.eventType} />
       </span>
-      <div className="min-w-0 flex-1">
+      <div className={COL_CONTENT}>
+        <button
+          type="button"
+          className="flex items-center gap-1 text-xs font-mono font-medium text-foreground hover:text-primary transition-colors"
+          onClick={() => setExpanded(prev => !prev)}
+          aria-expanded={expanded}
+        >
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          )}
+          {label}
+        </button>
+        {expanded && (
+          <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-foreground">
+            {formattedPayload}
+          </pre>
+        )}
+      </div>
+    </article>
+  )
+}
+
+// ---- Tool Result: line-based truncation ----
+
+function ToolResultRow({
+  message,
+  isFollowingToolUse,
+}: {
+  message: DomainSessionMessage
+  isFollowingToolUse: boolean
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const formattedPayload = formatToolResultPayload(message)
+  const { text: truncatedText, truncated } = truncateToLines(formattedPayload, MAX_RESULT_LINES)
+  const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
+
+  return (
+    <article
+      aria-label={`Tool Result, ${relativeTime}`}
+      className={cn(
+        'flex gap-3 px-3 py-2 text-sm',
+        isFollowingToolUse && 'mt-0 pt-1 border-l-2 border-l-border ml-4',
+      )}
+    >
+      <span className={COL_TIME}>{relativeTime}</span>
+      <span className={COL_BADGE}>
+        <EventTypeBadge eventType={message.eventType} />
+      </span>
+      <div className={COL_CONTENT}>
         <pre className="whitespace-pre-wrap break-words font-mono text-xs text-foreground">
-          {expanded ? message.payload : text}
+          {expanded ? formattedPayload : truncatedText}
           {truncated && !expanded && '...'}
         </pre>
         {truncated && (
@@ -65,7 +131,7 @@ export function EventRow({ message, isToolResultFollowingToolUse }: EventRowProp
             variant="link"
             size="sm"
             className="h-auto p-0 text-xs text-muted-foreground"
-            onClick={toggleExpanded}
+            onClick={() => setExpanded(prev => !prev)}
           >
             {expanded ? 'Show less' : 'Show more'}
           </Button>
@@ -73,4 +139,75 @@ export function EventRow({ message, isToolResultFollowingToolUse }: EventRowProp
       </div>
     </article>
   )
+}
+
+// ---- Generic: character-based truncation for other event types ----
+
+function GenericEventRow({ message }: { message: DomainSessionMessage }) {
+  const [expanded, setExpanded] = useState(false)
+  const isError = message.eventType === 'error'
+  const formattedPayload = tryFormatJson(message.payload)
+  const { text, truncated } = truncateContent(formattedPayload)
+  const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
+  const ariaLabel = `${message.eventType} event, ${relativeTime}`
+
+  return (
+    <article
+      aria-label={ariaLabel}
+      className={cn(
+        'flex gap-3 px-3 py-2 text-sm',
+        isError && 'border-l-2 border-l-status-error-foreground bg-status-error/20',
+      )}
+    >
+      <span className={COL_TIME}>{relativeTime}</span>
+      <span className={COL_BADGE}>
+        {isError && (
+          <AlertTriangle className="h-3.5 w-3.5 text-status-error-foreground" aria-hidden="true" />
+        )}
+        <EventTypeBadge eventType={message.eventType} />
+      </span>
+      <div className={COL_CONTENT}>
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs text-foreground">
+          {expanded ? formattedPayload : text}
+          {truncated && !expanded && '...'}
+        </pre>
+        {truncated && (
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-xs text-muted-foreground"
+            onClick={() => setExpanded(prev => !prev)}
+          >
+            {expanded ? 'Show less' : 'Show more'}
+          </Button>
+        )}
+      </div>
+    </article>
+  )
+}
+
+// ---- Public EventRow: dispatches to the right sub-component ----
+
+type EventRowProps = {
+  message: DomainSessionMessage
+  isToolResultFollowingToolUse: boolean
+}
+
+export function EventRow({ message, isToolResultFollowingToolUse }: EventRowProps) {
+  if (message.eventType === 'tool_use') {
+    const toolPayload = tryParseToolPayload(message.payload)
+    return <CollapsibleRow message={message} label={toolPayload?.name ?? 'Unknown Tool'} />
+  }
+  if (message.eventType === 'system') {
+    return <CollapsibleRow message={message} label="System" />
+  }
+  if (message.eventType === 'tool_result') {
+    return (
+      <ToolResultRow
+        message={message}
+        isFollowingToolUse={isToolResultFollowingToolUse}
+      />
+    )
+  }
+  return <GenericEventRow message={message} />
 }

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { AlertTriangle, ChevronRight, ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { deepUnwrapJson, tryFormatJson, tryParseToolPayload } from '@/components/chat-messages'
+import { tryFormatJson, tryParseToolPayload, tryParseToolResult } from '@/components/chat-messages'
 import type { DomainSessionMessage } from '@/domain/types'
 import { formatRelativeTime } from '@/lib/format-timestamp'
 import { cn } from '@/lib/utils'
@@ -38,15 +38,9 @@ function truncateToLines(text: string, maxLines: number): { text: string; trunca
 }
 
 function formatToolResultPayload(message: DomainSessionMessage): string {
-  try {
-    const parsed = JSON.parse(message.payload) as Record<string, unknown>
-    if (typeof parsed.result === 'string') {
-      return deepUnwrapJson(parsed.result)
-    }
-    return JSON.stringify(parsed, null, 2)
-  } catch {
-    return message.payload
-  }
+  const parsed = tryParseToolResult(message.payload)
+  if (parsed) return parsed.result
+  return tryFormatJson(message.payload)
 }
 
 // ---- Collapsible row: collapsed by default, shows a title label ----
@@ -59,7 +53,7 @@ function CollapsibleRow({
   label: string
 }) {
   const [expanded, setExpanded] = useState(false)
-  const formattedPayload = tryFormatJson(message.payload)
+  const formattedPayload = useMemo(() => tryFormatJson(message.payload), [message.payload])
   const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
 
   return (
@@ -105,7 +99,7 @@ function ToolResultRow({
   isFollowingToolUse: boolean
 }) {
   const [expanded, setExpanded] = useState(false)
-  const formattedPayload = formatToolResultPayload(message)
+  const formattedPayload = useMemo(() => formatToolResultPayload(message), [message.payload])
   const { text: truncatedText, truncated } = truncateToLines(formattedPayload, MAX_RESULT_LINES)
   const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
 
@@ -146,7 +140,7 @@ function ToolResultRow({
 function GenericEventRow({ message }: { message: DomainSessionMessage }) {
   const [expanded, setExpanded] = useState(false)
   const isError = message.eventType === 'error'
-  const formattedPayload = tryFormatJson(message.payload)
+  const formattedPayload = useMemo(() => tryFormatJson(message.payload), [message.payload])
   const { text, truncated } = truncateContent(formattedPayload)
   const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
   const ariaLabel = `${message.eventType} event, ${relativeTime}`

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
@@ -37,10 +37,10 @@ function truncateToLines(text: string, maxLines: number): { text: string; trunca
   }
 }
 
-function formatToolResultPayload(message: DomainSessionMessage): string {
-  const parsed = tryParseToolResult(message.payload)
+function formatToolResultPayload(payload: string): string {
+  const parsed = tryParseToolResult(payload)
   if (parsed) return parsed.result
-  return tryFormatJson(message.payload)
+  return tryFormatJson(payload)
 }
 
 // ---- Collapsible row: collapsed by default, shows a title label ----
@@ -99,7 +99,7 @@ function ToolResultRow({
   isFollowingToolUse: boolean
 }) {
   const [expanded, setExpanded] = useState(false)
-  const formattedPayload = useMemo(() => formatToolResultPayload(message), [message.payload])
+  const formattedPayload = useMemo(() => formatToolResultPayload(message.payload), [message.payload])
   const { text: truncatedText, truncated } = truncateToLines(formattedPayload, MAX_RESULT_LINES)
   const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
 

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/event-row.tsx
@@ -55,6 +55,7 @@ function CollapsibleRow({
   const [expanded, setExpanded] = useState(false)
   const formattedPayload = useMemo(() => tryFormatJson(message.payload), [message.payload])
   const relativeTime = message.createdAt ? formatRelativeTime(message.createdAt) : '--'
+  const contentId = `collapsible-${message.id}`
 
   return (
     <article
@@ -71,6 +72,7 @@ function CollapsibleRow({
           className="flex items-center gap-1 text-xs font-mono font-medium text-foreground hover:text-primary transition-colors"
           onClick={() => setExpanded(prev => !prev)}
           aria-expanded={expanded}
+          aria-controls={contentId}
         >
           {expanded ? (
             <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
@@ -80,7 +82,7 @@ function CollapsibleRow({
           {label}
         </button>
         {expanded && (
-          <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-foreground">
+          <pre id={contentId} className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-foreground">
             {formattedPayload}
           </pre>
         )}
@@ -188,9 +190,15 @@ type EventRowProps = {
 }
 
 export function EventRow({ message, isToolResultFollowingToolUse }: EventRowProps) {
+  const toolLabel = useMemo(
+    () => message.eventType === 'tool_use'
+      ? tryParseToolPayload(message.payload)?.name ?? 'Unknown Tool'
+      : null,
+    [message.eventType, message.payload],
+  )
+
   if (message.eventType === 'tool_use') {
-    const toolPayload = tryParseToolPayload(message.payload)
-    return <CollapsibleRow message={message} label={toolPayload?.name ?? 'Unknown Tool'} />
+    return <CollapsibleRow message={message} label={toolLabel ?? 'Unknown Tool'} />
   }
   if (message.eventType === 'system') {
     return <CollapsibleRow message={message} label="System" />

--- a/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
+++ b/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
@@ -3,6 +3,7 @@ import type { DomainSessionMessage } from '@/domain/types'
 import {
   tryParseToolPayload,
   tryParseToolResult,
+  deepUnwrapJson,
   filterEmptyMessages,
   groupChatItems,
   buildChatItems,
@@ -24,6 +25,48 @@ function makeMsg(
     ...overrides,
   }
 }
+
+// ---- deepUnwrapJson ----
+
+describe('deepUnwrapJson', () => {
+  it('returns plain text as-is', () => {
+    expect(deepUnwrapJson('hello world')).toBe('hello world')
+  })
+
+  it('pretty-prints a simple JSON object', () => {
+    const obj = { key: 'value' }
+    expect(deepUnwrapJson(JSON.stringify(obj))).toBe(JSON.stringify(obj, null, 2))
+  })
+
+  it('unwraps a double-stringified JSON object', () => {
+    const obj = { total: 5 }
+    const doubleEncoded = JSON.stringify(JSON.stringify(obj))
+    expect(deepUnwrapJson(doubleEncoded)).toBe(JSON.stringify(obj, null, 2))
+  })
+
+  it('unwraps a {result: "..."} wrapper from MCP tool responses', () => {
+    const innerData = { total: -1, issues: [{ id: '123', key: 'PROJ-1' }] }
+    const wrapped = JSON.stringify({ result: JSON.stringify(innerData) })
+    expect(deepUnwrapJson(wrapped)).toBe(JSON.stringify(innerData, null, 2))
+  })
+
+  it('unwraps multiply-encoded results with nested {result} wrappers', () => {
+    const innerData = { total: -1, start_at: 0 }
+    const level1 = JSON.stringify(innerData)
+    const level2 = JSON.stringify({ result: level1 })
+    const level3 = JSON.stringify(level2)
+    expect(deepUnwrapJson(level3)).toBe(JSON.stringify(innerData, null, 2))
+  })
+
+  it('preserves {result} objects that have extra keys beyond tool_call_id', () => {
+    const obj = { result: 'data', extra: 'field' }
+    expect(deepUnwrapJson(JSON.stringify(obj))).toBe(JSON.stringify(obj, null, 2))
+  })
+
+  it('unwraps a JSON-encoded string value', () => {
+    expect(deepUnwrapJson('"just a string"')).toBe('just a string')
+  })
+})
 
 // ---- tryParseToolPayload ----
 
@@ -87,12 +130,25 @@ describe('tryParseToolResult', () => {
     expect(result!.toolCallId).toBe('tc-1')
   })
 
-  it('strips wrapping double-quotes from result', () => {
+  it('unwraps a double-quoted result string', () => {
     const result = tryParseToolResult(
       JSON.stringify({ tool_call_id: 'tc-2', result: '"wrapped value"' }),
     )
     expect(result).not.toBeNull()
     expect(result!.result).toBe('wrapped value')
+  })
+
+  it('unwraps multiply-encoded JSON in the result field', () => {
+    const innerData = { total: -1, issues: [{ id: '123', key: 'PROJ-1' }] }
+    const level1 = JSON.stringify(innerData)
+    const level2 = JSON.stringify({ result: level1 })
+    const level3 = JSON.stringify(level2)
+    const result = tryParseToolResult(
+      JSON.stringify({ tool_call_id: 'tc-deep', result: level3 }),
+    )
+    expect(result).not.toBeNull()
+    expect(result!.toolCallId).toBe('tc-deep')
+    expect(result!.result).toBe(JSON.stringify(innerData, null, 2))
   })
 
   it('returns empty string toolCallId when tool_call_id is missing', () => {

--- a/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
+++ b/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
@@ -71,6 +71,19 @@ describe('deepUnwrapJson', () => {
     const arr = [1, 2, 3]
     expect(deepUnwrapJson(JSON.stringify(arr))).toBe(JSON.stringify(arr, null, 2))
   })
+
+  it('stops recursing at depth > 5 to prevent runaway unwrapping', () => {
+    // Build 7 levels of {result: ...} nesting — deeper than the depth=5 guard
+    let payload: unknown = 'inner value'
+    for (let i = 0; i < 7; i++) {
+      payload = JSON.stringify({ result: typeof payload === 'string' ? payload : JSON.stringify(payload) })
+    }
+    const result = deepUnwrapJson(payload as string)
+    // Should NOT reach "inner value" — the depth guard stops recursion early,
+    // leaving a partially-unwrapped {result} wrapper as pretty-printed JSON.
+    expect(result).not.toBe('inner value')
+    expect(result).toContain('result')
+  })
 })
 
 // ---- tryParseToolPayload ----

--- a/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
+++ b/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
@@ -66,6 +66,11 @@ describe('deepUnwrapJson', () => {
   it('unwraps a JSON-encoded string value', () => {
     expect(deepUnwrapJson('"just a string"')).toBe('just a string')
   })
+
+  it('pretty-prints a JSON array without unwrapping', () => {
+    const arr = [1, 2, 3]
+    expect(deepUnwrapJson(JSON.stringify(arr))).toBe(JSON.stringify(arr, null, 2))
+  })
 })
 
 // ---- tryParseToolPayload ----

--- a/components/ambient-ui/src/components/chat-messages.tsx
+++ b/components/ambient-ui/src/components/chat-messages.tsx
@@ -25,6 +25,8 @@ export const CHAT_EVENT_TYPES: ReadonlySet<SessionEventType> = new Set([
 
 // ---- Payload Parsing Helpers ----
 
+// Bounded unwrapping: max 5 recursive {result} wrappers × 10 iterative JSON.parse
+// layers = 50 parse calls worst-case. Both limits are well above real-world nesting.
 function unwrapNestedJson(value: unknown, depth = 0): unknown {
   if (depth > 5 || typeof value !== 'string') return value
 

--- a/components/ambient-ui/src/components/chat-messages.tsx
+++ b/components/ambient-ui/src/components/chat-messages.tsx
@@ -25,6 +25,35 @@ export const CHAT_EVENT_TYPES: ReadonlySet<SessionEventType> = new Set([
 
 // ---- Payload Parsing Helpers ----
 
+function unwrapNestedJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+
+  let current: unknown = value
+  for (let i = 0; i < 10; i++) {
+    if (typeof current !== 'string') break
+    try {
+      current = JSON.parse(current)
+    } catch {
+      break
+    }
+  }
+
+  if (typeof current === 'object' && current !== null && !Array.isArray(current)) {
+    const obj = current as Record<string, unknown>
+    if ('result' in obj && Object.keys(obj).every(k => k === 'result' || k === 'tool_call_id')) {
+      return unwrapNestedJson(obj.result)
+    }
+  }
+
+  return current
+}
+
+export function deepUnwrapJson(value: string): string {
+  const unwrapped = unwrapNestedJson(value)
+  if (typeof unwrapped === 'string') return unwrapped
+  return JSON.stringify(unwrapped, null, 2)
+}
+
 type ToolPayload = {
   name: string
   arguments: Record<string, unknown>
@@ -67,10 +96,8 @@ export function tryParseToolResult(payload: string): ToolResultPayload | null {
       return null
     }
     const obj = parsed as Record<string, unknown>
-    let result = typeof obj.result === 'string' ? obj.result : payload
-    if (result.startsWith('"') && result.endsWith('"')) {
-      result = result.slice(1, -1)
-    }
+    const raw = typeof obj.result === 'string' ? obj.result : payload
+    const result = deepUnwrapJson(raw)
     return {
       result,
       toolCallId: typeof obj.tool_call_id === 'string' ? obj.tool_call_id : '',

--- a/components/ambient-ui/src/components/chat-messages.tsx
+++ b/components/ambient-ui/src/components/chat-messages.tsx
@@ -25,8 +25,8 @@ export const CHAT_EVENT_TYPES: ReadonlySet<SessionEventType> = new Set([
 
 // ---- Payload Parsing Helpers ----
 
-function unwrapNestedJson(value: unknown): unknown {
-  if (typeof value !== 'string') return value
+function unwrapNestedJson(value: unknown, depth = 0): unknown {
+  if (depth > 5 || typeof value !== 'string') return value
 
   let current: unknown = value
   for (let i = 0; i < 10; i++) {
@@ -41,7 +41,7 @@ function unwrapNestedJson(value: unknown): unknown {
   if (typeof current === 'object' && current !== null && !Array.isArray(current)) {
     const obj = current as Record<string, unknown>
     if ('result' in obj && Object.keys(obj).every(k => k === 'result' || k === 'tool_call_id')) {
-      return unwrapNestedJson(obj.result)
+      return unwrapNestedJson(obj.result, depth + 1)
     }
   }
 

--- a/specs/ui/views.spec.md
+++ b/specs/ui/views.spec.md
@@ -116,9 +116,26 @@ Condition colors SHALL reflect semantic health, not literal True/False values. "
 
 - GIVEN a running session with AG-UI events
 - WHEN the Logs tab renders
-- THEN it displays a structured log view of events: timestamps, event type badges (text, tool call, error, lifecycle), content
+- THEN it displays a structured log view with aligned columns: timestamp (fixed width), event type badge (fixed width), and content
 - AND filter chips allow filtering by event type
 - AND errors are visually prominent
+
+### Scenario: Logs tab collapsible rows
+
+- GIVEN a session with tool_use and system events
+- WHEN the Logs tab renders
+- THEN Tool Call rows are collapsed by default, showing only the tool name with a chevron toggle
+- AND System rows are collapsed by default, showing "System" with a chevron toggle
+- AND clicking a collapsed row expands it to reveal the formatted payload
+- AND clicking an expanded row collapses it again
+
+### Scenario: Logs tab tool result truncation
+
+- GIVEN a session with tool_result events containing multi-line content
+- WHEN the Logs tab renders
+- THEN Tool Result rows truncate content to 4 lines with a "Show more" button
+- AND clicking "Show more" reveals the full content and changes to "Show less"
+- AND tool result payloads with multiply-encoded JSON are recursively unwrapped and pretty-printed
 
 ### Scenario: Resources tab
 
@@ -143,7 +160,7 @@ Condition colors SHALL reflect semantic health, not literal True/False values. "
 - THEN it displays a full AG-UI chat interface with messages
 - AND user messages are styled distinctly from assistant messages
 - AND assistant messages render as Markdown (headings, lists, code blocks, tables, links)
-- AND tool calls render as collapsible blocks showing tool name, arguments (when available), and result
+- AND tool calls render as collapsible blocks showing tool name, arguments (when available), and result (with multiply-encoded JSON recursively unwrapped and pretty-printed, depth-guarded to 5 levels)
 - AND the user can send messages via an input field (Enter to send, Shift+Enter for newline)
 - AND the agent's current status is displayed as a phase badge near the input
 - AND the input is disabled when the session is not in Running phase


### PR DESCRIPTION
## Summary
- **Deep JSON unwrapping**: Tool call results with multiply-encoded JSON escaping are now recursively unwrapped and pretty-printed, fixing unreadable `\\\"` noise in both the Logs and Chat tabs
- **Collapsible rows**: Tool Call and System events in the Logs tab are collapsed by default, showing just the tool name or "System" label with a chevron toggle
- **Line-based truncation**: Tool Result events truncate to 4 lines with a "Show more" button instead of the previous 300-character cutoff
- **Aligned columns**: Timestamp, badge, and content columns use fixed widths so all log rows align consistently

## Test plan
- [ ] Open a session with tool call activity and verify Logs tab shows readable JSON
- [ ] Verify Tool Call rows are collapsed by default and expand on click
- [ ] Verify System rows are collapsed by default and expand on click
- [ ] Verify Tool Result rows truncate at 4 lines with "Show more" working
- [ ] Verify Chat tab still renders tool results correctly
- [ ] `npm run build` passes with 0 errors (CI)
- [ ] `vitest` passes (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)