### PR TITLE
refactor(spec): remove owner/creator FK columns, favor RBAC-only ownership

### DIFF
--- a/specs/platform/data-model.spec.md
+++ b/specs/platform/data-model.spec.md
@@ -75,7 +75,6 @@ erDiagram
     Agent {
         string ID PK "KSUID"
         string project_id FK
-        string owner_user_id FK "user who owns this agent"
         string name "human-readable; unique within project"
         string display_name "nullable — human-friendly display label"
         string description "nullable — purpose description"
@@ -123,8 +122,6 @@ erDiagram
         string  name "human-readable display name"
         string  project_id FK "nullable — direct project context (no agent)"
         string  agent_id FK "nullable — set when started via agent ignite"
-        string  created_by_user_id FK "who created or started the session"
-        string  assigned_user_id FK "nullable — override for session ownership"
         string  parent_session_id FK "nullable — source session for clones"
         string  source_scheduled_session_id "nullable — FK to ScheduledSession that triggered this"
         time    scheduled_for "nullable — cron tick time; idempotency key with source_scheduled_session_id"
@@ -234,7 +231,6 @@ erDiagram
         string ID PK "KSUID"
         string project_id FK
         string agent_id FK "nullable — which Agent to ignite on each trigger"
-        string created_by_user_id "set from JWT on create; immutable"
         string name "human-readable; unique within project"
         string description
         string schedule "cron expression"
@@ -488,7 +484,6 @@ Agent is scoped to a Project. The stable address is `{project_name}/{agent_name}
 | `display_name` | Nullable. Human-friendly label for UI display; does not affect addressing. |
 | `description` | Nullable. Free-text purpose description. |
 | `prompt` | Defines who the agent is. Mutable via PATCH. Access controlled by RBAC (`agent:editor` or higher). |
-| `owner_user_id` | FK to the User who owns this agent. Set at creation; matches the authenticated caller. |
 | `repo_url` | Nullable. Primary repository URL cloned into every session the agent starts. Copied to `Session.repo_url` on ignite. |
 | `workflow_id` | Nullable. Default workflow identifier injected into sessions. Copied to `Session.workflow_id` on ignite. |
 | `llm_model` | Active LLM model name. Default: `claude-sonnet-4-6`. Copied to `Session.llm_model` on ignite. |
@@ -961,7 +956,6 @@ A `ScheduledSession` is a project-scoped definition that ignites an Agent on a r
 |-------|-------|
 | `name` | Human-readable, unique within the project. |
 | `agent_id` | Which Agent to ignite. Nullable — if NULL, creates a project-scoped session. |
-| `created_by_user_id` | User who created the schedule. Set server-side from JWT on create. Immutable. Used for pre-trigger authorization checks. |
 | `schedule` | Standard cron expression (e.g. `"0 9 * * 1-5"` = 9 AM on weekdays). Validated at write time. |
 | `timezone` | IANA timezone string (e.g. `"America/New_York"`). Defaults to `UTC`. |
 | `enabled` | `false` suspends evaluation without deleting the schedule. |
@@ -1307,7 +1301,6 @@ GET    /api/ambient/v1/projects/{id}/agents/{agent_id}/role_bindings    RBAC bin
     "id": "2abc...",
     "agent_id": "1def...",
     "phase": "pending",
-    "created_by_user_id": "...",
     "created_at": "2026-03-20T00:00:00Z"
   },
   "start_context": "# Agent: API\n\nYou are API...\n\n## Inbox\n...\n\n## Task\n..."
@@ -1870,7 +1863,7 @@ This structure means you can define and compose bespoke agent suites — entire 
 |---|---|
 | Agent is project-scoped, not global | Simplicity. An agent's identity and prompt are contextual to the project it serves. No indirection via a global registry. |
 | Agent.prompt is mutable | Prompt editing is a routine operational task. RBAC controls who can change it. No versioning overhead. |
-| Agent ownership via RBAC, not a hardcoded FK | Ownership is expressed as a RoleBinding (`scope=agent`, `agent_id=<id>`, `user_id=<owner>`). Enables multi-owner and delegated ownership consistently across all Kinds. |
+| Ownership via RBAC, not hardcoded FKs | Ownership of all Kinds is expressed through RoleBindings, not `owner_user_id` FKs. For Agents: `RoleBinding(scope=agent, agent_id=<id>, user_id=<owner>)`. For Sessions: `RoleBinding(scope=session, session_id=<id>, user_id=<assignee>)`. Enables multi-owner, delegated ownership, and transfer — consistently across all Kinds. Audit fields (who created/modified a resource) belong at the REST middleware layer, not on individual Kind schemas. |
 | One active Session per Agent | Avoids concurrent conflicting runs; start is idempotent |
 | Inbox on Agent, not Session | Messages persist across re-ignitions; addressed to the agent, not the run |
 | Inbox drained at start | Unread messages become part of the start context; session picks up where things left off |

--- a/specs/platform/mcp-server.spec.md
+++ b/specs/platform/mcp-server.spec.md
@@ -543,7 +543,6 @@ Lists agents visible to the caller.
     {
       "id": "agent-uuid-1",
       "name": "code-review",
-      "owner_user_id": "user-uuid",
       "version": 3
     }
   ]
@@ -1197,7 +1196,7 @@ func main() {
 | `INVALID_REQUEST` | 400 | Missing required field or malformed input |
 | `INVALID_LABEL_KEY` | 400 | Label key contains `=` or whitespace |
 | `INVALID_LABEL_VALUE` | 400 | Label value is empty |
-| `AGENT_NAME_CONFLICT` | 409 | Agent name already exists for this owner |
+| `AGENT_NAME_CONFLICT` | 409 | Agent name already exists in this project |
 | `SUBSCRIPTION_NOT_FOUND` | 404 | No active subscription with the given ID |
 | `TRANSPORT_NOT_SUPPORTED` | 400 | Operation requires SSE transport; caller is on stdio |
 | `ANNOTATION_VALUE_TOO_LARGE` | 400 | Annotation value exceeds 4096 bytes |

--- a/specs/platform/scheduled-session-execution.spec.md
+++ b/specs/platform/scheduled-session-execution.spec.md
@@ -8,7 +8,7 @@
 
 ## Purpose
 
-The `ScheduledSession` kind defines a recurring cron schedule that ignites an Agent at specified times. Today the kind is CRUD-only — nothing evaluates cron expressions, computes `next_run_at`, or creates sessions at the scheduled time. This spec defines the execution semantics: how schedules are evaluated, how sessions are created, how failures and edge cases are handled, and how the creator's identity is preserved across triggered runs.
+The `ScheduledSession` kind defines a recurring cron schedule that ignites an Agent at specified times. Today the kind is CRUD-only — nothing evaluates cron expressions, computes `next_run_at`, or creates sessions at the scheduled time. This spec defines the execution semantics: how schedules are evaluated, how sessions are created, and how failures and edge cases are handled.
 
 The scheduler runs inside the API server process. The control plane requires no changes — it picks up triggered sessions through the existing gRPC watch stream and reconciles them into Kubernetes Jobs exactly as it does today.
 
@@ -95,48 +95,23 @@ The API server SHALL run a background polling controller that evaluates due sche
 
 ---
 
-### Requirement: Creator Identity Propagation
+### Requirement: Pre-Trigger Validation
 
-The `ScheduledSession` model SHALL include a `created_by_user_id` field that records who created the schedule. Sessions created by the scheduler SHALL inherit this identity. The field SHALL be extracted from the authenticated JWT username via `auth.GetUsernameFromContext(ctx)` — the same pattern used by the session handler (`sessions/handler.go:88-89`).
+Before creating a session from a schedule, the scheduler SHALL verify that the schedule's referenced resources are still valid. The scheduler runs as internal API server code and uses its own service identity for session creation.
 
-#### Scenario: Creator identity set on create
-- GIVEN a user with ID `user-abc` creates a ScheduledSession
-- WHEN the API server persists the record
-- THEN `created_by_user_id` SHALL be set to `user-abc` from `auth.GetUsernameFromContext(ctx)`
-- AND `created_by_user_id` SHALL be immutable (ignored on PATCH)
-
-#### Scenario: Triggered session inherits creator identity
-- GIVEN a ScheduledSession with `created_by_user_id = "user-abc"`
-- WHEN the scheduler fires and creates a Session
-- THEN the new Session's `created_by_user_id` SHALL be set to `user-abc`
-- AND the scheduler SHALL call the session service layer's `Create` method directly (same code path as `ignite_handler.go:72`), setting `CreatedByUserId` on the session model before creation
-
----
-
-### Requirement: Pre-Trigger Authorization Check
-
-Before creating a session from a schedule, the scheduler SHALL verify that the schedule's creator still has permission to create sessions in the schedule's project. The scheduler runs as internal API server code (not as a user request), so it SHALL call the RBAC evaluator directly: `evaluator.Evaluate(ctx, createdByUserId, "session", "create", projectScope)`.
-
-#### Scenario: Creator still authorized
-- GIVEN a ScheduledSession with `created_by_user_id = "user-abc"` in project `my-project`
-- AND user `user-abc` has `session:create` permission on `my-project` (via `project:editor` or higher role)
+#### Scenario: Project still exists
+- GIVEN a ScheduledSession in project `my-project`
+- AND the project still exists and is not soft-deleted
 - WHEN the scheduler fires
 - THEN a Session SHALL be created normally
 
-#### Scenario: Creator no longer authorized
-- GIVEN a ScheduledSession with `created_by_user_id = "user-abc"` in project `my-project`
-- AND user `user-abc` no longer has `session:create` permission on `my-project`
+#### Scenario: Project no longer exists
+- GIVEN a ScheduledSession in project `my-project`
+- AND the project has been soft-deleted
 - WHEN the scheduler fires
 - THEN no Session SHALL be created
 - AND the schedule SHALL be set to `enabled = false`
-- AND a status message SHALL be recorded indicating the creator no longer has permission
-
-#### Scenario: Creator identity is NULL (pre-migration schedule)
-- GIVEN an existing ScheduledSession where `created_by_user_id` is NULL (created before the migration)
-- WHEN the scheduler evaluates this schedule
-- THEN the scheduler SHALL skip the schedule
-- AND set `enabled = false`
-- AND record a status message: "Schedule disabled: no creator identity. Re-create to enable."
+- AND a status message SHALL be recorded indicating the project no longer exists
 
 ---
 
@@ -238,7 +213,6 @@ When the scheduler or manual trigger creates a session, it SHALL copy template f
   - `agent_id` = `"agent-1"`
   - `source_scheduled_session_id` = the ScheduledSession's ID
   - `scheduled_for` = the cron tick time
-  - `created_by_user_id` = the ScheduledSession's `created_by_user_id`
 
 ---
 
@@ -285,10 +259,10 @@ Triggered sessions SHALL follow the existing session lifecycle for completion an
 
 ### Requirement: No Token Storage
 
-The scheduler SHALL NOT store user OAuth tokens, refresh tokens, or any credentials. Only the `created_by_user_id` (a user identifier) SHALL be stored on the `ScheduledSession`.
+The scheduler SHALL NOT store user OAuth tokens, refresh tokens, or any credentials on the `ScheduledSession`.
 
 #### Scenario: Credential resolution at trigger time
-- GIVEN a ScheduledSession with `created_by_user_id = "user-abc"`
+- GIVEN a ScheduledSession in project `my-project`
 - WHEN the scheduler fires
 - THEN credentials for the session SHALL be resolved at trigger time through the existing RBAC and credential-binding infrastructure
 - AND no stored tokens from the ScheduledSession record SHALL be used
@@ -346,7 +320,6 @@ The scheduler SHALL run inside the API server process. The control plane SHALL N
 
 | Field | Type | Nullable | Default | Notes |
 |-------|------|----------|---------|-------|
-| `created_by_user_id` | `string` | yes | `NULL` | Logical reference to users table (no FK constraint — matches Session.created_by_user_id pattern). Set from JWT on create. Immutable (ignored on PATCH). |
 | `overlap_policy` | `string` | no | `"skip"` | `"skip"` or `"allow"`. Validated at application level. |
 
 ### Session — New Fields
@@ -365,22 +338,20 @@ The scheduler SHALL run inside the API server process. The control plane SHALL N
 
 ### Migration Steps (ordered)
 
-1. Add `created_by_user_id` column to `scheduled_sessions` (nullable, no default)
-2. Add `overlap_policy` column to `scheduled_sessions` with default `"skip"`
-3. Add `source_scheduled_session_id` column to `sessions` (nullable)
-4. Add `scheduled_for` column to `sessions` (nullable)
-5. Create partial unique index `idx_sessions_schedule_idempotency`
-6. Create partial index `idx_ss_due`
-7. Backfill `next_run_at` for existing enabled scheduled sessions:
+1. Add `overlap_policy` column to `scheduled_sessions` with default `"skip"`
+2. Add `source_scheduled_session_id` column to `sessions` (nullable)
+3. Add `scheduled_for` column to `sessions` (nullable)
+4. Create partial unique index `idx_sessions_schedule_idempotency`
+5. Create partial index `idx_ss_due`
+6. Backfill `next_run_at` for existing enabled scheduled sessions:
    - Parse each schedule's cron expression using its `timezone` field
    - On parse failure, set `enabled = false` and `next_run_at = NULL`, log a warning
    - On success, compute `next_run_at` from `now()`
-8. Existing scheduled sessions with NULL `created_by_user_id` are left as-is — the scheduler skips and disables them on first evaluation (see Pre-Trigger Authorization Check)
 
 ### Cross-Spec Updates Required
 
 The following specs SHALL be updated to reflect these changes:
-- **`specs/platform/data-model.spec.md`**: Add `created_by_user_id`, `overlap_policy` to the ScheduledSession ERD and field table. Add `source_scheduled_session_id`, `scheduled_for` to the Session ERD and field table. Update trigger semantics (line 534) to reference `overlap_policy` instead of unconditional skip.
+- **`specs/platform/data-model.spec.md`**: Add `overlap_policy` to the ScheduledSession ERD and field table. Add `source_scheduled_session_id`, `scheduled_for` to the Session ERD and field table. Update trigger semantics to reference `overlap_policy` instead of unconditional skip.
 - **OpenAPI spec** (`openapi/openapi.yaml`): Add new fields to `ScheduledSession` and `Session` schemas. Update trigger response to return the created Session.
 - **SDKs** (Go, Python, TypeScript): Regenerate from updated OpenAPI spec. The `Trigger()` method return type changes from `error` to `(Session, error)`. The `Runs()` method return type changes from untyped map to `SessionList`.
 
@@ -413,9 +384,9 @@ The advisory lock ensures only one replica executes this query at a time. The `L
 | At-least-once with idempotency over at-most-once | Missing a scheduled session is worse than a harmless duplicate attempt rejected by a database constraint. The `UNIQUE(source_scheduled_session_id, scheduled_for)` constraint makes at-least-once operationally equivalent to exactly-once. |
 | Catch-up fires once, not all missed | AI sessions act on current repository state. Replaying N missed intervals after downtime wastes compute with no benefit. One catch-up run per schedule is sufficient. |
 | Skip-on-overlap as default | Concurrent AI sessions from the same schedule risk resource exhaustion and conflicting side effects. Skipping is the safe default; `allow` is opt-in per schedule. |
-| `created_by_user_id` over token storage | Storing user tokens creates a high-value attack target and requires rotation infrastructure. Storing only the user ID and resolving credentials at trigger time through existing RBAC is simpler and more secure. |
-| Pre-trigger auth check | Schedule creation time is not trigger time. A deprovisioned user should not continue spawning sessions indefinitely. The scheduler verifies the creator's permissions before every trigger. |
+| No token storage | Storing user tokens creates a high-value attack target and requires rotation infrastructure. Resolving credentials at trigger time through existing RBAC and credential-binding infrastructure is simpler and more secure. |
+| Pre-trigger validation, not auth check | The scheduler validates that referenced resources (project, agent) still exist before firing. Ownership and audit are handled at the REST middleware layer, not on individual Kind schemas (see data-model.spec.md Design Decisions). |
 | No gRPC watch for scheduled_sessions as prerequisite | The scheduler lives in the same process as the database. Watch streams for `scheduled_sessions` provide UI reactivity (live `next_run_at` updates) but are not required for scheduling and can be added later. |
-| Logical references, not FK constraints | `created_by_user_id` and `source_scheduled_session_id` are logical references (matching the existing `Session.created_by_user_id` pattern) rather than DB-level foreign keys. This avoids cascade complications with soft-deleted records and keeps the migration simple. |
+| Logical references, not FK constraints | `source_scheduled_session_id` is a logical reference rather than a DB-level foreign key. This avoids cascade complications with soft-deleted records and keeps the migration simple. |
 | Advisory lock over `FOR UPDATE SKIP LOCKED` | A single advisory lock per polling tick is simpler than per-row locking. At <1000 schedules the entire polling loop completes in milliseconds, so per-row contention is not a concern. If the API server scales to many replicas, the advisory lock ensures exactly one runs the scheduler. |
 | Partial unique index for idempotency | The unique index on `(source_scheduled_session_id, scheduled_for)` is partial (`WHERE source_scheduled_session_id IS NOT NULL`) to avoid PostgreSQL's NULL-pair uniqueness behavior. Non-scheduled sessions (NULL, NULL) are excluded from the constraint. |

--- a/specs/ui/scheduled-sessions.spec.md
+++ b/specs/ui/scheduled-sessions.spec.md
@@ -84,7 +84,7 @@ The user SHALL be able to edit an existing scheduled session.
 - GIVEN the user clicks the edit action on a schedule row
 - WHEN the edit sheet opens
 - THEN it SHALL be pre-populated with the schedule's current values
-- AND the user SHALL be able to modify any field except `created_by_user_id`
+- AND the user SHALL be able to modify any mutable field
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove `owner_user_id`, `created_by_user_id`, and `assigned_user_id` FK columns from Agent, Session, and ScheduledSession schemas across all specs
- Ownership is expressed through RoleBindings, not hardcoded FKs — consistent with the existing Design Decision in `data-model.spec.md`
- Audit fields (who created/modified a resource) belong at the REST middleware layer, not on individual Kind schemas

## Changes

### `data-model.spec.md`
- Removed `owner_user_id` from Agent ERD and field table
- Removed `created_by_user_id` and `assigned_user_id` from Session ERD
- Removed `created_by_user_id` from ScheduledSession ERD and field table
- Removed `created_by_user_id` from Ignite Response JSON example
- Updated Design Decision to broader RBAC-only ownership stance covering all Kinds

### `mcp-server.spec.md`
- Removed `owner_user_id` from `list_agents` API response example
- Changed `AGENT_NAME_CONFLICT` scoping from "for this owner" to "in this project"

### `scheduled-session-execution.spec.md`
- Replaced `Creator Identity Propagation` requirement with `Pre-Trigger Validation` (checks resource existence, not creator identity)
- Replaced `Pre-Trigger Authorization Check` (verifying creator's permissions) with project/agent existence validation
- Removed `created_by_user_id` from template fields, data model, migration steps, and design decisions
- Updated design rationale entries for token storage and auth check

### `scheduled-sessions.spec.md` (UI)
- Removed `created_by_user_id` from edit form immutability constraint

## Test plan
- [ ] Verify no remaining references to `owner_user_id`, `created_by_user_id`, or `assigned_user_id` as FK columns in any spec (counter-example mention in Design Decisions is intentional)
- [ ] Verify spec consistency: ScheduledSession execution spec no longer depends on creator identity for authorization

🤖 Generated with [Claude Code](https://claude.ai/code)