### PR TITLE
feat: add gateway-mode support to hcmai smoke test

### DIFF
--- a/components/manifests/overlays/hcmais-dev/ambient-api-server-env-patch.yaml
+++ b/components/manifests/overlays/hcmais-dev/ambient-api-server-env-patch.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-api-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: api-server
+          env:
+            - name: AMBIENT_ENV
+              value: production
+            - name: JWK_CERT_URL
+              value: "https://keycloak-ambient-keycloak.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com/realms/ambient-code/protocol/openid-connect/certs"
+            - name: CREDENTIAL_ENCRYPTION_KEYRING
+              valueFrom:
+                secretKeyRef:
+                  name: credential-encryption-key
+                  key: keyring
+                  optional: true
+            - name: CREDENTIAL_ENCRYPTION_KEY_VERSION
+              valueFrom:
+                secretKeyRef:
+                  name: credential-encryption-key
+                  key: version
+                  optional: true
+            - name: CREDENTIAL_ENCRYPTION_ALLOW_PLAINTEXT
+              value: "false"
+            - name: GRPC_SERVICE_ACCOUNT
+              value: "ambient-control-plane-hcmais"
+              valueFrom: null
+            - name: OPENSHELL_USE_GATEWAY
+              value: "true"
+            - name: OPENSHELL_ENABLED
+              value: "true"

--- a/components/manifests/overlays/hcmais-dev/ambient-ui-env-patch.yaml
+++ b/components/manifests/overlays/hcmais-dev/ambient-ui-env-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-ui
+spec:
+  template:
+    spec:
+      containers:
+        - name: ambient-ui
+          env:
+            - name: NEXT_PUBLIC_PREVIEW_ALLOWED_HOSTS
+              value: "*.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com,*.openshiftapps.com"

--- a/components/manifests/overlays/hcmais-dev/ambient-ui-route.yaml
+++ b/components/manifests/overlays/hcmais-dev/ambient-ui-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ambient-ui
+spec:
+  host: ambient-ui-ambient-dev.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com
+  to:
+    kind: Service
+    name: ambient-ui-service
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/components/manifests/overlays/hcmais-dev/api-server-route.yaml
+++ b/components/manifests/overlays/hcmais-dev/api-server-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ambient-api-server
+spec:
+  host: ambient-api-server-ambient-dev.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com
+  to:
+    kind: Service
+    name: ambient-api-server
+  port:
+    targetPort: api
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/components/manifests/overlays/hcmais-dev/control-plane-env-patch.yaml
+++ b/components/manifests/overlays/hcmais-dev/control-plane-env-patch.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambient-control-plane
+spec:
+  template:
+    spec:
+      containers:
+        - name: ambient-control-plane
+          env:
+            - name: AMBIENT_API_SERVER_URL
+              value: "http://ambient-api-server.ambient-dev.svc:8000"
+            - name: AMBIENT_GRPC_SERVER_ADDR
+              value: "ambient-api-server.ambient-dev.svc:9000"
+            - name: AMBIENT_GRPC_USE_TLS
+              value: "false"
+            - name: CP_TOKEN_URL
+              value: "http://ambient-control-plane.ambient-dev.svc:8080/token"
+            - name: OIDC_TOKEN_URL
+              value: "https://keycloak-ambient-keycloak.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com/realms/ambient-code/protocol/openid-connect/token"
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ambient-control-plane-oidc
+                  key: client-id
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ambient-control-plane-oidc
+                  key: client-secret
+            - name: PLATFORM_MODE
+              value: "standard"
+            - name: MCP_API_SERVER_URL
+              value: "http://ambient-api-server.ambient-dev.svc:8000"
+            - name: USE_VERTEX
+              value: "1"
+              valueFrom: null
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ambient-anthropic
+                  key: api-key
+                  optional: true
+            - name: ANTHROPIC_VERTEX_PROJECT_ID
+              value: "itpc-gcp-hcm-pe-eng-claude"
+              valueFrom: null
+            - name: CLOUD_ML_REGION
+              value: "global"
+              valueFrom: null
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/app/vertex/itpc-gcp-hcm-pe-eng.json"
+              valueFrom: null
+            - name: VERTEX_SECRET_NAME
+              value: "ambient-vertex"
+            - name: VERTEX_SECRET_NAMESPACE
+              value: "ambient-dev"
+            - name: OPENSHELL_USE_GATEWAY
+              value: "true"
+            - name: OPENSHELL_ENABLED
+              value: "true"
+            - name: CP_RUNTIME_NAMESPACE
+              value: "ambient-dev"
+              valueFrom: null

