### PR TITLE
spec: replace ConfigMap-based gateway provisioning with API-driven Gateway resource model

### DIFF
--- a/specs/index.spec.md
+++ b/specs/index.spec.md
@@ -26,12 +26,12 @@ Machine-readable index for autonomous reconciliation (`/reconcile` skill).
 
 | Path | Domain | Primary Entities | Components | Depends On |
 |------|--------|-----------------|------------|------------|
-| `platform/data-model.spec.md` | platform | User, Project, Agent, Inbox, Session, SessionMessage, SessionEvent, Role, RoleBinding, Credential, ScheduledSession, Application, ProjectSettings | API, SDK, BE, CLI, CP, FE | - |
+| `platform/data-model.spec.md` | platform | User, Project, Agent, Inbox, Session, SessionMessage, SessionEvent, Role, RoleBinding, Credential, ScheduledSession, Application, Gateway, ProjectSettings | API, SDK, BE, CLI, CP, FE | - |
 | `platform/control-plane.spec.md` | platform | WatchManager, Informer, KubeReconciler | CP, Runner | data-model |
 | `platform/runner.spec.md` | platform | PlatformBridge, GRPCSessionListener, GRPCMessageWriter | Runner, CP | data-model, control-plane |
 | `platform/mcp-server.spec.md` | platform | MCP tools (16) | MCP, CLI, SDK | data-model |
 | `platform/agent-sandbox-config.spec.md` | platform | Agent (sandbox fields), Provider, Policy | CP, BE, API | data-model |
-| `platform/gateway-provisioning.spec.md` | platform | Gateway, PlatformConfig | CP | control-plane |
+| `platform/gateway-provisioning.spec.md` | platform | Gateway, GatewayReconciler, SharedKustomizeLibrary | CP, CLI | control-plane, data-model |
 | `platform/openshell-sandbox-provisioning.spec.md` | platform | Sandbox | CP | gateway-provisioning, agent-sandbox-config |
 | `platform/scheduled-session-execution.spec.md` | platform | ScheduledSession | BE, API, CP | data-model |
 | `platform/session-activity-tracking.spec.md` | platform | Session (last_activity_at) | BE, API | data-model |

--- a/specs/platform/control-plane.spec.md
+++ b/specs/platform/control-plane.spec.md
@@ -67,6 +67,18 @@ Handles `session ADDED` and `session MODIFIED (phase=Pending)` events by provisi
 On `phase=Stopping` → calls `deprovisionSession` (deletes pods).
 On `DELETED` → calls `cleanupSession` (deletes pod, secret, service account, service, namespace).
 
+#### `internal/reconciler/project_reconciler.go` — ProjectReconciler
+
+Watches Project events via gRPC informer. Creates Kubernetes namespaces for each Project via `ensureNamespace()`, provisions runner secrets, and sets up control plane RBAC. Project = Namespace — the ProjectReconciler is the sole owner of namespace lifecycle.
+
+#### `internal/reconciler/gateway_reconciler.go` — GatewayReconciler
+
+Watches Gateway resource events via gRPC informer. Reconciles `kind: Gateway` API resources into Kubernetes gateway deployments (StatefulSet, Service, RBAC, certgen Job, NetworkPolicy) in the project namespace. Replaces the previous ConfigMap-based `internal/gateway/` package. Reuses manifest templating from `internal/gateway/manifests.go` and validation from `internal/gateway/validation.go`. See [gateway-provisioning.spec.md](./gateway-provisioning.spec.md) for the full specification.
+
+#### `internal/reconciler/application_reconciler.go` — ApplicationReconciler
+
+Git-based GitOps reconciler that syncs agent fleet definitions from git repositories. Uses the shared kustomize library (extracted from `acpctl apply`) to render manifests. Supports `kind: Gateway` documents in rendered manifests, applying them to the API server alongside Project, Agent, Credential, and RoleBinding resources.
+
 #### `internal/reconciler/shared.go` — SDKClientFactory
 
 Mints and caches per-project SDK clients. Each project uses the same bearer token but different project context. Also provides `namespaceForSession`, phase constants, and label helpers.
