### PR TITLE
fix(control-plane): verify sandbox ndots after ready instead of racing controller

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -42,8 +42,8 @@ func validateTSLValue(value string) error {
 }
 
 const (
-	mcpSidecarPort   = int64(8090)
-	mcpSidecarURL    = "http://localhost:8090"
+	mcpSidecarPort    = int64(8090)
+	mcpSidecarURL     = "http://localhost:8090"
 	initialPromptPath = "/tmp/initial_prompt.txt"
 )
 
@@ -72,39 +72,39 @@ var credentialSidecarRegistry = map[string]credentialSidecarSpec{
 }
 
 type KubeReconcilerConfig struct {
-	RunnerImage              string
-	RunnerGRPCURL            string
-	RunnerGRPCUseTLS         bool
-	AnthropicAPIKey          string
-	VertexEnabled            bool
-	VertexProjectID          string
-	VertexRegion             string
-	VertexCredentialsPath    string
-	VertexSecretName         string
-	VertexSecretNamespace    string
-	RunnerImageNamespace     string
-	MCPImage                 string
-	MCPAPIServerURL          string
-	GitHubMCPImage           string
-	JiraMCPImage             string
-	K8sMCPImage              string
-	GoogleMCPImage           string
-	RunnerLogLevel           string
-	CPRuntimeNamespace       string
-	CPTokenURL               string
-	CPTokenPublicKey         string
-	HTTPProxy                string
-	HTTPSProxy               string
-	NoProxy                  string
-	ImagePullSecret          string
-	PlatformMode             string
-	MPPConfigNamespace       string
-	OpenShellEnabled         bool
-	OpenShellUseGateway      bool
-	OpenShellRunnerImage     string
-	OpenShellPolicyName      string
-	ServiceIdentity          string
-	CACertFile               string
+	RunnerImage                    string
+	RunnerGRPCURL                  string
+	RunnerGRPCUseTLS               bool
+	AnthropicAPIKey                string
+	VertexEnabled                  bool
+	VertexProjectID                string
+	VertexRegion                   string
+	VertexCredentialsPath          string
+	VertexSecretName               string
+	VertexSecretNamespace          string
+	RunnerImageNamespace           string
+	MCPImage                       string
+	MCPAPIServerURL                string
+	GitHubMCPImage                 string
+	JiraMCPImage                   string
+	K8sMCPImage                    string
+	GoogleMCPImage                 string
+	RunnerLogLevel                 string
+	CPRuntimeNamespace             string
+	CPTokenURL                     string
+	CPTokenPublicKey               string
+	HTTPProxy                      string
+	HTTPSProxy                     string
+	NoProxy                        string
+	ImagePullSecret                string
+	PlatformMode                   string
+	MPPConfigNamespace             string
+	OpenShellEnabled               bool
+	OpenShellUseGateway            bool
+	OpenShellRunnerImage           string
+	OpenShellPolicyName            string
+	ServiceIdentity                string
+	CACertFile                     string
 	AllowedSandboxRegistries       []string
 	SandboxReadinessTimeoutSeconds int
 }
@@ -480,12 +480,41 @@ func (r *SimpleKubeReconciler) patchSandboxDNSConfig(ctx context.Context, namesp
 		return fmt.Errorf("patching sandbox %s dnsConfig: %w", sandboxName, err)
 	}
 