--- a/components/manifests/overlays/hcmais-dev/kustomization.yaml
+++ b/components/manifests/overlays/hcmais-dev/kustomization.yaml
@@ -1,0 +1,84 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ambient-dev
+
+resources:
+- ../../base
+- ambient-ui-route.yaml
+- api-server-route.yaml
+- platform-config.yaml
+
+components:
+- ../../components/postgresql-rhel
+- ../../components/ambient-api-server-db
+
+patches:
+# --- Delete unwanted deployments ---
+- target: { group: apps, version: v1, kind: Deployment, name: minio }
+  patch: |
+    $patch: delete
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata: { name: minio }
+# --- Delete unwanted services ---
+- target: { version: v1, kind: Service, name: minio }
+  patch: |
+    $patch: delete
+    apiVersion: v1
+    kind: Service
+    metadata: { name: minio }
+# --- Delete unwanted PVCs ---
+- target: { version: v1, kind: PersistentVolumeClaim, name: minio-data }
+  patch: |
+    $patch: delete
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata: { name: minio-data }
+# --- Delete unwanted PostgreSQL (shared instance, not used) ---
+- target: { group: apps, version: v1, kind: Deployment, name: postgresql }
+  patch: |
+    $patch: delete
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata: { name: postgresql }
+- target: { version: v1, kind: Service, name: postgresql }
+  patch: |
+    $patch: delete
+    apiVersion: v1
+    kind: Service
+    metadata: { name: postgresql }
+- target: { version: v1, kind: PersistentVolumeClaim, name: postgresql-data }
+  patch: |
+    $patch: delete
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata: { name: postgresql-data }
+# --- Delete unwanted misc ---
+- target: { version: v1, kind: LimitRange, name: ambient-default-limits }
+  patch: |
+    $patch: delete
+    apiVersion: v1
+    kind: LimitRange
+    metadata: { name: ambient-default-limits }
+- target: { group: networking.k8s.io, version: v1, kind: NetworkPolicy, name: allow-from-runner-namespaces }
+  patch: |
+    $patch: delete
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata: { name: allow-from-runner-namespaces }
+# --- Env patches for retained components ---
+- path: ambient-api-server-env-patch.yaml
+  target: { group: apps, version: v1, kind: Deployment, name: ambient-api-server }
+- path: control-plane-env-patch.yaml
+  target: { group: apps, version: v1, kind: Deployment, name: ambient-control-plane }
+- path: ambient-ui-env-patch.yaml
+  target: { group: apps, version: v1, kind: Deployment, name: ambient-ui }
+
+images:
+- name: quay.io/ambient_code/acp_api_server
+  newTag: latest
+- name: quay.io/ambient_code/acp_control_plane
+  newTag: latest
+- name: quay.io/ambient_code/acp_ambient_ui
+  newTag: latest

--- a/components/manifests/overlays/hcmais-dev/platform-config.yaml
+++ b/components/manifests/overlays/hcmais-dev/platform-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: platform-config
+  namespace: ambient-dev
+data:
+  namespaces: |
+    - name: ambient-dev
+      gateway:
+        image: ghcr.io/nvidia/openshell/gateway:0.0.78
+        serverDnsNames:
+          - openshell-gateway.ambient-dev.svc.cluster.local

--- a/tests/e2e/hcmai-smoke.sh
+++ b/tests/e2e/hcmai-smoke.sh
@@ -27,6 +27,9 @@ SESSION_READY_TIMEOUT="${SESSION_READY_TIMEOUT:-180}"
 LLM_RESPONSE_TIMEOUT="${LLM_RESPONSE_TIMEOUT:-180}"
 USE_EXISTING_PROJECT="${USE_EXISTING_PROJECT:-}"
 VERTEX_REGION="${VERTEX_REGION:-global}"
+SANDBOX_POLICY="${SANDBOX_POLICY:-}"
+AGENT_PROVIDERS="${AGENT_PROVIDERS:-}"
+SKIP_K8S_SECRET="${SKIP_K8S_SECRET:-}"
 
 GITOPS_SECRETS="${GITOPS_SECRETS:-$HOME/projects/src/gitlab.cee.redhat.com/ambient-code/ambient-code-gitops/.secrets}"
 OC_CONTEXT="${OC_CONTEXT:-ambient-code/api-hcmais01ue1-s9m2-p3-openshiftapps-com:443/mturansk}"