@@ -559,5 +571,8 @@ The `ambient-control-plane` ServiceAccount does not have `delete` on `namespaces
 | Runner SA token for CP auth | K8s SA tokens are already mounted in every pod, long-lived, and K8s-managed — no new secrets or out-of-band key distribution required |
 | CP is sole token source — no BOT_TOKEN Secret | CP creates the runner pod, so it is always reachable before the runner's first token request; retaining a Secret adds complexity and a second failure mode with the same blast radius |
 | `system:image-builder` bound to session SA at provision time | Agents need push access to the internal image registry to build and distribute images; OpenShift grants pull automatically via `system:image-pullers` at namespace init but push requires an explicit RoleBinding; co-locating it with the other session SA grants keeps all RBAC provisioning in one place |
+| Gateway as API resource, not ConfigMap | Gateway configuration lives in PostgreSQL as `kind: Gateway`, applied via `acpctl apply -k`. Eliminates the ConfigMap watcher, `initGatewayProvisioning()`, and the `internal/gateway/config.go` code path. The GatewayReconciler receives events via the same gRPC watch stream as all other resources — unified, testable, composable via kustomize |
+| ProjectReconciler owns namespace lifecycle | Project = Namespace. The ProjectReconciler creates namespaces; the GatewayReconciler deploys gateways into existing namespaces. No ConfigMap needed to declare which namespaces exist |
+| Shared kustomize library | The rendering engine from `acpctl apply` is extracted into a shared library consumed by both the CLI and the ApplicationReconciler, enabling unit testing without a running cluster |
 
 ---

--- a/specs/platform/data-model.spec.md
+++ b/specs/platform/data-model.spec.md
@@ -22,6 +22,7 @@ The Ambient API server provides a coordination layer for orchestrating fleets of
 - **Credential** — a global secret. Stores a Personal Access Token or equivalent for an external provider (GitHub, GitLab, Jira, Google, Vertex AI, Kubeconfig). Consumed by runners at session start. Bound to Projects via RoleBindings — a single Credential can be shared across multiple Projects without duplication.
 - **RoleBinding** — binds a Role to a subject (user or project) at a given scope. Ownership and access for all Kinds is expressed through RoleBindings. The subject and scope are each represented as typed nullable FKs — exactly one FK is non-null, determined by `scope`.
 - **Application** — a GitOps binding that continuously syncs agent fleet definitions from a git repository to an Ambient instance. The Ambient equivalent of an Argo CD Application.
+- **Gateway** — a project-scoped declaration that an OpenShell gateway should be deployed in the project’s namespace. Specifies the gateway image, TLS DNS names, and TOML configuration. Applied via `acpctl apply -k` and reconciled by the GatewayReconciler into Kubernetes resources (StatefulSet, Service, RBAC, certgen Job). See [gateway-provisioning.spec.md](./gateway-provisioning.spec.md).
 
 The stable address of an agent is `{project_name}/{agent_name}`. It holds the inbox and links to the active session.
 
@@ -249,6 +250,22 @@ erDiagram
         time   deleted_at
     }
 
+    %% ── Gateway (project-scoped OpenShell gateway declaration) ──────────
+
+    Gateway {
+        string ID PK "KSUID"
+        string project_id FK "target project (= namespace)"
+        string name "resource name; typically openshell-gateway"
+        string image "nullable — gateway container image; defaults to OPENSHELL_GATEWAY_IMAGE"
+        jsonb  server_dns_names "DNS names for TLS certificate generation"
+        string config "nullable — OpenShell gateway TOML configuration"
+        jsonb  labels
+        jsonb  annotations
+        time   created_at
+        time   updated_at
+        time   deleted_at
+    }
+
     %% ── Application (GitOps sync — Argo CD for Ambient) ──────────────
 
     Application {
@@ -300,6 +317,8 @@ erDiagram
 
     Inbox           }o--o| Agent            : "sent_from"
 
+    Project         ||--o{ Gateway          : "owns"
+
     Application }o--o| Project        : "syncs_to"
     Application }o--o| Credential     : "credential_id"
 
@@ -342,6 +361,7 @@ An Application syncs **project-scoped fleet definitions** — a subset of resour
 | `Agent` | Created or patched within the destination project; prompt, providers, payloads, labels, annotations updated |
 | `Credential` | Created if not present; idempotent by name |
 | `RoleBinding` | Created if not present; idempotent by user+role+scope key. **Escalation-bound:** the sync engine can only create RoleBindings at or below the level of the service credential it uses (see Design Decisions). |
+| `Gateway` | Created or patched within the destination project; image, serverDnsNames, config updated. Reconciled into K8s gateway resources by the GatewayReconciler. |
 | `Inbox` (seed messages) | Idempotent delivery — only new messages (by `from_agent_id` + `body` content hash dedup) are posted. Uses immutable `from_agent_id` FK, not mutable `from_name`. |
 
 ### What Does NOT Get Synced
@@ -1093,6 +1113,7 @@ The `acpctl` CLI mirrors the API 1-for-1. Every REST operation has a correspondi
 | `Project` | `name`, `description`, `prompt`, `labels`, `annotations` |
 | `Agent` | `name`, `prompt`, `providers`, `payloads`, `labels`, `annotations`, `inbox` (seed messages) |
 | `Credential` | `name`, `description`, `provider`, `token` (env var reference), `url`, `email`, `labels`, `annotations` — global resource; use `credential bind` to grant project access |
+| `Gateway` | `name`, `project`, `image`, `serverDnsNames`, `config`, `labels`, `annotations` — project-scoped; declares an OpenShell gateway deployment in the project namespace |
 
 `Agent` resources in `.ambient/teams/` files also carry an `inbox` list of seed messages. On apply, any message in the list is posted to the agent's inbox if an identical message (same `from_name` + `body`) does not already exist there.
 

--- a/specs/platform/gateway-provisioning.spec.md
+++ b/specs/platform/gateway-provisioning.spec.md
@@ -1,104 +1,301 @@
 # Gateway Provisioning Specification
 
-**Date:** 2026-06-26  
+**Date:** 2026-07-07  
 **Status:** Design  
-**Related:** `openshell-sandbox-provisioning.spec.md` — gateway mode usage; `control-plane.spec.md` — CP reconciliation patterns  
+**Supersedes:** Previous ConfigMap-based `platform-config` gateway provisioning design  
+**Related:** `openshell-sandbox-provisioning.spec.md` — gateway mode usage; `control-plane.spec.md` — CP reconciliation patterns; `data-model.spec.md` — Gateway kind definition  
 **Skill:** `skills/build/full-stack-pipeline/` — wave-based implementation pipeline
 
 ---
 
 ## Purpose
 
-The control plane SHALL provision and reconcile OpenShell gateway deployments in project namespaces. This replaces the assumption in `openshell-sandbox-provisioning.spec.md` (Iteration 1) that gateways are pre-installed. The control plane discovers which project namespaces to manage via a platform configuration ConfigMap and applies gateway resource manifests using Kubernetes APIs.
+The control plane SHALL provision and reconcile OpenShell gateway deployments in project namespaces through a fully API-driven model. Gateway configuration is expressed as a first-class ACP resource (`kind: Gateway`), applied via `acpctl apply -k` alongside Project, Agent, Credential, and RoleBinding resources. The API server persists Gateway resources in PostgreSQL. The control plane discovers Gateway resources via the same gRPC watch stream used for all other resources and reconciles them into Kubernetes gateway deployments.
 
-Gateway provisioning is an **infrastructure-layer capability**. Gateway state is NOT stored in PostgreSQL; the platform-config ConfigMap is the source of truth for which namespaces require gateways.
+This replaces the previous ConfigMap-based `platform-config` approach. The ConfigMap, its watcher (`internal/gateway/config.go`), and the `initGatewayProvisioning()` startup path are eliminated.
 
 This enables:
-- **Centralized gateway lifecycle management** — ACP team controls gateway versions
-- **Deterministic deployments** — Gateway manifests versioned with ACP code
-- **Self-service namespace provisioning** — Add namespace to ConfigMap → gateway auto-deploys
-- **Consistent gateway configuration** — All tenants use the same vetted gateway configuration
+- **Unified declarative model** — Gateways are managed with the same `acpctl apply -k` workflow as Projects and Agents
+- **Kustomize composition** — Gateway configuration inherits from bases and is patched via overlays, identical to all other ACP kinds
+- **API-driven lifecycle** — Gateway state lives in PostgreSQL, not in a ConfigMap; standard CRUD operations apply
+- **Shared kustomize library** — The rendering engine is extracted from `acpctl apply` into a reusable library consumed by both the CLI and the ApplicationReconciler
+- **Full testability** — The shared kustomize library is unit-testable without a running cluster; `--dry-run` validates the full rendering pipeline
+
+---
+
+## Architecture
+
+### Flow
+
+```
+acpctl apply -k overlays/tenant-a/
+    │  renders kustomization.yaml (Project + Gateway + Agents + Credentials)
+    │  POST/PATCH each resource to API server
+    ▼
+API Server (PostgreSQL)
+    │  persists Gateway resource
+    │  emits gRPC watch event
+    ▼
+Control Plane — GatewayReconciler (internal/reconciler/)
+    │  receives Gateway ADDED/MODIFIED event
+    │  validates image, DNS names, TOML config
+    │  applies gateway K8s manifests to the project namespace
+    ▼
+Kubernetes (StatefulSet, Service, RBAC, certgen Job, NetworkPolicy)
+```
+
+### Relationship to Projects
+
+**Project = Namespace.** The ProjectReconciler already creates a Kubernetes namespace for each Project via `ensureNamespace()`. A Gateway resource references a Project by name. When the GatewayReconciler processes a Gateway event, the target namespace already exists because the ProjectReconciler runs first in the reconciler chain.
+
+### Relationship to ApplicationReconciler
+
+The ApplicationReconciler performs GitOps continuous sync from git repositories. It uses the shared kustomize library to render manifests, which may include `kind: Gateway` documents. The sync engine applies Gateway resources to the API server just like any other kind. The GatewayReconciler then reconciles them into Kubernetes.
 
 ---
 
 ## Requirements
 
-### Requirement: Platform Configuration Discovery
+### Requirement: Gateway as API Resource
 
-The control plane SHALL read gateway configuration from a ConfigMap named `platform-config` in its own namespace. This ConfigMap SHALL contain a list of namespaces that the control plane is responsible for managing.
+Gateway SHALL be a first-class ACP resource kind, persisted in PostgreSQL and exposed via the REST API under the project scope. The Gateway resource declares that a project namespace should have an OpenShell gateway deployed with specific configuration.
 
-#### Scenario: Load platform configuration on startup
+#### Scenario: Create a Gateway via acpctl apply
 
-- GIVEN ACP starts up
-- AND a ConfigMap named `platform-config` exists in the ACP namespace
-- AND the ConfigMap contains a `namespaces` key with a YAML list
-- WHEN ACP loads configuration
-- THEN ACP SHALL parse the namespace list
-- AND ACP SHALL store the list of project namespaces in memory
+- GIVEN a kustomize overlay containing a `gateway.yaml`:
+  ```yaml
+  kind: Gateway
+  name: openshell-gateway
+  project: tenant-a
+  image: ghcr.io/nvidia/openshell:v0.0.70
+  serverDnsNames:
+    - openshell-gateway.tenant-a.svc.cluster.local
+  config: |
+    [openshell.gateway]
+    bind_address = "0.0.0.0:8080"
+  ```
+- WHEN a user runs `acpctl apply -k overlays/tenant-a/`
+- THEN the CLI SHALL render the kustomization and POST the Gateway resource to the API server
+- AND the API server SHALL persist the Gateway in PostgreSQL
+- AND the API server SHALL emit a gRPC watch event for the new Gateway
+- AND the GatewayReconciler SHALL receive the event and deploy gateway K8s resources to the `tenant-a` namespace
 
-#### Scenario: Platform ConfigMap not found
+#### Scenario: Update a Gateway via overlay patch
 
-- GIVEN ACP starts up
-- AND the ConfigMap `platform-config` does NOT exist in the ACP namespace
-- WHEN ACP attempts to load configuration
-- THEN ACP SHALL log an error "platform-config ConfigMap not found"
-- AND ACP SHALL NOT proceed with gateway deployments
-- AND ACP SHALL retry loading the ConfigMap periodically
+- GIVEN a Gateway already exists for `tenant-a` with image `v0.0.70`
+- AND a kustomize patch changes the image to `v0.0.71`
+- WHEN a user runs `acpctl apply -k overlays/tenant-a/`
+- THEN the CLI SHALL PATCH the existing Gateway resource
+- AND the GatewayReconciler SHALL detect the change and update the gateway Deployment
 
-#### Scenario: Platform ConfigMap malformed
+#### Scenario: Gateway without a corresponding Project
 
-- GIVEN the `platform-config` ConfigMap exists
-- AND the `namespaces` key contains invalid YAML
-- WHEN ACP attempts to parse the ConfigMap
-- THEN ACP SHALL log an error with parse failure details
-- AND ACP SHALL NOT proceed with gateway deployments
-- AND ACP SHALL wait for the ConfigMap to be corrected
-
-#### Scenario: Platform ConfigMap updated at runtime
-
-- GIVEN ACP is running with `platform-config` loaded in memory
-- AND an admin updates the `platform-config` ConfigMap
-- WHEN ACP detects the ConfigMap change
-- THEN ACP SHALL reload the ConfigMap
-- AND ACP SHALL update its in-memory namespace list
-- AND ACP SHALL reconcile gateways based on the new configuration
-- AND ACP SHALL deploy gateways for newly added namespaces
-- AND ACP SHALL update gateway configurations for modified namespaces
+- GIVEN a Gateway resource references project `nonexistent`
+- AND no Project named `nonexistent` exists
+- WHEN the Gateway is applied
+- THEN the API server SHALL accept and persist the Gateway (eventual consistency)
+- AND the GatewayReconciler SHALL log a warning and skip reconciliation until the Project (and namespace) exists
 
 ---
 
-### Requirement: Namespace Validation
+### Requirement: Shared Kustomize Library
 
-For each namespace listed in the platform configuration, the control plane SHALL verify that the namespace exists in the cluster before attempting to deploy a gateway.
+The kustomize rendering engine SHALL be extracted from `acpctl apply/cmd.go` into a shared library package. This library SHALL be consumed by both the CLI (`acpctl apply`) and the ApplicationReconciler.
 
-#### Scenario: All namespaces exist
+#### Scenario: Library extraction
 
-- GIVEN `platform-config` lists namespaces: `tenant-alpha`, `tenant-beta`, `tenant-gamma`
-- AND all three namespaces exist in the cluster
-- WHEN ACP validates namespaces
-- THEN ACP SHALL proceed with gateway reconciliation for all three namespaces
+- GIVEN the kustomize engine currently lives in `components/ambient-cli/cmd/acpctl/apply/cmd.go`
+- WHEN the shared library is created
+- THEN it SHALL be placed in a package accessible to both the CLI and the control plane (e.g., `components/ambient-sdk/go-sdk/kustomize/`)
+- AND it SHALL expose functions for: loading a kustomization directory, resolving bases, merging resources, applying strategic-merge patches, and producing a flat manifest stream
+- AND the existing `acpctl apply` command SHALL be refactored to use the shared library
+- AND the ApplicationReconciler SHALL be updated to use the shared library for rendering
 
-#### Scenario: Namespace does not exist
+#### Scenario: Supported kinds
 
-- GIVEN `platform-config` lists namespace `tenant-nonexistent`
-- AND this namespace does NOT exist in the cluster
-- WHEN ACP validates namespaces
-- THEN ACP SHALL log an error "namespace tenant-nonexistent not found"
-- AND ACP SHALL skip gateway deployment for that namespace
-- AND ACP SHALL continue processing other valid namespaces
-- AND ACP SHALL NOT crash or enter a crash loop
+- GIVEN the shared kustomize library renders manifests
+- THEN it SHALL support the following ACP resource kinds:
+  - `Project`
+  - `Agent`
+  - `Credential`
+  - `RoleBinding`
+  - `Gateway` *(new)*
+- AND documents with unrecognized `kind` values SHALL be skipped with a warning
 
-#### Scenario: Namespace deleted at runtime
+#### Scenario: Unit testability
 
-- GIVEN ACP is managing `tenant-alpha` with a deployed gateway
-- AND `platform-config` still lists `tenant-alpha`
-- WHEN an admin deletes the namespace from the cluster
-- THEN ACP SHALL detect the missing namespace in the next reconcile cycle
-- AND ACP SHALL log a warning "namespace tenant-alpha listed in config but not found in cluster"
-- AND ACP SHALL skip that namespace until it reappears or is removed from the ConfigMap
-- AND the UI SHALL display the namespace in an "error" state with message "namespace not found in cluster"
+- GIVEN the shared kustomize library
+- THEN it SHALL be fully unit-testable without a running cluster or API server
+- AND tests SHALL cover: base resolution, resource merging, strategic-merge patch semantics (scalar overwrite, map merge, sequence replace), `--dry-run` output, multi-document YAML, kind filtering, and error cases (missing bases, invalid YAML, circular references)
 
-**Note:** UI error state integration with existing namespace status representation is described in #158.
+---
+
+### Requirement: GatewayReconciler
+
+The control plane SHALL include a GatewayReconciler in `internal/reconciler/` that watches Gateway resource events via the gRPC informer and reconciles them into Kubernetes gateway deployments. This replaces the `internal/gateway/` package and the ConfigMap watcher.
+
+#### Scenario: Gateway ADDED event
+
+- GIVEN the GatewayReconciler receives a Gateway ADDED event
+- AND the target namespace exists (created by ProjectReconciler)
+- WHEN the reconciler processes the event
+- THEN it SHALL validate the Gateway configuration (image reference, DNS names, TOML config)
+- AND it SHALL apply gateway K8s manifests to the namespace: StatefulSet, Service, ServiceAccount, RBAC, certgen Job, ConfigMap, NetworkPolicy
+- AND all resources SHALL carry the label `ambient-code.io/managed-by=ambient-control-plane`
+- AND the reconciler SHALL use update-or-create semantics (SSA or equivalent)
+
+#### Scenario: Gateway MODIFIED event
+
+- GIVEN the GatewayReconciler receives a Gateway MODIFIED event
+- WHEN the reconciler processes the event
+- THEN it SHALL detect changes (image version, config, DNS names)
+- AND it SHALL update the affected K8s resources
+- AND the update SHALL be a rolling update for StatefulSets (zero downtime)
+
+#### Scenario: Gateway DELETED event
+
+- GIVEN the GatewayReconciler receives a Gateway DELETED event
+- WHEN the reconciler processes the event
+- THEN it SHALL delete gateway K8s resources from the namespace
+- AND it SHALL NOT delete the namespace itself (namespace lifecycle is owned by ProjectReconciler)
+
+#### Scenario: Validation failure
+
+- GIVEN a Gateway resource with an invalid image reference or malformed TOML config
+- WHEN the GatewayReconciler processes the event
+- THEN it SHALL log a validation error with the Gateway name and project
+- AND it SHALL NOT apply any K8s resources
+- AND it SHALL retry on the next reconciliation cycle
+
+#### Scenario: Namespace not yet ready
+
+- GIVEN the GatewayReconciler receives a Gateway event
+- AND the target namespace does not exist yet (ProjectReconciler hasn't processed the Project)
+- WHEN the reconciler processes the event
+- THEN it SHALL log a warning and skip reconciliation
+- AND it SHALL retry when the namespace becomes available
+
+---
+
+### Requirement: Gateway Manifest Templating
+
+The GatewayReconciler SHALL load gateway resource manifests from the container filesystem and apply namespace-specific substitutions. This reuses the existing manifest loading and templating logic from the `internal/gateway/manifests.go` module.
+
+#### Scenario: Load gateway manifests from filesystem
+
+- GIVEN the ACP container includes gateway manifests at `/manifests/gateway/`
+- WHEN the GatewayReconciler loads manifests
+- THEN it SHALL read all YAML files from the manifests directory
+- AND it SHALL parse each file into Kubernetes resource objects
+- AND it SHALL substitute `NAMESPACE_PLACEHOLDER` with the target namespace name
+- AND it SHALL substitute `IMAGE_PLACEHOLDER` with the Gateway resource's `image` field
+
+#### Scenario: Required manifest files missing
+
+- GIVEN the `/manifests/gateway/` directory is missing or empty
+- WHEN the GatewayReconciler attempts to load manifests
+- THEN it SHALL log an error and fail gracefully
+- AND it SHALL NOT crash the control plane
+
+---
+
+### Requirement: Gateway Configuration Validation
+
+The GatewayReconciler SHALL validate Gateway resource fields before applying K8s manifests. Validation logic is reused from `internal/gateway/validation.go`.
+
+#### Scenario: Valid Gateway configuration
+
+- GIVEN a Gateway with a valid image reference, RFC-1123-compliant DNS names, and valid TOML config
+- WHEN the GatewayReconciler validates the configuration
+- THEN validation SHALL pass and reconciliation SHALL proceed
+
+#### Scenario: Invalid image reference
+
+- GIVEN a Gateway with an image reference containing invalid characters
+- WHEN the GatewayReconciler validates the configuration
+- THEN validation SHALL fail with a descriptive error
+- AND the Gateway SHALL not be reconciled until the configuration is corrected
+
+#### Scenario: Invalid DNS name
+
+- GIVEN a Gateway with a `serverDnsNames` entry that violates RFC 1123
+- WHEN the GatewayReconciler validates the configuration
+- THEN validation SHALL fail with a descriptive error listing the invalid DNS name
+
+---
+
+### Requirement: Kustomize Overlay Structure for Gateways
+
+Gateway resources SHALL be expressible in the existing `examples/` kustomize overlay structure alongside Project, Agent, and Credential resources.
+
+#### Scenario: Gateway in a tenant overlay
+
+- GIVEN the directory `examples/overlays/tenant-a/`:
+  ```
+  kustomization.yaml
+  project.yaml          # kind: Project
+  gateway.yaml          # kind: Gateway
+  providers/
+    github.yaml         # kind: Credential
+  ```
+- AND `kustomization.yaml` references all resources:
+  ```yaml
+  kind: Kustomization
+  bases:
+    - ../../base
+  resources:
+    - project.yaml
+    - gateway.yaml
+  ```
+- WHEN a user runs `acpctl apply -k examples/overlays/tenant-a/`
+- THEN the Project, Gateway, Agents (from base), and Credentials SHALL all be applied in order
+- AND the ProjectReconciler SHALL create the namespace
+- AND the GatewayReconciler SHALL deploy the gateway into that namespace
+
+#### Scenario: Gateway base with per-tenant patches
+
+- GIVEN a base gateway configuration in `examples/base/gateway.yaml`:
+  ```yaml
+  kind: Gateway
+  name: openshell-gateway
+  image: ghcr.io/nvidia/openshell:v0.0.70
+  serverDnsNames: []
+  ```
+- AND a tenant overlay patches the DNS names:
+  ```yaml
+  kind: Gateway
+  name: openshell-gateway
+  project: tenant-a
+  serverDnsNames:
+    - openshell-gateway.tenant-a.svc.cluster.local
+  ```
+- WHEN the kustomize engine resolves the overlay
+- THEN the merged Gateway SHALL have the base image and the overlay's DNS names and project
+
+---
+
+### Requirement: Elimination of ConfigMap-Based Provisioning
+
+The ConfigMap-based `platform-config` gateway provisioning path SHALL be removed.
+
+#### Scenario: Removed components
+
+- WHEN the migration is complete
+- THEN the following SHALL be deleted:
+  - `internal/gateway/config.go` — ConfigMap schema, loader, watcher
+  - `internal/gateway/reconciler.go` — ConfigMap-driven gateway reconciler (logic moves to GatewayReconciler)
+  - `initGatewayProvisioning()` in `main.go` — ConfigMap watcher startup
+  - `components/manifests/overlays/kind/platform-config.yaml` — ConfigMap overlay
+- AND the following SHALL be preserved and reused by the GatewayReconciler:
+  - `internal/gateway/manifests.go` — manifest loading and templating
+  - `internal/gateway/validation.go` — configuration validation
+
+#### Scenario: No ConfigMap required for gateway mode
+
+- GIVEN `OPENSHELL_USE_GATEWAY=true`
+- WHEN the control plane starts
+- THEN it SHALL NOT look for a `platform-config` ConfigMap
+- AND gateway provisioning SHALL be driven entirely by Gateway API resources received via gRPC watch events
 
 ---
 
@@ -120,7 +317,7 @@ Control Plane
 
 This follows the same pattern used by the OpenShell CLI for file uploads (`ssh_tar_upload` in `openshell-cli`). A single SSH connection is established per upload batch — individual payloads each open an SSH session (channel) within that connection.
 
-**Path validation:** Before constructing the shell command, each `sandbox_path` is validated against the regex `^/[a-zA-Z0-9/_.\-]+$` and checked for `..` traversal segments. Paths that fail validation are rejected before any SSH session is opened. This prevents shell injection via crafted payload paths in agent ConfigMaps. The path constraint is defined in `agent-sandbox-config.spec.md` § Payloads.
+**Path validation:** Before constructing the shell command, each `sandbox_path` is validated against the regex `^/[a-zA-Z0-9/_.\\-]+$` and checked for `..` traversal segments. Paths that fail validation are rejected before any SSH session is opened. This prevents shell injection via crafted payload paths in agent ConfigMaps. The path constraint is defined in `agent-sandbox-config.spec.md` § Payloads.
 
 **SSH security model:** The SSH connection uses `InsecureIgnoreHostKey()` (no host key verification) and `ssh.Password("")` (no-credential auth). This matches the OpenShell upstream pattern:
 - The sandbox SSH server (`openshell-supervisor-process/src/ssh.rs`) generates ephemeral Ed25519 host keys on each boot — there is no stable identity to verify
@@ -144,7 +341,7 @@ Security is enforced at layers below SSH:
 - AND it SHALL open a `ForwardTcp` bidirectional gRPC stream
 - AND it SHALL send a `TcpForwardInit` frame with `SshRelayTarget` and the authorization token
 - AND it SHALL perform an SSH handshake over the gRPC stream using `golang.org/x/crypto/ssh`
-- AND it SHALL validate each `sandbox_path` against the path allowlist (`^/[a-zA-Z0-9/_.\-]+$`, no `..` traversal) before constructing any shell command
+- AND it SHALL validate each `sandbox_path` against the path allowlist (`^/[a-zA-Z0-9/_.\\-]+$`, no `..` traversal) before constructing any shell command
 - AND it SHALL write each payload by executing `mkdir -p '<dir>' && cat > '<path>'` via an SSH session with the file content piped to stdin
 - AND it SHALL reuse the same SSH connection for all payloads in the batch
 
@@ -167,49 +364,12 @@ Security is enforced at layers below SSH:
 
 ---
 
-### Requirement: Gateway Manifest Loading
+### Requirement: Gateway Deployment Resources
 
-The control plane SHALL load gateway resource manifests from its container filesystem. Gateway manifests SHALL be stored in the ACP codebase and packaged into the ACP container image.
-
-Gateway manifests SHALL be generated via `helm template` with namespace-specific configuration from the platform ConfigMap, including:
-- `gateway.image` → image reference
-- `gateway.serverDnsNames` → PKI init job serverDnsNames (e.g., `openshell-gateway.<namespace>.svc.cluster.local`)
-- `gateway.config` → TOML configuration injected into gateway ConfigMap
-
-**Helm command reference:**
-```bash
-helm template openshell-gateway oci://ghcr.io/nvidia/openshell/helm-chart \
-  --namespace <tenant-namespace> \
-  --set "pkiInitJob.serverDnsNames={openshell-gateway.<tenant-namespace>.svc.cluster.local}"
-```
-
-The generated manifests SHALL be placed at `components/ambient-control-plane/manifests/gateway/` in the ACP codebase and packaged into the container image.
-
-#### Scenario: Load gateway manifests from filesystem
-
-- GIVEN ACP container includes gateway manifests at `/manifests/gateway/`
-- AND the directory contains files: `deployment.yaml`, `service.yaml`, `serviceaccount.yaml`, `rbac.yaml`
-- WHEN ACP loads gateway manifests
-- THEN ACP SHALL read all YAML files from the manifests directory
-- AND ACP SHALL parse each file into Kubernetes resource objects
-
-#### Scenario: Required manifest file missing
-
-- GIVEN ACP container is expected to have `/manifests/gateway/deployment.yaml`
-- AND this file does NOT exist
-- WHEN ACP attempts to load manifests
-- THEN ACP SHALL log an error "required manifest file not found: /manifests/gateway/deployment.yaml"
-- AND ACP SHALL NOT proceed with gateway deployments
-- AND ACP SHALL exit with a non-zero code
-
----
-
-### Requirement: Gateway Deployment
-
-For each project namespace, the control plane SHALL deploy an OpenShell gateway by applying the loaded manifests to the namespace. The gateway SHALL consist of a Deployment, Service, ServiceAccount, and RBAC resources.
+For each Gateway resource, the GatewayReconciler SHALL deploy the following Kubernetes resources into the project namespace:
 
 All gateway resources SHALL use fixed names:
-- Deployment: `openshell-gateway`
+- StatefulSet: `openshell-gateway`
 - Service: `openshell-gateway`
 - ServiceAccount: `openshell-gateway`
 - Role: `openshell-gateway`
@@ -219,167 +379,48 @@ All gateway resources SHALL carry the following labels:
 - `app.kubernetes.io/name=openshell`
 - `app.kubernetes.io/component=gateway`
 - `app.kubernetes.io/managed-by=agent-control-plane`
+- `ambient-code.io/managed=true`
 
-The gateway Deployment SHALL specify:
+The gateway StatefulSet SHALL specify:
 - **SecurityContext:** `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, capabilities `drop: [ALL]`
 - **Resource requests:** `cpu: 100m`, `memory: 256Mi`
 - **Resource limits:** `cpu: 500m`, `memory: 512Mi`
 
