### PR TITLE
feat: add custom ACP login theme for Keycloak

### DIFF
--- a/components/manifests/overlays/kind/keycloak-deployment.yaml
+++ b/components/manifests/overlays/kind/keycloak-deployment.yaml
@@ -43,6 +43,22 @@ spec:
             - name: realm-config
               mountPath: /opt/keycloak/data/import
               readOnly: true
+            - name: acp-theme
+              mountPath: /opt/keycloak/themes/acp/login/theme.properties
+              subPath: theme.properties
+              readOnly: true
+            - name: acp-theme
+              mountPath: /opt/keycloak/themes/acp/login/resources/css/login.css
+              subPath: login.css
+              readOnly: true
+            - name: acp-theme
+              mountPath: /opt/keycloak/themes/acp/login/resources/img/acp-logo.svg
+              subPath: acp-logo.svg
+              readOnly: true
+            - name: acp-theme
+              mountPath: /opt/keycloak/themes/acp/login/messages/messages_en.properties
+              subPath: messages_en.properties
+              readOnly: true
           resources:
             requests:
               cpu: 200m
@@ -68,6 +84,9 @@ spec:
         - name: realm-config
           configMap:
             name: keycloak-realm-config
+        - name: acp-theme
+          configMap:
+            name: keycloak-acp-theme
 ---
 apiVersion: v1
 kind: Service

--- a/components/manifests/overlays/kind/keycloak-realm.json
+++ b/components/manifests/overlays/kind/keycloak-realm.json
@@ -1,6 +1,7 @@
 {
   "realm": "ambient-code",
   "enabled": true,
+  "loginTheme": "acp",
   "sslRequired": "none",
   "registrationAllowed": false,
   "accessTokenLifespan": 300,

--- a/components/manifests/overlays/kind/keycloak-theme/acp-logo.svg
+++ b/components/manifests/overlays/kind/keycloak-theme/acp-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="#f56e6e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 8V4H8"/>
+  <rect width="16" height="12" x="4" y="8" rx="2"/>
+  <path d="M2 14h2"/>
+  <path d="M20 14h2"/>
+  <path d="M15 13v2"/>
+  <path d="M9 13v2"/>
+</svg>

--- a/components/manifests/overlays/kind/keycloak-theme/acp-logo.svg
+++ b/components/manifests/overlays/kind/keycloak-theme/acp-logo.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="#f56e6e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="#f56e6e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="ACP Logo">
+  <title>ACP Logo</title>
   <path d="M12 8V4H8"/>
   <rect width="16" height="12" x="4" y="8" rx="2"/>
   <path d="M2 14h2"/>

--- a/components/manifests/overlays/kind/keycloak-theme/login.css
+++ b/components/manifests/overlays/kind/keycloak-theme/login.css
@@ -1,6 +1,6 @@
 /* ACP Keycloak Login Theme — matches ambient-ui dark palette */
 
-/* Import Red Hat Text to match the main UI */
+/* Red Hat Text from Google Fonts — requires network access; falls back to system-ui offline */
 @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text:wght@400;500;600;700&display=swap');
 
 /* Page background — true gray with subtle dot texture */
@@ -27,7 +27,7 @@ html.pf-v5-theme-dark .pf-v5-c-login {
   grid-template-areas: none !important;
 }
 
-/* Header — hide raw text from kc-header-wrapper, use pseudo-elements */
+/* Header — hide raw text from kc-header-wrapper (Keycloak 26.0 / PF5 DOM) */
 #kc-header-wrapper {
   font-size: 0 !important;
   line-height: 0 !important;
@@ -51,25 +51,26 @@ html.pf-v5-theme-dark .pf-v5-c-login {
 }
 
 .pf-v5-c-login__header::before {
-  content: "" !important;
-  display: block !important;
-  width: 88px !important;
-  height: 88px !important;
-  background-image: url("../img/acp-logo.svg") !important;
-  background-size: contain !important;
-  background-repeat: no-repeat !important;
-  background-position: center !important;
-  margin-bottom: 0.5rem !important;
+  content: "";
+  display: block;
+  width: 88px;
+  height: 88px;
+  background-image: url("../img/acp-logo.svg");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  margin-bottom: 0.5rem;
 }
 
+/* Title must match messages_en.properties:loginTitleHtml */
 .pf-v5-c-login__header::after {
-  content: "Agent Control Plane" !important;
-  display: block !important;
-  color: #f2f2f2 !important;
-  font-size: 1.75rem !important;
-  font-weight: 600 !important;
-  font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif !important;
-  letter-spacing: 0.01em !important;
+  content: "Agent Control Plane";
+  display: block;
+  color: #f2f2f2;
+  font-size: 1.75rem;
+  font-weight: 600;
+  font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif;
+  letter-spacing: 0.01em;
 }
 
 /* Login card — centered with explicit margin auto */
@@ -87,11 +88,11 @@ html.pf-v5-theme-dark .pf-v5-c-login {
 }
 
 .pf-v5-c-login__main-body {
-  background-color: transparent !important;
+  background-color: transparent;
 }
 
 .pf-v5-c-login__main-header {
-  background-color: transparent !important;
+  background-color: transparent;
 }
 
 /* "Sign in to your account" heading */
@@ -111,21 +112,21 @@ h1.pf-v5-c-title.pf-m-3xl,
   font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif !important;
 }
 