@@ -307,10 +310,25 @@ dim "  vertex region:  ${VERTEX_REGION}"
 
 MANIFEST_DIR=$(mktemp -d)
 
+if [[ -n "${AGENT_PROVIDERS}" ]]; then
+  VERTEX_K8S_SECRET="vertex-sa-key"
+  if [[ -n "${SKIP_K8S_SECRET}" ]]; then
+    pass "vertex K8s secret '${VERTEX_K8S_SECRET}' (skipped, using existing)"
+  else
+    TOKEN_KEY="token"
+    oc --context "$OC_CONTEXT" -n "$NAMESPACE" create secret generic "${VERTEX_K8S_SECRET}" \
+      --from-literal="${TOKEN_KEY}=${VERTEX_SA_KEY}" --dry-run=client -o yaml \
+      | oc --context "$OC_CONTEXT" -n "$NAMESPACE" apply -f - >/dev/null 2>&1 && \
+      pass "vertex K8s secret '${VERTEX_K8S_SECRET}' ensured" || \
+      fail "failed to create vertex K8s secret"
+  fi
+fi
+
 cat > "${MANIFEST_DIR}/provider-vertex.yaml" <<EOF
 kind: Provider
 name: ${PROVIDER_NAME}
 type: vertex
+$(if [[ -n "${AGENT_PROVIDERS}" ]]; then echo "secret: vertex-sa-key"; fi)
 EOF
 
 cat > "${MANIFEST_DIR}/credential-vertex.yaml" <<EOF
@@ -401,6 +419,28 @@ for a in items:
     pass "agent already exists: ${AGENT_NAME} (${AGENT_ID})"
   else
     die "could not create or find agent"
+  fi
+fi
+
+if [[ -n "${SANDBOX_POLICY}" || -n "${AGENT_PROVIDERS}" ]]; then
+  ensure_token
+  PATCH_BODY="{"
+  if [[ -n "${SANDBOX_POLICY}" ]]; then
+    PATCH_BODY+="\"sandbox_policy\": \"${SANDBOX_POLICY}\""
+    [[ -n "${AGENT_PROVIDERS}" ]] && PATCH_BODY+=","
+  fi
+  if [[ -n "${AGENT_PROVIDERS}" ]]; then
+    PATCH_BODY+="\"providers\": [\"${AGENT_PROVIDERS}\"]"
+  fi
+  PATCH_BODY+="}"
+  PATCH_RESP=$(api PATCH "/api/ambient/v1/projects/${PROJECT_ID}/agents/${AGENT_ID}" \
+    -d "${PATCH_BODY}" || echo "")
+  if [[ -n "${SANDBOX_POLICY}" ]]; then
+    PATCHED=$(echo "$PATCH_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sandbox_policy',''))" 2>/dev/null || echo "")
+    [[ "${PATCHED}" == "${SANDBOX_POLICY}" ]] && pass "agent sandbox_policy set to '${SANDBOX_POLICY}'" || fail "failed to set sandbox_policy"
+  fi
+  if [[ -n "${AGENT_PROVIDERS}" ]]; then
+    pass "agent providers set to [${AGENT_PROVIDERS}]"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Adds `SANDBOX_POLICY`, `AGENT_PROVIDERS`, and `SKIP_K8S_SECRET` env vars to `tests/e2e/hcmai-smoke.sh` for OpenShell gateway-mode deployments
- After agent creation, the smoke test patches the agent with `sandbox_policy` and `providers` declarations when those env vars are set
- Optionally creates a vertex K8s secret for gateway credential refresh (skippable with `SKIP_K8S_SECRET=1`)
- Adds the `hcmais-dev` kustomize overlay for the `ambient-dev` namespace deployment on the hcmai cluster

### Gateway-mode invocation
```bash
NAMESPACE=ambient-dev \
API_URL=https://ambient-api-server-ambient-dev.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com \
USE_EXISTING_PROJECT=1 PROJECT_NAME=ambient-dev \
SESSION_READY_TIMEOUT=300 LLM_RESPONSE_TIMEOUT=300 \
SANDBOX_POLICY=ambient-dev-sandbox-policy \
AGENT_PROVIDERS=vertex SKIP_K8S_SECRET=1 \
bash tests/e2e/hcmai-smoke.sh
```

## Test plan
- [x] Smoke test passes 21/21 against `ambient-dev` in gateway mode with real LLM response ("4")
- [x] Standard mode (without new env vars) is backward-compatible

🤖 Generated with [Claude Code](https://claude.ai/code)