-Gateway resources SHALL NOT have OwnerReferences (consistent with current session pod pattern where resources are managed via labels, not ownership chains).
+#### Scenario: Deploy gateway to project namespace
 
-#### Scenario: Deploy gateway to empty namespace
-
-- GIVEN `tenant-alpha` namespace exists
-- AND no OpenShell gateway is deployed in `tenant-alpha`
-- WHEN ACP reconciles gateways
-- THEN ACP SHALL apply all gateway manifests to `tenant-alpha`
-- AND each resource SHALL have its namespace field set to `tenant-alpha`
-- AND the gateway Deployment SHALL be created
-- AND the gateway Service SHALL be created with label `app.kubernetes.io/name=openshell`
-- AND the ServiceAccount and RBAC resources SHALL be created
+- GIVEN a Gateway resource exists for project `tenant-a`
+- AND the namespace `tenant-a` exists (created by ProjectReconciler)
+- WHEN the GatewayReconciler reconciles
+- THEN it SHALL apply all gateway manifests with namespace set to `tenant-a`
+- AND it SHALL use update-or-create semantics (never create-and-ignore-AlreadyExists)
 
 #### Scenario: Gateway already exists (idempotency)
 
-- GIVEN `tenant-alpha` has an OpenShell gateway already deployed
-- AND `platform-config` lists `tenant-alpha`
-- WHEN ACP reconciles gateways
-- THEN ACP SHALL detect the existing gateway via Service label `app.kubernetes.io/name=openshell`
-- AND ACP SHALL apply the latest gateway configurations using client-go Server-Side Apply (SSA) or equivalent
-- AND ACP SHALL NOT create duplicate resources
-- AND ACP MAY verify the gateway is healthy
-
-#### Scenario: Multiple namespaces, parallel deployment
-
-- GIVEN `platform-config` lists 10 namespaces without gateways
-- WHEN ACP reconciles gateways on startup
-- THEN ACP SHALL deploy gateways to all 10 namespaces
-- AND deployments MAY execute in parallel
-- AND failure in one namespace SHALL NOT block deployments in other namespaces
-
----
-
-### Requirement: Gateway Discovery
-
-The control plane SHALL discover existing gateways in a namespace by looking for a Service with the label `app.kubernetes.io/name=openshell`.
-
-#### Scenario: Gateway detected via Service label
-
-- GIVEN `tenant-alpha` has a Service with label `app.kubernetes.io/name=openshell`
-- WHEN ACP checks for an existing gateway
-- THEN ACP SHALL consider the gateway as already deployed
-- AND ACP SHALL NOT attempt to create a new gateway
-
-#### Scenario: Service exists but Deployment missing
-
-- GIVEN `tenant-alpha` has a Service with label `app.kubernetes.io/name=openshell`
-- AND the corresponding Deployment does NOT exist
-- WHEN ACP reconciles gateways
-- THEN ACP SHALL detect the inconsistent state
-- AND ACP SHALL create the missing Deployment
-- AND ACP SHALL log a warning "inconsistent state detected: Service exists without Deployment"
-
----
-
-### Requirement: Gateway Version Updates
-
-When the gateway manifests in the ACP codebase are updated, the control plane SHALL detect drift between deployed gateway resources and the new manifests, and update the deployed resources accordingly.
-
-Drift detection enables automated gateway updates without manual intervention. When ACP is upgraded with new gateway manifests (e.g., new image version, configuration changes), it SHALL automatically roll out the updates to all managed namespaces.
-
-#### Scenario: Detect drift after ACP upgrade
-
-- GIVEN `tenant-alpha` has gateway v0.0.70 deployed
-- AND ACP is upgraded with manifests specifying gateway v0.0.71
-- WHEN ACP reconciles gateways after the upgrade
-- THEN ACP SHALL detect that the deployed Deployment differs from the manifest
-- AND ACP SHALL update the Deployment to v0.0.71
-- AND the update SHALL be a rolling update (zero downtime)
-
-**Note:** Drift detection mechanism (template hash annotations, image tag comparison, resource spec comparison) is implementation-specific.
-
----
-
-### Requirement: Dynamic Configuration Updates
-
-The control plane SHALL detect changes to the platform-config ConfigMap and reconcile gateway state accordingly.
-
-When a new namespace is added to the platform configuration, the control plane SHALL deploy a gateway to the new namespace.
-
-**Note:** Implementation MAY use Kubernetes ConfigMap watch (recommended) or periodic polling to detect configuration changes.
-
-#### Scenario: New namespace added to ConfigMap
-
-- GIVEN ACP is managing `tenant-alpha` and `tenant-beta`
-- AND an admin updates `platform-config` to add `tenant-gamma`
-- WHEN ACP detects the ConfigMap change
-- THEN ACP SHALL validate that `tenant-gamma` namespace exists
-- AND ACP SHALL deploy a gateway to `tenant-gamma`
-- AND the existing gateways in `tenant-alpha` and `tenant-beta` SHALL NOT be modified
+- GIVEN `tenant-a` has an OpenShell gateway already deployed
+- WHEN the GatewayReconciler reconciles again
+- THEN it SHALL apply the latest configuration using SSA or equivalent
+- AND it SHALL NOT create duplicate resources
 
 ---
 
 ### Requirement: Gateway Deployment Failure Handling
 
