### PR TITLE
fix: remove SSO_REDIRECT_URI from hcmais UI overlay to fix value/valueFrom conflict

### DIFF
--- a/components/manifests/overlays/hcmais/ambient-ui-env-patch.yaml
+++ b/components/manifests/overlays/hcmais/ambient-ui-env-patch.yaml
@@ -8,7 +8,5 @@ spec:
       containers:
         - name: ambient-ui
           env:
-            - name: SSO_REDIRECT_URI
-              value: "https://ambient-ui-ambient-api.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com/api/auth/sso/callback"
             - name: NEXT_PUBLIC_PREVIEW_ALLOWED_HOSTS
               value: "*.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com,*.openshiftapps.com"


### PR DESCRIPTION
## Summary

- Removes the hardcoded `SSO_REDIRECT_URI` env var from the hcmais UI overlay patch, which conflicted with the `valueFrom` secret reference in the base manifest (Kubernetes rejects a container env entry that has both `value` and `valueFrom`).

## Resolution Steps for HCMAI Deployments

This PR is the code change portion of a broader deployment validation effort across `hcmai-01`, `hcmai-02`, and `hcmai-03`. The full set of issues diagnosed and resolved:

### 1. UI SSO Redirect Failure (this PR)
- **Symptom**: UI pod crashlooped — Kubernetes rejected the pod spec with `value/valueFrom` conflict on `SSO_REDIRECT_URI`.
- **Root cause**: The hcmais overlay set `SSO_REDIRECT_URI` via `value:`, but the base manifest already sources it via `valueFrom:` (secret reference). Kubernetes does not allow both.
- **Fix**: Removed the hardcoded `SSO_REDIRECT_URI` from the overlay. The base `valueFrom` secret reference is sufficient.

### 2. Sandbox Policy Not Delivered via gRPC (API fix, no code change)
- **Symptom**: v5 validation sessions failed — sandbox fell back to container disk policy (`/etc/openshell/policy.yaml`) instead of receiving the gRPC-delivered policy. Sandbox denied all ACP-internal requests (`DENIED .../token [policy:- engine:opa]`).
- **Root cause**: All 9 agents across 3 projects had `sandbox_policy=""` (empty). The kustomize patches referenced `sandbox_policy: ambient-dev-sandbox-policy` but `acpctl apply -k` did not apply the field.
- **Fix**: Directly PATCHed all 9 agents via REST API with `sandbox_policy: ambient-dev-sandbox-policy`.

### 3. GitLab L7 Proxy Blocks Encoded Slashes (API policy fix, no code change)
- **Symptom**: v6 sessions — GitLab requests DENIED at L7 layer despite passing OPA L4.
- **Root cause**: OpenShell L7 proxy rejects `%2F` (encoded `/`) in request-targets by default. GitLab API requires `%2F` for namespaced project paths (e.g., `ambient-code%2Fambient-code-gitops`).
- **Fix**: Added `allow_encoded_slash: true` to the GitLab endpoint in the sandbox policy spec. PATCHed all 4 policies (ambient-dev + 3 hcmai projects).

### 4. Jira v2 API Deprecated (test prompt fix, no code change)
- **Symptom**: v6 sessions — Jira requests returned errors.
- **Root cause**: Red Hat Jira deprecated `/rest/api/2/search`. The v3 replacement is `/rest/api/3/search/jql`.
- **Fix**: Updated validation session prompts to use v3 API.

## Validation Results (v7 Sessions)

All 3 projects validated with 4/4 PASS:

 < /dev/null |  Project  | LLM  | GitHub | GitLab | Jira |
|----------|------|--------|--------|------|
| hcmai-01 | PASS | PASS   | PASS   | PASS |
| hcmai-02 | PASS | PASS   | PASS   | PASS |
| hcmai-03 | PASS | PASS   | PASS   | PASS |

## Test plan
- [x] v7 validation sessions created for all 3 hcmai projects
- [x] Sandbox L7 logs confirm all 4 providers ALLOWED (GitHub, GitLab, Jira, Vertex AI)
- [x] Session messages confirm 4/4 PASS in all 3 projects
- [x] No regressions in ambient-dev project

🤖 Generated with [Claude Code](https://claude.ai/code)