-	if err := r.nsKube().DeletePod(ctx, namespace, sandboxName, &metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-		r.logger.Warn().Err(err).Str("sandbox", sandboxName).Msg("failed to delete sandbox pod for dnsConfig recreation")
+	r.logger.Info().Str("sandbox", sandboxName).Str("namespace", namespace).Msg("patched sandbox CR dnsConfig with ndots:1")
+	return nil
+}
+
+// verifyAndFixDNSConfig checks the sandbox pod's /etc/resolv.conf for the
+// incorrect ndots:5 value. If found, the pod is deleted so the agent-sandbox
+// controller recreates it from the already-patched CR (which has ndots:1).
+// Returns (true, nil) when DNS config is correct, (false, nil) when the pod
+// was deleted and needs recreation, or (false, err) on failure.
+func (r *SimpleKubeReconciler) verifyAndFixDNSConfig(namespace, sandboxID, sbxName string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := r.gateway.ExecSandbox(ctx, namespace, &openshellpb.ExecSandboxRequest{
+		SandboxId:      sandboxID,
+		Command:        []string{"cat", "/etc/resolv.conf"},
+		TimeoutSeconds: 10,
+	})
+	if err != nil {
+		return false, fmt.Errorf("exec cat /etc/resolv.conf: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return false, fmt.Errorf("cat /etc/resolv.conf exited %d: %s", result.ExitCode, string(result.Stderr))
 	}
 
-	r.logger.Info().Str("sandbox", sandboxName).Str("namespace", namespace).Msg("patched sandbox dnsConfig with ndots:1 and triggered pod recreation")
-	return nil
+	if !strings.Contains(string(result.Stdout), "ndots:5") {
+		r.logger.Info().Str("sandbox", sbxName).Msg("verified sandbox DNS config: ndots is correct")
+		return true, nil
+	}
+
+	r.logger.Warn().Str("sandbox", sbxName).Msg("sandbox pod has ndots:5, deleting for recreation from patched CR")
+	if err := r.nsKube().DeletePod(ctx, namespace, sbxName, &metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		return false, fmt.Errorf("deleting pod %s for ndots fix: %w", sbxName, err)
+	}
+	return false, nil
 }
 
 func (r *SimpleKubeReconciler) appendPromptToEntrypoint(ctx context.Context, entrypoint []string, session types.Session, sdk *sdkclient.Client) []string {
@@ -592,6 +621,8 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 	defer ticker.Stop()
 	pollStart := time.Now()
 	lastProgressLog := pollStart
+	ndotsRetries := 0
+	const maxNdotsRetries = 3
 
 	for {
 		select {
@@ -640,6 +671,22 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 			sandboxID := sbxName
 			if resp.Sandbox.Metadata != nil && resp.Sandbox.Metadata.Id != "" {
 				sandboxID = resp.Sandbox.Metadata.Id
+			}
+
+			dnsOK, dnsErr := r.verifyAndFixDNSConfig(namespace, sandboxID, sbxName)
+			if dnsErr != nil {
+				r.logger.Warn().Err(dnsErr).Str("sandbox", sbxName).Int("ndots_retry", ndotsRetries).Msg("failed to verify sandbox DNS config")
+				continue
+			}
+			if !dnsOK {
+				ndotsRetries++
+				if ndotsRetries > maxNdotsRetries {
+					r.logger.Error().Str("sandbox", sbxName).Str("session_id", sessionID).Int("retries", ndotsRetries).Msg("sandbox DNS config still incorrect after max retries")
+					failSession("sandbox DNS config (ndots) incorrect after maximum retries")
+					return
+				}
+				r.logger.Warn().Str("sandbox", sbxName).Int("ndots_retry", ndotsRetries).Msg("sandbox pod had ndots:5; deleted pod, waiting for recreation")
+				continue
 			}
 
 			r.logger.Info().

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -623,6 +623,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 	lastProgressLog := pollStart
 	ndotsRetries := 0
 	const maxNdotsRetries = 3
+	awaitingPodRestart := false
 
 	for {
 		select {
@@ -661,10 +662,18 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				return
 			}
 			if phase != openshellpb.SandboxPhase_SANDBOX_PHASE_READY {
+				if awaitingPodRestart {
+					awaitingPodRestart = false
+					r.logger.Info().Str("sandbox", sbxName).Str("phase", phase.String()).Msg("sandbox left READY after pod deletion, waiting for new pod")
+				}
 				r.logger.Debug().
 					Str("sandbox", sbxName).
 					Str("phase", phase.String()).
 					Msg("sandbox not ready yet")
+				continue
+			}
+			if awaitingPodRestart {
+				r.logger.Debug().Str("sandbox", sbxName).Msg("sandbox still READY after pod deletion, waiting for phase transition")
 				continue
 			}
 
@@ -691,6 +700,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 					failSession("sandbox DNS config (ndots) incorrect after maximum retries")
 					return
 				}
+				awaitingPodRestart = true
 				r.logger.Warn().Str("sandbox", sbxName).Int("ndots_retry", ndotsRetries).Msg("sandbox pod had ndots:5; deleted pod, waiting for recreation")
 				continue
 			}

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -489,8 +489,8 @@ func (r *SimpleKubeReconciler) patchSandboxDNSConfig(ctx context.Context, namesp
 // controller recreates it from the already-patched CR (which has ndots:1).
 // Returns (true, nil) when DNS config is correct, (false, nil) when the pod
 // was deleted and needs recreation, or (false, err) on failure.
-func (r *SimpleKubeReconciler) verifyAndFixDNSConfig(namespace, sandboxID, sbxName string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func (r *SimpleKubeReconciler) verifyAndFixDNSConfig(ctx context.Context, namespace, sandboxID, sbxName string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	result, err := r.gateway.ExecSandbox(ctx, namespace, &openshellpb.ExecSandboxRequest{
@@ -673,9 +673,15 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				sandboxID = resp.Sandbox.Metadata.Id
 			}
 
-			dnsOK, dnsErr := r.verifyAndFixDNSConfig(namespace, sandboxID, sbxName)
+			dnsOK, dnsErr := r.verifyAndFixDNSConfig(pollCtx, namespace, sandboxID, sbxName)
 			if dnsErr != nil {
+				ndotsRetries++
 				r.logger.Warn().Err(dnsErr).Str("sandbox", sbxName).Int("ndots_retry", ndotsRetries).Msg("failed to verify sandbox DNS config")
+				if ndotsRetries > maxNdotsRetries {
+					r.logger.Error().Str("sandbox", sbxName).Str("session_id", sessionID).Int("retries", ndotsRetries).Msg("sandbox DNS verification failed after max retries")
+					failSession(fmt.Sprintf("sandbox DNS verification failed after %d retries: %v", ndotsRetries, dnsErr))
+					return
+				}
 				continue
 			}
 			if !dnsOK {

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler_test.go
@@ -1,15 +1,23 @@
 package reconciler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/ambient-code/platform/components/ambient-control-plane/internal/kubeclient"
+	"github.com/ambient-code/platform/components/ambient-control-plane/internal/openshell"
+	pb "github.com/ambient-code/platform/components/ambient-control-plane/internal/openshell/grpc/openshell/v1"
 	"github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
+	"github.com/rs/zerolog"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
 )
 
 func TestBuildCredentialSidecars_NoCredentials(t *testing.T) {
@@ -415,6 +423,145 @@ func TestUseMCPSidecar_GatewayModeDisablesMCP(t *testing.T) {
 
 			if useMCPSidecar != tt.expectedUseMCP {
 				t.Errorf("useMCPSidecar = %v, want %v", useMCPSidecar, tt.expectedUseMCP)
+			}
+		})
+	}
+}
+
+func newFakeKubeClientWithPods(objects ...runtime.Object) *kubeclient.KubeClient {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+		&unstructured.Unstructured{},
+	)
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodList"},
+		&unstructured.UnstructuredList{},
+	)
+	dynClient := fake.NewSimpleDynamicClient(scheme, objects...)
+	return kubeclient.NewFromDynamic(dynClient, zerolog.Nop())
+}
+
+func makeNamedPod(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+			"spec":       map[string]interface{}{},
+		},
+	}
+}
+
+func TestVerifyAndFixDNSConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		execResult  *openshell.ExecResult
+		execErr     error
+		podExists   bool
+		wantOK      bool
+		wantErr     bool
+		wantDeleted bool
+	}{
+		{
+			name: "ndots:1 present - DNS is correct",
+			execResult: &openshell.ExecResult{
+				Stdout:   []byte("nameserver 10.96.0.10\nsearch default.svc.cluster.local svc.cluster.local cluster.local\noptions ndots:1\n"),
+				ExitCode: 0,
+			},
+			podExists:   true,
+			wantOK:      true,
+			wantErr:     false,
+			wantDeleted: false,
+		},
+		{
+			name: "ndots:5 present - deletes pod",
+			execResult: &openshell.ExecResult{
+				Stdout:   []byte("nameserver 10.96.0.10\nsearch default.svc.cluster.local svc.cluster.local cluster.local\noptions ndots:5\n"),
+				ExitCode: 0,
+			},
+			podExists:   true,
+			wantOK:      false,
+			wantErr:     false,
+			wantDeleted: true,
+		},
+		{
+			name:        "exec error - returns error",
+			execErr:     fmt.Errorf("connection refused"),
+			podExists:   true,
+			wantOK:      false,
+			wantErr:     true,
+			wantDeleted: false,
+		},
+		{
+			name: "non-zero exit code - returns error",
+			execResult: &openshell.ExecResult{
+				Stderr:   []byte("cat: /etc/resolv.conf: No such file or directory"),
+				ExitCode: 1,
+			},
+			podExists:   true,
+			wantOK:      false,
+			wantErr:     true,
+			wantDeleted: false,
+		},
+		{
+			name: "ndots:2 present - DNS is correct (not ndots:5)",
+			execResult: &openshell.ExecResult{
+				Stdout:   []byte("nameserver 10.96.0.10\noptions ndots:2\n"),
+				ExitCode: 0,
+			},
+			podExists:   true,
+			wantOK:      true,
+			wantErr:     false,
+			wantDeleted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &mockGateway{
+				execSandboxFn: func(_ context.Context, _ string, req *pb.ExecSandboxRequest) (*openshell.ExecResult, error) {
+					if len(req.Command) < 2 || req.Command[0] != "cat" || req.Command[1] != "/etc/resolv.conf" {
+						t.Errorf("unexpected command: %v", req.Command)
+					}
+					return tt.execResult, tt.execErr
+				},
+			}
+
+			var objects []runtime.Object
+			if tt.podExists {
+				objects = append(objects, makeNamedPod("test-ns", "test-sandbox"))
+			}
+			kube := newFakeKubeClientWithPods(objects...)
+			logger := zerolog.Nop()
+
+			r := &SimpleKubeReconciler{
+				gateway: gw,
+				kube:    kube,
+				logger:  logger,
+			}
+
+			ok, err := r.verifyAndFixDNSConfig(context.Background(), "test-ns", "sandbox-id-123", "test-sandbox")
+
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+
+			// Verify pod was deleted when expected
+			if tt.wantDeleted {
+				_, getErr := kube.DynamicClient().Resource(kubeclient.PodGVR).Namespace("test-ns").Get(context.Background(), "test-sandbox", metav1.GetOptions{})
+				if !k8serrors.IsNotFound(getErr) {
+					t.Errorf("expected pod to be deleted, but got err: %v", getErr)
+				}
+			}
+			if !tt.wantDeleted && tt.podExists && err == nil {
+				_, getErr := kube.DynamicClient().Resource(kubeclient.PodGVR).Namespace("test-ns").Get(context.Background(), "test-sandbox", metav1.GetOptions{})
+				if getErr != nil {
+					t.Errorf("expected pod to still exist, but got err: %v", getErr)
+				}
 			}
 		})
 	}