-When gateway deployment fails (e.g., ImagePullBackOff, insufficient permissions), the control plane SHALL log the error and retry on subsequent reconcile cycles without crashing.
+When gateway deployment fails (e.g., ImagePullBackOff, insufficient permissions), the GatewayReconciler SHALL log the error and retry on subsequent reconcile cycles without crashing.
 
 #### Scenario: Image pull failure
 
-- GIVEN ACP attempts to deploy a gateway to `tenant-alpha`
-- AND the gateway manifest specifies an image that does not exist
+- GIVEN a Gateway resource specifies an image that does not exist
 - WHEN Kubernetes attempts to pull the image
-- THEN the Deployment SHALL enter ImagePullBackOff state
-- AND ACP SHALL log an error with the namespace and failure reason
-- AND ACP SHALL retry on the next reconcile cycle
-- AND ACP SHALL NOT mark the namespace as permanently failed
+- THEN the StatefulSet SHALL enter ImagePullBackOff state
+- AND the GatewayReconciler SHALL log an error with the Gateway name, project, and failure reason
+- AND the GatewayReconciler SHALL retry on the next reconcile cycle
 
 #### Scenario: Insufficient RBAC permissions
 
-- GIVEN ACP ServiceAccount does NOT have permission to create Deployments in `tenant-alpha`
-- WHEN ACP attempts to apply gateway manifests
+- GIVEN the CP ServiceAccount does NOT have permission to create StatefulSets in a namespace
+- WHEN the GatewayReconciler attempts to apply gateway manifests
 - THEN the Kubernetes API SHALL return a Forbidden error
