### PR TITLE
docs: update README to reflect gateway mode as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#local-development-setup) for full local de
 
 ### OpenShell Gateway (Kind)
 
-The control plane delegates sandbox creation to an OpenShell gateway by default. `make kind-up` automatically installs all prerequisites: the tenant namespace, the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD (v0.4.6), and the [OpenShell gateway Helm chart](https://github.com/NVIDIA/OpenShell/tree/main/deploy/helm/openshell).
+The control plane delegates sandbox creation to an OpenShell gateway by default. `make kind-up` automatically installs all prerequisites: the tenant namespace, and the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD (v0.4.6). ACP will automatically install configuration similar to the [OpenShell gateway Helm chart](https://github.com/NVIDIA/OpenShell/tree/main/deploy/helm/openshell) when it is configured to manage a namespace.
 
 Override defaults with:
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,9 @@ make kind-port-forward   # ports shown in output
 
 See [CONTRIBUTING.md](CONTRIBUTING.md#local-development-setup) for full local development setup.
 
-### OpenShell Gateway Mode (Kind)
+### OpenShell Gateway (Kind)
 
-When running with `OPENSHELL_USE_GATEWAY=true`, the control plane delegates sandbox creation to an OpenShell gateway instead of creating pods directly.
-
-```bash
-make kind-up OPENSHELL_USE_GATEWAY=true
-```
-
-This automatically installs all prerequisites: the tenant namespace, the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD (v0.4.6), and the [OpenShell gateway Helm chart](https://github.com/NVIDIA/OpenShell/tree/main/deploy/helm/openshell). It also patches the control plane deployment with `OPENSHELL_USE_GATEWAY=true`.
+The control plane delegates sandbox creation to an OpenShell gateway by default. `make kind-up` automatically installs all prerequisites: the tenant namespace, the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD (v0.4.6), and the [OpenShell gateway Helm chart](https://github.com/NVIDIA/OpenShell/tree/main/deploy/helm/openshell).
 
 Override defaults with:
 


### PR DESCRIPTION
## Summary
- Gateway mode is now the default operating mode — removed instructions telling users to pass `OPENSHELL_USE_GATEWAY=true` to `make kind-up`
- Renamed section from "OpenShell Gateway Mode (Kind)" to "OpenShell Gateway (Kind)"
- Consolidated the description into a single paragraph stating gateway is the default

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `make kind-up` still sets up gateway mode without the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)