--- a/components/ambient-control-plane/internal/reconciler/provider_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/provider_reconciler_test.go
@@ -34,6 +34,7 @@ type mockGateway struct {
 	setClusterInferenceFn      func(ctx context.Context, namespace string, req *inferencepb.SetClusterInferenceRequest) (*inferencepb.SetClusterInferenceResponse, error)
 	configureProviderRefreshFn func(ctx context.Context, namespace string, req *pb.ConfigureProviderRefreshRequest) (*pb.ConfigureProviderRefreshResponse, error)
 	rotateProviderCredentialFn func(ctx context.Context, namespace string, req *pb.RotateProviderCredentialRequest) (*pb.RotateProviderCredentialResponse, error)
+	execSandboxFn              func(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (*openshell.ExecResult, error)
 }
 
 func (m *mockGateway) CreateSandbox(_ context.Context, _ string, _ *pb.CreateSandboxRequest) (*pb.SandboxResponse, error) {
@@ -83,7 +84,10 @@ func (m *mockGateway) RotateProviderCredential(ctx context.Context, namespace st
 	return &pb.RotateProviderCredentialResponse{}, nil
 }
 
-func (m *mockGateway) ExecSandbox(_ context.Context, _ string, _ *pb.ExecSandboxRequest) (*openshell.ExecResult, error) {
+func (m *mockGateway) ExecSandbox(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (*openshell.ExecResult, error) {
+	if m.execSandboxFn != nil {
+		return m.execSandboxFn(ctx, namespace, req)
+	}
 	return &openshell.ExecResult{}, nil
 }
 

--- a/components/ambient-control-plane/internal/reconciler/provider_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/provider_reconciler_test.go
@@ -99,6 +99,10 @@ func (m *mockGateway) UploadPayloads(_ context.Context, _ string, _ string, _ []
 	return nil
 }
 
+func (m *mockGateway) FetchSandboxLogs(_ context.Context, _, _ string, _ uint32) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 func newFakeKubeClientWithSecrets(objects ...runtime.Object) *kubeclient.KubeClient {
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(


### PR DESCRIPTION
## Summary

- Fixes race condition where the agent-sandbox controller could create a pod with `ndots:5` before our CR patch landed, breaking inference routing via `inference.local`
- Instead of eagerly deleting the pod after patching the CR, now verifies the pod's actual `/etc/resolv.conf` after it reaches Ready
- If `ndots:5` is found, deletes the pod so the controller recreates it from the already-patched CR (up to 3 retries)

## Test plan

- [ ] `cd components/ambient-control-plane && go build ./...` passes
- [ ] Deploy to kind cluster with cold image pull (clear containerd cache)
- [ ] Create a session and verify CP logs show `"verified sandbox DNS config: ndots is correct"`
- [ ] Verify sandbox pod has `ndots:1` in `/etc/resolv.conf`
- [ ] If race is hit, verify logs show `"sandbox pod has ndots:5, deleting for recreation"` followed by successful recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)