-- AND ACP SHALL log an error "insufficient permissions to create Deployment in namespace tenant-alpha"
-- AND ACP SHALL continue processing other namespaces where it has permissions
-
----
-
-### Requirement: Platform ConfigMap Gateway Configuration Mandatory
-
-When a namespace entry exists in the platform configuration, it MUST include gateway configuration. If gateway configuration is missing, the control plane SHALL log an error and skip that namespace.
-
-This requirement ensures explicit configuration for all gateways and prevents unexpected deployments with unconfigured gateway instances.
-
-#### Scenario: Namespace with missing gateway configuration
-
-- GIVEN `OPENSHELL_USE_GATEWAY=true` in ACP environment
-- AND `platform-config` contains:
-  ```yaml
-  namespaces:
-    - name: tenant-alpha
-  ```
-- WHEN ACP processes the ConfigMap
-- THEN ACP SHALL log an error "namespace tenant-alpha missing required gateway configuration"
-- AND ACP SHALL skip gateway deployment for that namespace
-- AND ACP SHALL continue processing other namespaces
-
-#### Scenario: Namespace with complete gateway configuration
-
-- GIVEN `platform-config` contains:
-  ```yaml
-  namespaces:
-    - name: tenant-alpha
-      gateway:
-        image: ghcr.io/nvidia/openshell:v0.0.70
-        serverDnsNames:
-          - openshell-gateway.tenant-alpha.svc.cluster.local
-        config: |
-          [openshell.gateway]
-          bind_address = "0.0.0.0:8080"
-  ```
-- WHEN ACP processes the ConfigMap
-- THEN ACP SHALL deploy the gateway to `tenant-alpha` with the specified configuration
-- AND no namespace-specific customization SHALL be applied
-
-**Note:** If `OPENSHELL_USE_GATEWAY=false` or the feature is disabled, missing gateway configuration SHALL NOT trigger errors.
+- AND the GatewayReconciler SHALL log an error and continue processing other Gateway resources
 
 ---
 
@@ -387,39 +428,60 @@ This requirement ensures explicit configuration for all gateways and prevents un
 
 Gateway provisioning SHALL be independent of agent definitions. Agent-specific configuration (schedules, prompts, policies) is out of scope for this specification.
 
-**Note:** Future work may introduce per-tenant agent ConfigMaps that ACP discovers, but the schema and discovery mechanism are not defined in this specification.
-
 ---
 
 ## Migration
 
 ### Relationship to Existing Specs
 
-This specification supersedes the "Gateway provisioning" constraint in `openshell-sandbox-provisioning.spec.md` (line 20-22), which stated:
+This specification supersedes the "Gateway provisioning" constraint in `openshell-sandbox-provisioning.spec.md` (Iteration 1), which stated:
 
 > "Gateway provisioning — the OpenShell gateway is assumed to already be deployed in each project namespace; ACP will not create it. A future iteration should have the control plane provision and reconcile gateway lifecycle per project namespace..."
 
-This specification IS that future iteration.
+This specification IS that future iteration, implemented through the API-driven Gateway resource model rather than the previously designed ConfigMap-based approach.
+
+### Removed Components
+
+| Component | Disposition |
+|---|---|
+| `internal/gateway/config.go` | Deleted — ConfigMap schema, loader, watcher eliminated |
+| `internal/gateway/reconciler.go` | Logic moves to `internal/reconciler/gateway_reconciler.go` |
+| `initGatewayProvisioning()` in `main.go` | Deleted — no ConfigMap watcher startup needed |
+| `platform-config` ConfigMap and overlays | Deleted — replaced by `kind: Gateway` API resources |
+| `internal/gateway/manifests.go` | Preserved — reused by GatewayReconciler |
+| `internal/gateway/validation.go` | Preserved — reused by GatewayReconciler |
+
+### New Components
+
+| Component | Purpose |
+|---|---|
+| `internal/reconciler/gateway_reconciler.go` | Watches Gateway gRPC events, reconciles K8s gateway resources |
+| Shared kustomize library (e.g., `ambient-sdk/go-sdk/kustomize/`) | Extracted from `acpctl apply`; consumed by CLI and ApplicationReconciler |
+| `kind: Gateway` API resource | PostgreSQL-backed, REST API, gRPC watch events |
+| `examples/overlays/*/gateway.yaml` | Per-tenant Gateway declarations in kustomize overlays |
+| `examples/base/gateway.yaml` | Base Gateway configuration for overlay inheritance |
 
 ### Backward Compatibility
 