-/* Form inputs */
+/* Form inputs — CSS custom properties cascade naturally on same selector */
 .pf-v5-c-form-control {
-  --pf-v5-c-form-control--BorderTopColor: #383838 !important;
-  --pf-v5-c-form-control--BorderRightColor: #383838 !important;
-  --pf-v5-c-form-control--BorderBottomColor: #383838 !important;
-  --pf-v5-c-form-control--BorderLeftColor: #383838 !important;
-  --pf-v5-c-form-control--hover--BorderBottomColor: #f56e6e !important;
-  --pf-v5-c-form-control--focus--BorderBottomColor: #f56e6e !important;
-  --pf-v5-c-form-control--m-expanded--BorderBottomColor: #f56e6e !important;
-  --pf-v5-c-form-control--BackgroundColor: #292929 !important;
-  --pf-v5-c-form-control--Color: #f2f2f2 !important;
-  --pf-v5-c-form-control--OutlineOffset: 0 !important;
-  --pf-v5-c-form-control--after--BorderBottomColor: #383838 !important;
-  --pf-v5-c-form-control--hover__after--BorderBottomColor: #f56e6e !important;
-  --pf-v5-c-form-control--focus__after--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-form-control--BorderTopColor: #383838;
+  --pf-v5-c-form-control--BorderRightColor: #383838;
+  --pf-v5-c-form-control--BorderBottomColor: #383838;
+  --pf-v5-c-form-control--BorderLeftColor: #383838;
+  --pf-v5-c-form-control--hover--BorderBottomColor: #f56e6e;
+  --pf-v5-c-form-control--focus--BorderBottomColor: #f56e6e;
+  --pf-v5-c-form-control--m-expanded--BorderBottomColor: #f56e6e;
+  --pf-v5-c-form-control--BackgroundColor: #292929;
+  --pf-v5-c-form-control--Color: #f2f2f2;
+  --pf-v5-c-form-control--OutlineOffset: 0;
+  --pf-v5-c-form-control--after--BorderBottomColor: #383838;
+  --pf-v5-c-form-control--hover__after--BorderBottomColor: #f56e6e;
+  --pf-v5-c-form-control--focus__after--BorderBottomColor: #f56e6e;
   background-color: #292929 !important;
   border-color: #383838 !important;
   color: #f2f2f2 !important;
@@ -138,7 +139,7 @@ h1.pf-v5-c-title.pf-m-3xl,
 
 .pf-v5-c-form-control::after {
   border-bottom-color: #383838 !important;
-  transition: border-bottom-color 0.2s ease !important;
+  transition: border-bottom-color 0.2s ease;
 }
 
 .pf-v5-c-form-control:hover::after,
@@ -160,10 +161,10 @@ h1.pf-v5-c-title.pf-m-3xl,
 
 /* Primary button — ACP dark primary (orange-red) */
 .pf-v5-c-button.pf-m-primary {
-  --pf-v5-c-button--m-primary--BackgroundColor: #f56e6e !important;
-  --pf-v5-c-button--m-primary--hover--BackgroundColor: #e05555 !important;
-  --pf-v5-c-button--m-primary--focus--BackgroundColor: #e05555 !important;
-  --pf-v5-c-button--m-primary--active--BackgroundColor: #e05555 !important;
+  --pf-v5-c-button--m-primary--BackgroundColor: #f56e6e;
+  --pf-v5-c-button--m-primary--hover--BackgroundColor: #e05555;
+  --pf-v5-c-button--m-primary--focus--BackgroundColor: #e05555;
+  --pf-v5-c-button--m-primary--active--BackgroundColor: #e05555;
   background-color: #f56e6e !important;
   border-color: #f56e6e !important;
   color: #151515 !important;
@@ -179,24 +180,24 @@ h1.pf-v5-c-title.pf-m-3xl,
 
 /* Password visibility toggle — orange-red on hover */
 .pf-v5-c-button.pf-m-control {
-  --pf-v5-c-button--m-control--BackgroundColor: #292929 !important;
-  --pf-v5-c-button--m-control--hover--BackgroundColor: #292929 !important;
-  --pf-v5-c-button--m-control--focus--BackgroundColor: #292929 !important;
-  --pf-v5-c-button--m-control--active--BackgroundColor: #292929 !important;
-  --pf-v5-c-button--m-control--BorderColor: #383838 !important;
-  --pf-v5-c-button--m-control--after--BorderBottomColor: #383838 !important;
-  --pf-v5-c-button--m-control--hover--after--BorderBottomColor: #f56e6e !important;
-  --pf-v5-c-button--m-control--focus--after--BorderBottomColor: #f56e6e !important;
-  --pf-v5-c-button--m-control--active--after--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-button--m-control--BackgroundColor: #292929;
+  --pf-v5-c-button--m-control--hover--BackgroundColor: #292929;
+  --pf-v5-c-button--m-control--focus--BackgroundColor: #292929;
+  --pf-v5-c-button--m-control--active--BackgroundColor: #292929;
+  --pf-v5-c-button--m-control--BorderColor: #383838;
+  --pf-v5-c-button--m-control--after--BorderBottomColor: #383838;
+  --pf-v5-c-button--m-control--hover--after--BorderBottomColor: #f56e6e;
+  --pf-v5-c-button--m-control--focus--after--BorderBottomColor: #f56e6e;
+  --pf-v5-c-button--m-control--active--after--BorderBottomColor: #f56e6e;
   background-color: #292929 !important;
   border-color: #383838 !important;
   color: #a3a3a3 !important;
-  transition: color 0.2s ease, border-color 0.2s ease !important;
+  transition: color 0.2s ease, border-color 0.2s ease;
 }
 
 .pf-v5-c-button.pf-m-control::after {
   border-bottom-color: #383838 !important;
-  transition: border-bottom-color 0.2s ease !important;
+  transition: border-bottom-color 0.2s ease;
 }
 
 .pf-v5-c-button.pf-m-control:hover::after,
@@ -222,7 +223,7 @@ h1.pf-v5-c-title.pf-m-3xl,
 .pf-v5-c-button.pf-m-control i,
 .pf-v5-c-button[data-password-toggle] i {
   color: #a3a3a3 !important;
-  transition: color 0.2s ease !important;
+  transition: color 0.2s ease;
 }
 
 .pf-v5-c-button.pf-m-control:hover i.fa-eye,
@@ -246,7 +247,7 @@ h1.pf-v5-c-title.pf-m-3xl,
 
 /* Footer */
 .pf-v5-c-login__main-footer {
-  background-color: transparent !important;
+  background-color: transparent;
 }
 
 /* Alert styling */
@@ -266,8 +267,8 @@ h1.pf-v5-c-title.pf-m-3xl,
 
 /* Page footer */
 .pf-v5-c-login__footer {
-  text-align: center !important;
-  color: #a3a3a3 !important;
-  margin-top: 1.5rem !important;
+  text-align: center;
+  color: #a3a3a3;
+  margin-top: 1.5rem;
   grid-area: unset !important;
 }

--- a/components/manifests/overlays/kind/keycloak-theme/login.css
+++ b/components/manifests/overlays/kind/keycloak-theme/login.css
@@ -9,7 +9,9 @@ html.pf-v5-theme-dark .pf-v5-c-login {
   background-color: #151515 !important;
   background-image: radial-gradient(circle, #1f1f1f 1px, transparent 1px) !important;
   background-size: 24px 24px !important;
-  min-height: 100vh !important;
+  height: 100vh !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
 }
 
 /* Kill the PatternFly grid at ALL breakpoints — force centered single-column */
@@ -18,10 +20,11 @@ html.pf-v5-theme-dark .pf-v5-c-login {
   flex-direction: column !important;
   align-items: center !important;
   justify-content: center !important;
-  min-height: 100vh !important;
+  height: 100vh !important;
+  min-height: 0 !important;
   width: 100% !important;
   max-width: 100% !important;
-  padding: 2rem !important;
+  padding: 1rem !important;
   box-sizing: border-box !important;
   grid-template-columns: none !important;
   grid-template-areas: none !important;
@@ -44,7 +47,7 @@ html.pf-v5-theme-dark .pf-v5-c-login {
   align-items: center !important;
   text-align: center !important;
   width: auto !important;
-  margin-bottom: 2.5rem !important;
+  margin-bottom: 1.5rem !important;
   padding: 0 !important;
   grid-area: unset !important;
   order: -1 !important;
@@ -269,6 +272,6 @@ h1.pf-v5-c-title.pf-m-3xl,
 .pf-v5-c-login__footer {
   text-align: center;
   color: #a3a3a3;
-  margin-top: 1.5rem;
+  margin-top: 0.75rem;
   grid-area: unset !important;
 }

--- a/components/manifests/overlays/kind/keycloak-theme/login.css
+++ b/components/manifests/overlays/kind/keycloak-theme/login.css
@@ -1,0 +1,273 @@
+/* ACP Keycloak Login Theme — matches ambient-ui dark palette */
+
+/* Import Red Hat Text to match the main UI */
+@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text:wght@400;500;600;700&display=swap');
+
+/* Page background — true gray with subtle dot texture */
+.pf-v5-c-login,
+html.pf-v5-theme-dark .pf-v5-c-login {
+  background-color: #151515 !important;
+  background-image: radial-gradient(circle, #1f1f1f 1px, transparent 1px) !important;
+  background-size: 24px 24px !important;
+  min-height: 100vh !important;
+}
+
+/* Kill the PatternFly grid at ALL breakpoints — force centered single-column */
+.pf-v5-c-login__container {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  justify-content: center !important;
+  min-height: 100vh !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  padding: 2rem !important;
+  box-sizing: border-box !important;
+  grid-template-columns: none !important;
+  grid-template-areas: none !important;
+}
+
+/* Header — hide raw text from kc-header-wrapper, use pseudo-elements */
+#kc-header-wrapper {
+  font-size: 0 !important;
+  line-height: 0 !important;
+  color: transparent !important;
+  height: 0 !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.pf-v5-c-login__header {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  text-align: center !important;
+  width: auto !important;
+  margin-bottom: 2.5rem !important;
+  padding: 0 !important;
+  grid-area: unset !important;
+  order: -1 !important;
+}
+
+.pf-v5-c-login__header::before {
+  content: "" !important;
+  display: block !important;
+  width: 88px !important;
+  height: 88px !important;
+  background-image: url("../img/acp-logo.svg") !important;
+  background-size: contain !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  margin-bottom: 0.5rem !important;
+}
+
+.pf-v5-c-login__header::after {
+  content: "Agent Control Plane" !important;
+  display: block !important;
+  color: #f2f2f2 !important;
+  font-size: 1.75rem !important;
+  font-weight: 600 !important;
+  font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif !important;
+  letter-spacing: 0.01em !important;
+}
+
+/* Login card — centered with explicit margin auto */
+.pf-v5-c-login__main {
+  width: 100% !important;
+  max-width: 400px !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  align-self: center !important;
+  background-color: #1f1f1f !important;
+  border: 1px solid #383838 !important;
+  border-radius: 0.625rem !important;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4) !important;
+  grid-area: unset !important;
+}
+
+.pf-v5-c-login__main-body {
+  background-color: transparent !important;
+}
+
+.pf-v5-c-login__main-header {
+  background-color: transparent !important;
+}
+
+/* "Sign in to your account" heading */
+.pf-v5-c-login__main-header h1,
+h1.pf-v5-c-title,
+h1.pf-v5-c-title.pf-m-3xl,
+#kc-page-title {
+  color: #f2f2f2 !important;
+  font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif !important;
+}
+
+/* All form text uses Red Hat Text */
+.pf-v5-c-form,
+.pf-v5-c-form-control,
+.pf-v5-c-form-control input,
+.pf-v5-c-button {
+  font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif !important;
+}
+
+/* Form inputs */
+.pf-v5-c-form-control {
+  --pf-v5-c-form-control--BorderTopColor: #383838 !important;
+  --pf-v5-c-form-control--BorderRightColor: #383838 !important;
+  --pf-v5-c-form-control--BorderBottomColor: #383838 !important;
+  --pf-v5-c-form-control--BorderLeftColor: #383838 !important;
+  --pf-v5-c-form-control--hover--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-form-control--focus--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-form-control--m-expanded--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-form-control--BackgroundColor: #292929 !important;
+  --pf-v5-c-form-control--Color: #f2f2f2 !important;
+  --pf-v5-c-form-control--OutlineOffset: 0 !important;
+  --pf-v5-c-form-control--after--BorderBottomColor: #383838 !important;
+  --pf-v5-c-form-control--hover__after--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-form-control--focus__after--BorderBottomColor: #f56e6e !important;
+  background-color: #292929 !important;
+  border-color: #383838 !important;
+  color: #f2f2f2 !important;
+}
+
+.pf-v5-c-form-control input {
+  background-color: transparent !important;
+  color: #f2f2f2 !important;
+}
+
+.pf-v5-c-form-control::after {
+  border-bottom-color: #383838 !important;
+  transition: border-bottom-color 0.2s ease !important;
+}
+
+.pf-v5-c-form-control:hover::after,
+.pf-v5-c-form-control:focus-within::after {
+  border-bottom-color: #f56e6e !important;
+}
+
+.pf-v5-c-form-control:focus-within,
+.pf-v5-c-form-control:focus {
+  border-color: #f56e6e !important;
+  outline: none !important;
+}
+
+/* Labels */
+.pf-v5-c-form__label-text {
+  color: #a3a3a3 !important;
+  font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif !important;
+}
+
+/* Primary button — ACP dark primary (orange-red) */
+.pf-v5-c-button.pf-m-primary {
+  --pf-v5-c-button--m-primary--BackgroundColor: #f56e6e !important;
+  --pf-v5-c-button--m-primary--hover--BackgroundColor: #e05555 !important;
+  --pf-v5-c-button--m-primary--focus--BackgroundColor: #e05555 !important;
+  --pf-v5-c-button--m-primary--active--BackgroundColor: #e05555 !important;
+  background-color: #f56e6e !important;
+  border-color: #f56e6e !important;
+  color: #151515 !important;
+  font-family: 'Red Hat Text', system-ui, -apple-system, sans-serif !important;
+}
+
+.pf-v5-c-button.pf-m-primary:hover,
+.pf-v5-c-button.pf-m-primary:focus,
+.pf-v5-c-button.pf-m-primary:active {
+  background-color: #e05555 !important;
+  border-color: #e05555 !important;
+}
+
+/* Password visibility toggle — orange-red on hover */
+.pf-v5-c-button.pf-m-control {
+  --pf-v5-c-button--m-control--BackgroundColor: #292929 !important;
+  --pf-v5-c-button--m-control--hover--BackgroundColor: #292929 !important;
+  --pf-v5-c-button--m-control--focus--BackgroundColor: #292929 !important;
+  --pf-v5-c-button--m-control--active--BackgroundColor: #292929 !important;
+  --pf-v5-c-button--m-control--BorderColor: #383838 !important;
+  --pf-v5-c-button--m-control--after--BorderBottomColor: #383838 !important;
+  --pf-v5-c-button--m-control--hover--after--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-button--m-control--focus--after--BorderBottomColor: #f56e6e !important;
+  --pf-v5-c-button--m-control--active--after--BorderBottomColor: #f56e6e !important;
+  background-color: #292929 !important;
+  border-color: #383838 !important;
+  color: #a3a3a3 !important;
+  transition: color 0.2s ease, border-color 0.2s ease !important;
+}
+
+.pf-v5-c-button.pf-m-control::after {
+  border-bottom-color: #383838 !important;
+  transition: border-bottom-color 0.2s ease !important;
+}
+
+.pf-v5-c-button.pf-m-control:hover::after,
+.pf-v5-c-button.pf-m-control:focus::after,
+.pf-v5-c-button.pf-m-control:active::after {
+  border-bottom-color: #f56e6e !important;
+}
+
+.pf-v5-c-button.pf-m-control:hover,
+.pf-v5-c-button.pf-m-control:focus,
+.pf-v5-c-button.pf-m-control:active {
+  color: #f56e6e !important;
+  border-color: #f56e6e !important;
+  background-color: #292929 !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+/* Eye icon inside password toggle — override Font Awesome color */
+.pf-v5-c-button.pf-m-control i.fa-eye,
+.pf-v5-c-button.pf-m-control i.fa-eye-slash,
+.pf-v5-c-button.pf-m-control i.fas,
+.pf-v5-c-button.pf-m-control i,
+.pf-v5-c-button[data-password-toggle] i {
+  color: #a3a3a3 !important;
+  transition: color 0.2s ease !important;
+}
+
+.pf-v5-c-button.pf-m-control:hover i.fa-eye,
+.pf-v5-c-button.pf-m-control:hover i.fa-eye-slash,
+.pf-v5-c-button.pf-m-control:hover i.fas,
+.pf-v5-c-button.pf-m-control:hover i,
+.pf-v5-c-button.pf-m-control:focus i,
+.pf-v5-c-button[data-password-toggle]:hover i {
+  color: #f56e6e !important;
+}
+
+/* Links — orange-red to match brand */
+.pf-v5-c-login__main-footer-links a,
+.pf-v5-c-button.pf-m-link {
+  color: #f56e6e !important;
+}
+
+.pf-v5-c-button.pf-m-link:hover {
+  color: #e05555 !important;
+}
+
+/* Footer */
+.pf-v5-c-login__main-footer {
+  background-color: transparent !important;
+}
+
+/* Alert styling */
+.pf-v5-c-alert {
+  background-color: #292929 !important;
+  border-color: #383838 !important;
+}
+
+.pf-v5-c-alert__title {
+  color: #f2f2f2 !important;
+}
+
+/* Checkbox */
+.pf-v5-c-check__label {
+  color: #a3a3a3 !important;
+}
+
+/* Page footer */
+.pf-v5-c-login__footer {
+  text-align: center !important;
+  color: #a3a3a3 !important;
+  margin-top: 1.5rem !important;
+  grid-area: unset !important;
+}

--- a/components/manifests/overlays/kind/keycloak-theme/messages_en.properties
+++ b/components/manifests/overlays/kind/keycloak-theme/messages_en.properties
@@ -1,0 +1,1 @@
+loginTitleHtml=Agent Control Plane

--- a/components/manifests/overlays/kind/keycloak-theme/theme.properties
+++ b/components/manifests/overlays/kind/keycloak-theme/theme.properties
@@ -1,0 +1,3 @@
+parent=keycloak.v2
+import=common/keycloak
+styles=css/login.css

--- a/components/manifests/overlays/kind/keycloak-theme/theme.properties
+++ b/components/manifests/overlays/kind/keycloak-theme/theme.properties
@@ -1,3 +1,4 @@
+# CSS-only theme (no login.ftl) — avoids Keycloak upgrade friction
 parent=keycloak.v2
 import=common/keycloak
 styles=css/login.css

--- a/components/manifests/overlays/kind/kustomization.yaml
+++ b/components/manifests/overlays/kind/kustomization.yaml
@@ -94,3 +94,11 @@ configMapGenerator:
   - ambient-code-realm.json=keycloak-realm.json
   options:
     disableNameSuffixHash: true
+- name: keycloak-acp-theme
+  files:
+  - theme.properties=keycloak-theme/theme.properties
+  - login.css=keycloak-theme/login.css
+  - acp-logo.svg=keycloak-theme/acp-logo.svg
+  - messages_en.properties=keycloak-theme/messages_en.properties
+  options:
+    disableNameSuffixHash: true


### PR DESCRIPTION
## Summary
<img width="812" height="861" alt="Screenshot 2026-07-07 at 7 29 13 AM" src="https://github.com/user-attachments/assets/2ce98579-1883-4b23-a62b-e3b3007779df" />

- Adds a branded Keycloak login page for the Kind dev overlay with the ACP robot logo (Lucide Bot), "Agent Control Plane" title, and Red Hat Text font
- Uses the ambient-ui dark palette (`#151515` background, `#1f1f1f` card, `#f56e6e` accent) with subtle dot-grid texture
- Theme files are mounted via ConfigMap into the upstream `quay.io/keycloak/keycloak:26.0` image — no custom Docker build needed
- Overrides PatternFly v5 login layout to a centered single-column stack with smooth hover transitions on form controls

## Test plan

- [x] Run `kubectl kustomize components/manifests/overlays/kind/ | kubectl apply -f -` and restart Keycloak
- [x] Visit the Keycloak login page and verify gray background, centered layout, robot logo, and "Agent Control Plane" title
- [x] Verify form input focus and password visibility toggle use orange-red accent (`#f56e6e`), not blue
- [x] Verify hover transitions fade smoothly on input borders and eye icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)