-This is a new capability. When disabled (no `platform-config` ConfigMap), ACP behavior is unchanged — it will not attempt to manage gateways.
-
-When enabled, this specification does NOT conflict with:
-- Existing gateway mode (`OPENSHELL_USE_GATEWAY=true`) — that controls whether sessions use the gateway for sandboxing
-- File mode (`OPENSHELL_ENABLED=true`) — unaffected
-- Direct pod mode (`OPENSHELL_USE_GATEWAY=false`, `OPENSHELL_ENABLED=false`) — unaffected
+When `OPENSHELL_USE_GATEWAY=false` (the default), all behavior is identical to the current system. The GatewayReconciler is only active when `OPENSHELL_USE_GATEWAY=true` and Gateway resources exist.
 
 ### Existing Consumers
 
 | Consumer | Impact |
 |---|---|
-| `kube_reconciler.go` | No changes — gateway provisioning is a separate reconciler |
+| `kube_reconciler.go` | No changes — continues to use gateways for sandbox creation |
 | `openshell/gateway_client.go` | No changes — continues to use gateways for sandbox creation |
 | `pod_sync.go` | No changes |
-| `StandardNamespaceProvisioner` | No changes — continues to create/verify namespaces as before |
+| `ApplicationReconciler` | Updated to use shared kustomize library; now supports `kind: Gateway` in rendered manifests |
+| `acpctl apply` | Refactored to use shared kustomize library; now supports `kind: Gateway` |
 
-**Note:** Namespaces MAY be managed by ACP (current behavior) or externally via App Interface. Gateway provisioning works with both models — it only requires that namespaces exist before gateway deployment.
+---
+
+## RBAC Requirements
+
+The ACP ServiceAccount SHALL have sufficient permissions to:
+- Watch Gateway resources via gRPC (existing API server watch mechanism)
+- Create, update, patch, and get StatefulSets, Services, ServiceAccounts, Roles, RoleBindings, ConfigMaps, Jobs, and NetworkPolicies in project namespaces
 
 ---
 
@@ -427,70 +489,38 @@ When enabled, this specification does NOT conflict with:
 
 ### Environment Variables
 
-No new environment variables are required. Gateway provisioning is enabled by the presence OPENSHELL_USE_GATEWAY=true
+No new environment variables are required for gateway provisioning. Gateway configuration is expressed declaratively via `kind: Gateway` resources. The existing `OPENSHELL_USE_GATEWAY=true` flag enables gateway mode, and the GatewayReconciler activates when Gateway resources are present.
 
-### ConfigMap Schema
+### Gateway Resource Schema
 
-**Name:** `platform-config`  
-**Namespace:** Same namespace where ACP is deployed (e.g., `ambient-code`)
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `name` | Yes | — | Resource name (typically `openshell-gateway`) |
+| `project` | Yes | — | Project name (determines target namespace) |
+| `image` | No | `OPENSHELL_GATEWAY_IMAGE` env var | Gateway container image reference |
+| `serverDnsNames` | Yes | — | DNS names for TLS certificate generation |
+| `config` | No | — | OpenShell gateway TOML configuration (overrides defaults) |
 
-**Required Keys:**
-- `namespaces` (string, YAML format) — List of namespace objects with gateway configuration
+### Example
 
-**Example:**
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: platform-config
-  namespace: ambient-code
-data:
-  namespaces: |
-    - name: tenant-alpha
-      gateway:
-        image: ghcr.io/nvidia/openshell:v0.0.70
-        serverDnsNames:
-          - openshell-gateway.tenant-alpha.svc.cluster.local
-        config: |
-          [openshell.gateway]
-          bind_address = "0.0.0.0:8080"
-          log_level = "info"
-          sandbox_namespace = "tenant-alpha"
-          default_image = "ghcr.io/nvidia/openshell-community/sandboxes/base:latest"
-          supervisor_image = "ghcr.io/nvidia/openshell/supervisor:0.0.63"
-          
-          [openshell.gateway.auth]
-          allow_unauthenticated_users = true
-    
-    - name: tenant-beta
-      gateway:
-        image: ghcr.io/nvidia/openshell:v0.0.70
-        serverDnsNames:
-          - openshell-gateway.tenant-beta.svc.cluster.local
-        # config field optional - uses defaults if omitted
-    
-    - name: tenant-gamma
-      gateway:
-        image: ghcr.io/nvidia/openshell:v0.0.70
-        serverDnsNames:
-          - openshell-gateway.tenant-gamma.svc.cluster.local
+kind: Gateway
+name: openshell-gateway
+project: tenant-a
+image: ghcr.io/nvidia/openshell:v0.0.70
+serverDnsNames:
+  - openshell-gateway.tenant-a.svc.cluster.local
+config: |
+  [openshell.gateway]
+  bind_address = "0.0.0.0:8080"
+  log_level = "info"
+  sandbox_namespace = "tenant-a"
+  default_image = "ghcr.io/nvidia/openshell-community/sandboxes/base:latest"
+  supervisor_image = "ghcr.io/nvidia/openshell/supervisor:0.0.63"
+  
+  [openshell.gateway.auth]
+  allow_unauthenticated_users = true
 ```
-
-**Gateway Configuration Fields:**
-- `gateway.image` (optional) — Gateway container image (defaults to `OPENSHELL_GATEWAY_IMAGE` env var)
-- `gateway.serverDnsNames` (required) — DNS names for TLS certificate generation
-- `gateway.config` (optional) — OpenShell gateway TOML configuration (overrides defaults from base manifests)
-
----
-
-## RBAC Requirements
-
-The ACP ServiceAccount SHALL have sufficient permissions to:
-- Get and watch ConfigMaps in its own namespace (to load and detect changes to `platform-config`)
-- List and get namespaces (to validate namespace existence)
-- Create, update, patch, and get Deployments, Services, ServiceAccounts, Roles, and RoleBindings in project namespaces
-
-**Note:** The exact ClusterRole definition will be determined during implementation. The control plane follows the principle of least privilege — permissions are scoped to only what is necessary for gateway provisioning.
 
 ---
 
@@ -502,22 +532,6 @@ Gateway manifests SHALL be:
 - Packaged into the ACP container image at build time
 - Read from the container filesystem at `/manifests/gateway/` at runtime
 
-**Manifest files:**
-- `deployment.yaml` — Gateway Deployment
-- `service.yaml` — Gateway Service
-- `serviceaccount.yaml` — ServiceAccount for gateway pods
-- `rbac.yaml` — Role/RoleBinding for gateway ServiceAccount
-
----
-
-## Future Work
-
-The following capabilities are deferred to future iterations:
-
-1. **Namespace-specific gateway configuration:** Different namespaces MAY require different gateway settings (e.g., resource limits, image overrides). This can be added via additional fields in the platform-config namespace entries.
-
-2. **Advanced drift detection:** The initial implementation MAY use a create-only pattern (matching current session pod behavior). Future iterations can add hash-based drift detection or spec comparison for automatic updates.
-
 ---
 
 ## References
@@ -525,4 +539,4 @@ The following capabilities are deferred to future iterations:
 - [OpenShell Gateway Helm Chart](https://github.com/NVIDIA/OpenShell/tree/main/deploy/helm/openshell)
 - [openshell-sandbox-provisioning.spec.md](./openshell-sandbox-provisioning.spec.md) — Gateway usage for sandboxing
 - [control-plane.spec.md](./control-plane.spec.md) — Control plane architecture
-- Design document: `gateway-provisioning-design-es.md`
+- [data-model.spec.md](./data-model.spec.md) — Gateway kind definition

--- a/specs/platform/index.spec.md
+++ b/specs/platform/index.spec.md
@@ -24,6 +24,10 @@ Behavioral rules and versioned governance for the runner component. Inherits fro
 
 Declarative agent YAML schema for ConfigMap-based agent definitions. Covers entrypoint, providers (namespace-scoped shared resources), payloads, sandbox policies, sandbox templates, and environment variables for OpenShell Gateway-managed sandboxes.
 
+### [Gateway Provisioning](gateway-provisioning.spec.md)
+
+API-driven gateway lifecycle management. Gateways are declared as `kind: Gateway` resources, applied via `acpctl apply -k`, persisted in PostgreSQL, and reconciled by the GatewayReconciler into Kubernetes gateway deployments (StatefulSet, Service, RBAC, certgen Job). Replaces the previous ConfigMap-based `platform-config` approach.
+
 ### [Agent Configuration Reuse via Kustomize Overlays](agent-inheritance.spec.md) *(Draft)*
 
 Configuration reuse patterns using Kustomize bases and overlays for agent, provider, and policy composition. Composition happens at apply time — the control plane only sees fully-resolved ConfigMaps. Extension to the Agent Sandbox Configuration spec.

--- a/specs/platform/openshell-sandbox-provisioning.spec.md
+++ b/specs/platform/openshell-sandbox-provisioning.spec.md
@@ -58,8 +58,8 @@ This installs the `agent-sandbox-system` namespace, the CRD, and the sandbox con
 This iteration is scoped to **scheduled agent runs** (single-run, short-lived sessions). The following are explicitly out of scope:
 
 - **Long-running / steerable sessions** — credential lifecycle concerns (token expiry mid-session, gateway-managed refresh via OAuth2/client-credentials flows) are deferred
-- **Gateway provisioning** — the OpenShell gateway is assumed to already be deployed in each project namespace; ACP will not create it. A future iteration should have the control plane provision and reconcile gateway lifecycle per project namespace (potentially adapting the [upstream Helm chart values](https://github.com/NVIDIA/OpenShell/blob/main/deploy/helm/openshell/values.yaml) into a managed resource)
-- **Namespace lifecycle (gateway mode)** — in gateway mode (`OPENSHELL_USE_GATEWAY=true`), project namespaces are created and managed externally to ACP (e.g., by the OpenShell gateway Helm install or cluster provisioning tooling). ACP verifies existence and fails with a clear error if a required namespace is missing. In pod mode, ACP continues to create and delete namespaces directly. See [Namespace Lifecycle](#requirement-namespace-lifecycle)
+- **Gateway provisioning** — ~~the OpenShell gateway is assumed to already be deployed in each project namespace~~ **Resolved:** Gateway provisioning is now specified in [gateway-provisioning.spec.md](./gateway-provisioning.spec.md). Gateways are declared as `kind: Gateway` API resources via `acpctl apply -k` and reconciled by the GatewayReconciler in `internal/reconciler/`
+- **Namespace lifecycle (gateway mode)** — ~~project namespaces are created and managed externally to ACP~~ **Resolved:** The ProjectReconciler now creates namespaces for all Projects (Project = Namespace). In gateway mode, the GatewayReconciler deploys gateways into namespaces that the ProjectReconciler has already created. No external namespace provisioning is required. See [Namespace Lifecycle](#requirement-namespace-lifecycle)
 - **Namespace-level credential storage** — credentials remain stored in ACP, not as Kubernetes Secrets in the project namespace. A future iteration should store credentials as Kubernetes Secrets in each project namespace, with ACP reading them from the Secret and passing them to the gateway when configuring providers. This indirection is necessary because the gateway does not yet support loading credentials directly from Kubernetes Secrets ([OpenShell#1882](https://github.com/NVIDIA/OpenShell/issues/1882))
 - **Network policy ownership** — OpenShell policies (including network egress rules allowing runner-to-control-plane gRPC) will be user-configurable via the Agent spec. Whether ACP auto-injects the control plane egress rule on top of the user-configured policy or requires users to include it explicitly is TBD
 
@@ -711,51 +711,33 @@ The control plane SHALL load client TLS credentials dynamically from a Kubernete
 
 ### Requirement: Namespace Lifecycle
 
-Namespace lifecycle is mode-dependent:
+Namespace lifecycle is unified across modes. The ProjectReconciler creates and manages namespaces for all Projects (Project = Namespace). There is no mode-dependent namespace provisioning.
 
-- **Pod mode** (`OPENSHELL_USE_GATEWAY=false`): The control plane manages namespace lifecycle directly. `StandardNamespaceProvisioner.ProvisionNamespace` creates the namespace if absent or updates its labels if it already exists. `DeprovisionNamespace` deletes the namespace on cleanup.
-- **Gateway mode** (`OPENSHELL_USE_GATEWAY=true`): Project namespaces are created and managed externally to ACP (e.g., by the OpenShell gateway Helm install or cluster provisioning tooling). The control plane verifies existence via a direct `GetNamespace` call and fails with a descriptive error if a required namespace is missing. It never creates or deletes namespaces. However, during gateway initialization (`initGatewayProvisioning`), the control plane SHALL apply managed labels (`ambient-code.io/managed=true`, `ambient-code.io/project-id`, `ambient-code.io/managed-by=ambient-control-plane`) to each namespace listed in `platform-config` via `ProvisionNamespace`. This labeling identifies ACP-managed namespaces for the `ApplicationReconciler` and general namespace discovery.
+- **All modes**: The ProjectReconciler watches Project events via gRPC and creates a Kubernetes namespace for each Project via `ensureNamespace()`. The namespace carries managed labels (`ambient-code.io/managed=true`, `ambient-code.io/project-id`, `ambient-code.io/managed-by=ambient-control-plane`). Gateway mode no longer requires externally-provisioned namespaces.
+- **Gateway mode** (`OPENSHELL_USE_GATEWAY=true`): The GatewayReconciler deploys OpenShell gateway resources into the namespace after the ProjectReconciler has created it. Gateway configuration is declared as a `kind: Gateway` API resource applied via `acpctl apply -k`. No `platform-config` ConfigMap or `initGatewayProvisioning()` startup path is needed.
 
-#### Scenario: Pod mode — namespace provisioning
+#### Scenario: Namespace created by ProjectReconciler
 
-- GIVEN `OPENSHELL_USE_GATEWAY` is `false`
-- WHEN the control plane provisions a session
-- THEN it SHALL call `StandardNamespaceProvisioner.ProvisionNamespace`
-- AND if the namespace does not exist, it SHALL create it
-- AND if the namespace already exists, it SHALL update its labels (update-or-create)
-- AND provisioning SHALL proceed with resource creation within the namespace
+- GIVEN a Project named `my-project` exists in the API server
+- WHEN the ProjectReconciler processes the Project event
+- THEN it SHALL create namespace `my-project` with managed labels
+- AND the namespace SHALL be available for both session provisioning and gateway deployment
 
-#### Scenario: Pod mode — namespace deprovisioning
-
-- GIVEN `OPENSHELL_USE_GATEWAY` is `false`
-- WHEN the control plane cleans up a session
-- THEN it SHALL call `StandardNamespaceProvisioner.DeprovisionNamespace`
-- AND it SHALL delete the namespace
-
-#### Scenario: Gateway mode — namespace does not exist
+#### Scenario: Gateway mode — namespace exists before gateway deployment
 
 - GIVEN `OPENSHELL_USE_GATEWAY` is `true`
-- AND namespace `my-project` does not exist on the cluster
-- WHEN the control plane attempts to provision resources
-- THEN it SHALL fail with an error: `namespace my-project does not exist; gateway-managed namespaces must be provisioned externally`
-- AND it SHALL NOT attempt to create the namespace
+- AND a `kind: Gateway` resource references project `my-project`
+- WHEN the GatewayReconciler processes the Gateway event
+- THEN the namespace `my-project` SHALL already exist (created by ProjectReconciler)
+- AND the GatewayReconciler SHALL deploy gateway K8s resources into it
 
-#### Scenario: Gateway mode — direct namespace verification during session provisioning
+#### Scenario: Gateway mode — namespace does not yet exist
 
 - GIVEN `OPENSHELL_USE_GATEWAY` is `true`
-- WHEN the control plane provisions a session
-- THEN it SHALL verify the target namespace exists via a direct `GetNamespace` API call
-- AND it SHALL NOT call the provisioner's `ProvisionNamespace` method during session provisioning — the provisioner is bypassed at session time to prevent any provisioner implementation (Standard, MPP) from attempting to create the namespace
-- AND if the namespace does not exist, the control plane SHALL fail with: `namespace <name> does not exist; gateway-managed namespaces must be provisioned externally`
-
-**Note:** The provisioner IS called during gateway initialization (`initGatewayProvisioning` / `ensureProject`) to apply managed labels to existing namespaces. This is distinct from session-time provisioning where the provisioner is bypassed.
-
-#### Scenario: Project deletion
-
-- GIVEN a project with name `my-project` and associated namespace `my-project`
-- WHEN the project is deleted from ACP
-- THEN the control plane SHALL NOT delete the namespace
-- AND ACP-managed resources within the namespace (secrets, service accounts, RBAC bindings) MAY become orphaned and should be cleaned up by external tooling or a future garbage collection mechanism
+- AND a Gateway event arrives before the corresponding Project has been reconciled
+- WHEN the GatewayReconciler attempts to deploy
+- THEN it SHALL log a warning and skip reconciliation
+- AND it SHALL retry when the namespace becomes available
 
 #### Scenario: Session cleanup (pod mode)
 
@@ -771,14 +753,14 @@ Namespace lifecycle is mode-dependent:
 - AND a session is being stopped or deleted
 - WHEN the control plane cleans up session resources
 - THEN it SHALL delete session-scoped resources (secrets, service accounts, services, sandboxes) within the namespace
-- AND it SHALL NOT delete the namespace
+- AND it SHALL NOT delete the namespace (the namespace is owned by the ProjectReconciler and may be used by other sessions and the gateway)
 
-#### Scenario: Gateway mode — no DeprovisionNamespace on cleanup
+#### Scenario: Project deletion
 
-- GIVEN `OPENSHELL_USE_GATEWAY` is `true`
-- WHEN the control plane cleans up a session
-- THEN it SHALL NOT call `DeprovisionNamespace` — the namespace is owned by external infrastructure (OpenShell gateway Helm install, cluster provisioning tooling) and must not be destroyed by ACP session lifecycle events
-- AND only session-scoped resources (sandbox, secrets, service accounts, services) SHALL be deleted
+- GIVEN a project with name `my-project` and associated namespace `my-project`
+- WHEN the project is deleted from ACP
+- THEN the ProjectReconciler SHALL handle namespace cleanup according to its lifecycle policy
+- AND gateway resources within the namespace SHALL be cleaned up by the GatewayReconciler when the corresponding Gateway resource is deleted
 
 ### Requirement: Configuration
 

--- a/specs/security/gateway-rbac-policy.spec.md
+++ b/specs/security/gateway-rbac-policy.spec.md
@@ -2,13 +2,13 @@
 
 **Date:** 2026-07-05
 **Status:** Active
-**Related:** `specs/security/rbac-enforcement.spec.md` (base RBAC model), `specs/platform/agent-sandbox-config.spec.md` (ConfigMap agent schema), `specs/platform/gateway-provisioning.spec.md` (gateway deployment), `specs/platform/openshell-sandbox-provisioning.spec.md` (sandbox provisioning flow)
+**Related:** `specs/security/rbac-enforcement.spec.md` (base RBAC model), `specs/platform/agent-sandbox-config.spec.md` (agent schema), `specs/platform/gateway-provisioning.spec.md` (API-driven gateway provisioning), `specs/platform/openshell-sandbox-provisioning.spec.md` (sandbox provisioning flow)
 
 ---
 
 ## Purpose
 
-OpenShell is the default and only sandbox runtime. The platform enforces a tiered RBAC policy that constrains human users to three effective tiers: Admin, Editor, and Viewer. Agent definitions MAY be managed through both the API (full CRUD) and GitOps ConfigMaps applied to tenant namespaces (schema defined in `agent-sandbox-config.spec.md`). Policy and provider declarations (ConfigMaps with labels `ambient.ai/kind: policy` and `ambient.ai/kind: provider`) are GitOps-only by design — no API endpoints exist for them. A user's effective ACP tier SHALL be derived from their Kubernetes RoleBindings on the tenant namespace — if a user has `view` access on the namespace, they are a viewer in ACP for that project. Standard RBAC from `rbac-enforcement.spec.md` governs all agent CRUD operations.
+OpenShell is the default and only sandbox runtime. The platform enforces a tiered RBAC policy that constrains human users to three effective tiers: Admin, Editor, and Viewer. Agent definitions MAY be managed through both the API (full CRUD) and GitOps workflows via `acpctl apply -k` (schema defined in `agent-sandbox-config.spec.md`). Policy and provider declarations are GitOps-only by design — no API endpoints exist for them. Gateway configuration is declared as `kind: Gateway` API resources applied via `acpctl apply -k` and reconciled by the GatewayReconciler (see `gateway-provisioning.spec.md`). A user's effective ACP tier SHALL be derived from their Kubernetes RoleBindings on the tenant namespace — if a user has `view` access on the namespace, they are a viewer in ACP for that project. Standard RBAC from `rbac-enforcement.spec.md` governs all agent CRUD operations.
 
 ---
 
@@ -18,10 +18,10 @@ OpenShell is the default and only sandbox runtime. The platform enforces a tiere
 - **Admin tier** — users with `admin` or `cluster-admin` access on the tenant namespace, or holding `platform:admin` or `project:owner` ACP internal roles. Full management access including agent CRUD, session creation, schedule management, and role binding grants.
 - **Editor tier** — users with `edit` access on the tenant namespace, or holding `project:editor` or `agent:operator` ACP internal roles. Can create/update agents, start agent sessions, and manage schedules, but cannot manage project membership or roles.
 - **Viewer tier** — users with `view` access on the tenant namespace, or holding `project:viewer`, `agent:observer`, `platform:viewer`, or any project-scoped binding not in the Admin or Editor tier. Read-only access to agents, sessions, and schedules.
-- **GitOps-managed agent** — an Agent record reconciled from a ConfigMap with label `ambient.ai/kind: agent` in a tenant namespace. Distinguished from API-created agents by the annotation `ambient.ai/managed-by: configmap`.
+- **GitOps-managed agent** — an Agent record applied via `acpctl apply -k` or reconciled by the ApplicationReconciler from a git repository. Distinguished from interactively-created agents by the annotation `ambient.ai/managed-by: gitops`.
 - **API-managed agent** — an Agent record created or modified via the REST API. Full CRUD is permitted for users with appropriate RBAC bindings.
-- **Policy declaration** — a ConfigMap entry with label `ambient.ai/kind: policy` containing an OpenShell `SandboxPolicy` YAML definition. Namespace-scoped, referenced by agents by name. No API endpoints exist for policies; they are GitOps-only by design (see `agent-sandbox-config.spec.md`).
-- **Provider declaration** — a ConfigMap entry with label `ambient.ai/kind: provider` defining a named credential provider with its type and Secret reference. Namespace-scoped, referenced by agents by name. No API endpoints exist for providers; they are GitOps-only by design (see `agent-sandbox-config.spec.md`).
+- **Policy declaration** — a YAML definition containing an OpenShell `SandboxPolicy`. Namespace-scoped, referenced by agents by name. No API endpoints exist for policies; they are GitOps-only by design (see `agent-sandbox-config.spec.md`).
+- **Provider declaration** — a YAML definition defining a named credential provider with its type and Secret reference. Namespace-scoped, referenced by agents by name. No API endpoints exist for providers; they are GitOps-only by design (see `agent-sandbox-config.spec.md`).
 
 ---
 

--- a/specs/standards/control-plane/conventions.spec.md
+++ b/specs/standards/control-plane/conventions.spec.md
@@ -83,6 +83,19 @@ ctx := context.TODO()
 
 Same as backend: return `fmt.Errorf` with context instead. A panic crashes the entire control plane, affecting all sessions.
 
+### Shared Kustomize Library
+
+The kustomize rendering engine is extracted from `acpctl apply` into a shared library (e.g., `ambient-sdk/go-sdk/kustomize/`). Both the CLI and the ApplicationReconciler consume this library. Key conventions:
+
+- The library SHALL be fully unit-testable without a running cluster or API server
+- The library handles: kustomization loading, base resolution, resource merging, strategic-merge patching, and flat manifest production
+- Supported kinds: `Project`, `Agent`, `Credential`, `RoleBinding`, `Gateway`
+- The ApplicationReconciler SHALL NOT duplicate kustomize rendering logic — it SHALL use the shared library
+
+### Reconciler Registration
+
+All reconcilers (`KubeReconciler`, `ProjectReconciler`, `GatewayReconciler`, `ApplicationReconciler`) implement the `Reconciler` interface from `internal/reconciler/shared.go` and are registered with the Informer. Gateway provisioning is driven by `kind: Gateway` API resources received via gRPC watch events, not by ConfigMaps.
+
 ## Pre-Commit Checklist
 
 - [ ] OwnerReferences set on all child resources


### PR DESCRIPTION
## Summary

- Rewrites `gateway-provisioning.spec.md` to introduce `kind: Gateway` as a first-class ACP resource persisted in PostgreSQL, applied via `acpctl apply -k`, and reconciled by a new GatewayReconciler in `internal/reconciler/`
- Eliminates the ConfigMap-based `platform-config` watcher and `initGatewayProvisioning()` startup path
- Updates 8 spec files across platform, security, and standards domains to reflect the unified declarative model where Project = Namespace and gateway configuration flows through the same API → gRPC watch → reconciler pipeline as all other resources

## Changes across specs

 < /dev/null |  File | Change |
|---|---|
| `gateway-provisioning.spec.md` | Full rewrite: Gateway as API resource, shared kustomize library, GatewayReconciler, kustomize overlay structure, ConfigMap elimination |
| `control-plane.spec.md` | Added ProjectReconciler, GatewayReconciler, ApplicationReconciler component descriptions + 3 design decisions |
| `openshell-sandbox-provisioning.spec.md` | Marked gateway provisioning and namespace lifecycle constraints as Resolved; rewrote Namespace Lifecycle requirement |
| `data-model.spec.md` | Added Gateway entity to overview, ERD, relationships, "What Gets Synced" table, and `acpctl apply` supported kinds |
| `platform/index.spec.md` | Added Gateway Provisioning sub-spec entry |
| `index.spec.md` | Updated spec registry: Gateway in data-model entities; gateway-provisioning primary entities updated |
| `conventions.spec.md` | Added Shared Kustomize Library and Reconciler Registration conventions |
| `gateway-rbac-policy.spec.md` | Updated Related links, Purpose, and Terminology to reference `acpctl apply -k` instead of ConfigMaps |

## Test plan

- [ ] Review spec changes for consistency across all 8 files
- [ ] Verify Gateway entity in data-model ERD renders correctly in mermaid
- [ ] Confirm no orphaned references to `platform-config` ConfigMap remain in specs

🤖 Generated with [Claude Code](https://claude.ai/code)