### PR TITLE
feat: wire session-config harness into runner

### DIFF
--- a/.github/workflows/sdd-preflight.yml
+++ b/.github/workflows/sdd-preflight.yml
@@ -47,6 +47,7 @@ jobs:
           fi
 
           # Get changed files in this PR (paginated API handles large diffs)
+          # shellcheck disable=SC2016
           CHANGED_FILES=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
           if [ -z "$CHANGED_FILES" ]; then
             echo "No changed files, skipping"
@@ -58,6 +59,7 @@ jobs:
           # Parse all managed components in a single yq call:
           # Output format: component<TAB>mode<TAB>path (one line per path)
           DEFAULT_MODE=$(yq '.default-mode // "warn"' "$MANIFEST")
+          # shellcheck disable=SC2016
           COMPONENT_PATHS=$(yq -r '
             .managed-components | to_entries[] |
             .key as $comp |
@@ -154,7 +156,10 @@ jobs:
           echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
-        if: steps.check.outputs.has_findings == 'true'
+        if: |
+          github.event_name == 'pull_request' &&
+          steps.check.outputs.has_findings == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.tekton/acp-runner-openshell-main-pull-request.yaml
+++ b/.tekton/acp-runner-openshell-main-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main" && ( "components/runners/ambient-runner/***".pathChanged() || ".tekton/acp-runner-openshell-main-pull-request.yaml".pathChanged()
-      || "Dockerfile.gw".pathChanged() )
+      || "components/runners/ambient-runner/Dockerfile.openshell".pathChanged() )
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: acp-runner-openshell-main
@@ -28,7 +28,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Dockerfile.gw
+    value: Dockerfile.openshell
   - name: path-context
     value: components/runners/ambient-runner
   pipelineSpec:

--- a/.tekton/acp-runner-openshell-main-push.yaml
+++ b/.tekton/acp-runner-openshell-main-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main" && ( "components/runners/ambient-runner/***".pathChanged() || ".tekton/acp-runner-openshell-main-push.yaml".pathChanged()
-      || "Dockerfile.gw".pathChanged() )
+      || "components/runners/ambient-runner/Dockerfile.openshell".pathChanged() )
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: acp-runner-openshell-main
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/agent-control-plane-main/acp-runner-openshell-main:{{revision}}
   - name: dockerfile
-    value: Dockerfile.gw
+    value: Dockerfile.openshell
   - name: path-context
     value: components/runners/ambient-runner
   pipelineSpec:

--- a/components/runners/ambient-runner/README.md
+++ b/components/runners/ambient-runner/README.md
@@ -170,6 +170,49 @@ On the cluster, when the operator copies `ambient-admin-mlflow-observability-sec
 
 - `MCP_CONFIG_FILE` - Path to MCP servers config (default: `/app/claude-runner/.mcp.json`)
 
+### Session Config Harness
+
+`SESSION_CONFIG_PATH` points the runner at a mounted session-config repository.
+Use this when an Agent should bring its own Claude skills or reusable harness
+content without making that repository the work repo.
+
+Declare the session-config repo as a sandbox payload and set the matching
+environment variable on the Agent:
+
+```yaml
+payloads:
+  - sandbox_path: /sandbox/session-config
+    repo_url: https://github.com/example/team-session-config
+    ref: main
+environment:
+  SESSION_CONFIG_PATH: /sandbox/session-config
+```
+
+At runtime:
+
+- The primary workflow or work repo remains Claude's `cwd`.
+- `/sandbox/session-config` is passed to the Claude SDK as an additional
+  directory.
+- Claude SDK skills are enabled so skills under the mounted harness can be
+  discovered and invoked semantically.
+
+A typical session-config repo can contain native Claude Code surfaces:
+
+```text
+.
+|-- AGENTS.md
+|-- .claude/
+|   `-- skills/
+|       `-- my-skill/
+|           `-- SKILL.md
+|-- skills/
+`-- library/
+```
+
+`SESSION_CONFIG_PATH` must be an existing absolute directory. If it is unset,
+relative, missing, or not a directory, the runner ignores it and starts with the
+normal workspace behavior.
+
 ### Google Workspace Integration
 
 - `USER_GOOGLE_EMAIL` - User's Google email for authentication (set by operator)

--- a/components/runners/ambient-runner/ambient_runner/app.py
+++ b/components/runners/ambient-runner/ambient_runner/app.py
@@ -36,7 +36,7 @@ from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
 from ambient_runner.bridge import PlatformBridge
-from ambient_runner.platform.config import load_ambient_config
+from ambient_runner.platform.config import get_session_config_path, load_ambient_config
 from ambient_runner.platform.context import RunnerContext
 from ambient_runner.platform.utils import get_bot_token, parse_owner_repo
 
@@ -114,6 +114,7 @@ def create_ambient_app(
         context = RunnerContext(
             session_id=session_id,
             workspace_path=workspace_path,
+            session_config_path=get_session_config_path(),
         )
         bridge.set_context(context)
 

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
@@ -34,6 +34,7 @@ from ambient_runner.bridge import (
     setup_bridge_observability,
 )
 from ambient_runner.bridges.claude.session import SessionManager
+from ambient_runner.platform.config import get_session_config_path
 from ambient_runner.platform.context import RunnerContext
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,7 @@ _SDK_OPTIONS_DENYLIST = frozenset(
         "api_key",
         "cli_path",
         "env",
+        "skills",
     }
 )
 
@@ -742,6 +744,8 @@ class ClaudeBridge(PlatformBridge):
 
         if self._add_dirs:
             options["add_dirs"] = self._add_dirs
+        if get_session_config_path():
+            options["skills"] = "all"
         if self._configured_model:
             options["model"] = self._configured_model
 

--- a/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
+++ b/components/runners/ambient-runner/ambient_runner/bridges/claude/bridge.py
@@ -34,7 +34,6 @@ from ambient_runner.bridge import (
     setup_bridge_observability,
 )
 from ambient_runner.bridges.claude.session import SessionManager
-from ambient_runner.platform.config import get_session_config_path
 from ambient_runner.platform.context import RunnerContext
 
 logger = logging.getLogger(__name__)
@@ -148,6 +147,7 @@ class ClaudeBridge(PlatformBridge):
         self._configured_model: str = ""
         self._cwd_path: str = ""
         self._add_dirs: list[str] = []
+        self._session_config_path: str | None = None
         self._mcp_servers: dict = {}
         self._allowed_tools: list[str] = []
         self._system_prompt: dict = {}
@@ -691,6 +691,7 @@ class ClaudeBridge(PlatformBridge):
         self._configured_model = configured_model
         self._cwd_path = cwd_path
         self._add_dirs = add_dirs
+        self._session_config_path = self._context.session_config_path
         self._mcp_servers = mcp_servers
         self._allowed_tools = allowed_tools
         self._system_prompt = system_prompt
@@ -744,7 +745,7 @@ class ClaudeBridge(PlatformBridge):
 
         if self._add_dirs:
             options["add_dirs"] = self._add_dirs
-        if get_session_config_path():
+        if self._session_config_path:
             options["skills"] = "all"
         if self._configured_model:
             options["model"] = self._configured_model

--- a/components/runners/ambient-runner/ambient_runner/platform/config.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/config.py
@@ -9,11 +9,40 @@ import json as _json
 import logging
 import os
 from pathlib import Path
+from typing import Final
 
 from ambient_runner.platform.context import RunnerContext
 from ambient_runner.platform.utils import parse_owner_repo
 
 logger = logging.getLogger(__name__)
+
+SESSION_CONFIG_PATH_ENV: Final = "SESSION_CONFIG_PATH"
+
+
+def get_session_config_path() -> str | None:
+    raw_path = os.getenv(SESSION_CONFIG_PATH_ENV, "").strip()
+    if not raw_path:
+        return None
+
+    session_config_path = Path(raw_path)
+    if not session_config_path.is_absolute():
+        logger.warning("%s must be absolute: %s", SESSION_CONFIG_PATH_ENV, raw_path)
+        return None
+    if not session_config_path.exists():
+        logger.warning(
+            "%s does not exist: %s",
+            SESSION_CONFIG_PATH_ENV,
+            session_config_path,
+        )
+        return None
+    if not session_config_path.is_dir():
+        logger.warning(
+            "%s is not a directory: %s",
+            SESSION_CONFIG_PATH_ENV,
+            session_config_path,
+        )
+        return None
+    return str(session_config_path)
 
 
 def load_ambient_config(cwd_path: str) -> dict:

--- a/components/runners/ambient-runner/ambient_runner/platform/context.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/context.py
@@ -18,12 +18,14 @@ class RunnerContext:
     Args:
         session_id: Unique identifier for this runner session.
         workspace_path: Absolute path to the workspace root directory.
+        session_config_path: Validated session-config directory, if configured.
         environment: Extra environment overrides (merged with ``os.environ``).
         metadata: Arbitrary key-value store for cross-cutting state.
     """
 
     session_id: str
     workspace_path: str
+    session_config_path: str | None = None
     environment: dict[str, str] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
     current_user_id: str = ""

--- a/components/runners/ambient-runner/ambient_runner/platform/workspace.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/workspace.py
@@ -161,6 +161,14 @@ def resolve_workspace_paths(context: RunnerContext) -> tuple[str, list[str]]:
             logger.error(f"Failed to create working directory: {e}")
             cwd_path = context.workspace_path
 
+    session_config_path = runner_config.get_session_config_path()
+    if (
+        session_config_path
+        and session_config_path != cwd_path
+        and session_config_path not in add_dirs
+    ):
+        add_dirs.append(session_config_path)
+
     logger.info(f"Claude SDK CWD: {cwd_path}")
     if add_dirs:
         logger.info(f"Claude SDK additional directories: {add_dirs}")

--- a/components/runners/ambient-runner/ambient_runner/platform/workspace.py
+++ b/components/runners/ambient-runner/ambient_runner/platform/workspace.py
@@ -161,7 +161,7 @@ def resolve_workspace_paths(context: RunnerContext) -> tuple[str, list[str]]:
             logger.error(f"Failed to create working directory: {e}")
             cwd_path = context.workspace_path
 
-    session_config_path = runner_config.get_session_config_path()
+    session_config_path = context.session_config_path
     if (
         session_config_path
         and session_config_path != cwd_path

--- a/components/runners/ambient-runner/tests/test_sdk_options.py
+++ b/components/runners/ambient-runner/tests/test_sdk_options.py
@@ -114,6 +114,7 @@ class TestParseSdkOptionsDenylist:
             "add_dirs",
             "cli_path",
             "env",
+            "skills",
         }
         assert _SDK_OPTIONS_DENYLIST == expected
 

--- a/components/runners/ambient-runner/tests/test_session_config_harness.py
+++ b/components/runners/ambient-runner/tests/test_session_config_harness.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from ambient_runner.bridges.claude import ClaudeBridge
+from ambient_runner.platform.config import get_session_config_path
 from ambient_runner.platform.context import RunnerContext
 from ambient_runner.platform.workspace import resolve_workspace_paths
 
@@ -23,12 +26,75 @@ def test_resolve_workspace_paths_adds_session_config_harness(
     monkeypatch.setenv("SESSION_CONFIG_PATH", str(session_config))
     monkeypatch.delenv("ACTIVE_WORKFLOW_GIT_URL", raising=False)
 
-    context = RunnerContext(session_id="s1", workspace_path=str(workspace))
+    context = RunnerContext(
+        session_id="s1",
+        workspace_path=str(workspace),
+        session_config_path=get_session_config_path(),
+    )
 
     cwd_path, add_dirs = resolve_workspace_paths(context)
 
     assert cwd_path == str(repo)
     assert str(session_config) in add_dirs
+
+
+def test_resolve_workspace_paths_uses_context_session_config_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    repo = workspace / "repos" / "app"
+    session_config = tmp_path / "sandbox" / "session-config"
+    repo.mkdir(parents=True)
+    session_config.mkdir(parents=True)
+
+    monkeypatch.setenv(
+        "REPOS_JSON",
+        '[{"name":"app","url":"https://github.com/example/app.git"}]',
+    )
+    monkeypatch.delenv("SESSION_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("ACTIVE_WORKFLOW_GIT_URL", raising=False)
+    monkeypatch.setattr(
+        "ambient_runner.platform.config.get_session_config_path",
+        lambda: pytest.fail("session-config path should be resolved once"),
+    )
+
+    context = RunnerContext(
+        session_id="s1",
+        workspace_path=str(workspace),
+        session_config_path=str(session_config),
+    )
+
+    cwd_path, add_dirs = resolve_workspace_paths(context)
+
+    assert cwd_path == str(repo)
+    assert str(session_config) in add_dirs
+
+
+def test_get_session_config_path_relative_path_returns_none(monkeypatch) -> None:
+    monkeypatch.setenv("SESSION_CONFIG_PATH", "relative/path")
+
+    assert get_session_config_path() is None
+
+
+def test_get_session_config_path_missing_dir_returns_none(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("SESSION_CONFIG_PATH", str(tmp_path / "missing"))
+
+    assert get_session_config_path() is None
+
+
+def test_get_session_config_path_file_not_dir_returns_none(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    session_config_file = tmp_path / "session-config-file"
+    session_config_file.write_text("not a directory")
+    monkeypatch.setenv("SESSION_CONFIG_PATH", str(session_config_file))
+
+    assert get_session_config_path() is None
 
 
 def test_claude_adapter_enables_skills_for_session_config_harness(
@@ -37,10 +103,10 @@ def test_claude_adapter_enables_skills_for_session_config_harness(
 ) -> None:
     session_config = tmp_path / "sandbox" / "session-config"
     session_config.mkdir(parents=True)
-    monkeypatch.setenv("SESSION_CONFIG_PATH", str(session_config))
 
     bridge = ClaudeBridge()
     bridge._cwd_path = "/workspace/repos/app"
+    bridge._session_config_path = str(session_config)
     bridge._allowed_tools = ["Read", "Write", "Bash"]
     bridge._mcp_servers = {}
     bridge._system_prompt = {

--- a/components/runners/ambient-runner/tests/test_session_config_harness.py
+++ b/components/runners/ambient-runner/tests/test_session_config_harness.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from ambient_runner.bridges.claude import ClaudeBridge
+from ambient_runner.platform.context import RunnerContext
+from ambient_runner.platform.workspace import resolve_workspace_paths
+
+
+def test_resolve_workspace_paths_adds_session_config_harness(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    repo = workspace / "repos" / "app"
+    session_config = tmp_path / "sandbox" / "session-config"
+    repo.mkdir(parents=True)
+    session_config.mkdir(parents=True)
+
+    monkeypatch.setenv(
+        "REPOS_JSON",
+        '[{"name":"app","url":"https://github.com/example/app.git"}]',
+    )
+    monkeypatch.setenv("SESSION_CONFIG_PATH", str(session_config))
+    monkeypatch.delenv("ACTIVE_WORKFLOW_GIT_URL", raising=False)
+
+    context = RunnerContext(session_id="s1", workspace_path=str(workspace))
+
+    cwd_path, add_dirs = resolve_workspace_paths(context)
+
+    assert cwd_path == str(repo)
+    assert str(session_config) in add_dirs
+
+
+def test_claude_adapter_enables_skills_for_session_config_harness(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    session_config = tmp_path / "sandbox" / "session-config"
+    session_config.mkdir(parents=True)
+    monkeypatch.setenv("SESSION_CONFIG_PATH", str(session_config))
+
+    bridge = ClaudeBridge()
+    bridge._cwd_path = "/workspace/repos/app"
+    bridge._allowed_tools = ["Read", "Write", "Bash"]
+    bridge._mcp_servers = {}
+    bridge._system_prompt = {
+        "type": "preset",
+        "preset": "claude_code",
+        "append": "base",
+    }
+
+    with patch(
+        "ambient_runner.bridges.claude.bridge.ClaudeAgentAdapter",
+    ) as adapter_class:
+        bridge._ensure_adapter()
+
+    options = adapter_class.call_args[1]["options"]
+    assert options["skills"] == "all"

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
             { slug: 'getting-started' },
             { slug: 'getting-started/quickstart-ui' },
             { slug: 'getting-started/concepts' },
+            { slug: 'getting-started/session-config' },
             { slug: 'getting-started/cli' },
           ],
         },

--- a/docs/src/content/docs/getting-started/quickstart-ui.md
+++ b/docs/src/content/docs/getting-started/quickstart-ui.md
@@ -37,7 +37,14 @@ Start the agent with a task prompt. ACP creates or reuses an active session for 
 
 The control plane then creates a runner Pod. When the runner is reachable, the session moves toward `Running` and starts streaming messages and AG-UI events.
 
-## 6. Work with the session
+## 6. Add a session-config harness
+
+Use a [session-config repo](../session-config/) when an agent needs shared team
+instructions, Claude skills, reusable review checklists, or curated Library
+content. The day-0 path mounts that repo into `/sandbox/session-config` through
+Agent YAML applied with `acpctl apply`.
+
+## 7. Work with the session
 
 Use the session view to follow the conversation, send more messages, inspect events, and review available file, Git, repository, workspace, and MCP status panels. These panels are backed by runner endpoints and are most useful while the session Pod is running.
 

--- a/docs/src/content/docs/getting-started/session-config.md
+++ b/docs/src/content/docs/getting-started/session-config.md
@@ -1,0 +1,98 @@
+---
+title: "Session Config Quickstart"
+---
+
+A session-config repo is a Git-backed harness for an agent session. Use it on
+day 0 when you want the runner to load shared instructions, Claude skills, or
+reusable context without making that repo the work repo.
+
+The current day-0 path is declarative Agent YAML applied with `acpctl apply`.
+There is not yet a `--session-config` CLI flag.
+
+## Create the repo
+
+Create a Git repository for your session harness. A minimal Claude skill layout
+looks like this:
+
+```text
+.
+|-- AGENTS.md
+`-- .claude/
+    `-- skills/
+        `-- release-reviewer/
+            `-- SKILL.md
+```
+
+Example `SKILL.md`:
+
+```markdown
+---
+name: release-reviewer
+description: Use when reviewing release readiness, release notes, or release-blocking risk.
+---
+
+# Release Reviewer
+
+Check open issues, recent commits, tests, docs, and known deployment risks.
+Return a short release readiness report with blockers first.
+```
+
+## Mount it into an Agent
+
+Add the repo as a payload at `/sandbox/session-config` and set
+`SESSION_CONFIG_PATH` to the same path:
+
+```yaml
+kind: Agent
+name: release-lead
+prompt: |
+  You manage release readiness. Use the team session-config harness when it
+  contains relevant skills or instructions.
+providers:
+  - vertex
+  - github
+repo_url: https://github.com/example/app
+payloads:
+  - sandbox_path: /sandbox/session-config
+    repo_url: https://github.com/example/team-session-config
+    ref: main
+environment:
+  SESSION_CONFIG_PATH: /sandbox/session-config
+```
+
+Apply the Agent:
+
+```bash
+acpctl apply -f release-lead.yaml --project my-project
+```
+
+Start the Agent:
+
+```bash
+acpctl agent start release-lead --prompt "Review release readiness for this week."
+```
+
+## What happens at runtime
+
+When `SESSION_CONFIG_PATH` points to an existing absolute directory:
+
+- The work repo remains the runner's working directory.
+- `/sandbox/session-config` is added as an extra Claude-readable directory.
+- Claude SDK skills are enabled, so skills from the mounted harness can be
+  activated by prompt intent.
+
+The session-config repo is loaded when the sandbox starts. Existing-session
+commands such as `acpctl session send` only add messages to a running session;
+they do not change the mounted harness for that session.
+
+## When to use it
+
+Use session config for stable team harness content:
+
+- Claude skills.
+- Team instructions.
+- Reusable review checklists.
+- Curated Library or memory files.
+
+Keep task-specific instructions in the session prompt. Keep code changes in the
+work repo.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -18,7 +18,9 @@ ACP is not a CRD data model. The API server is a Go service backed by PostgreSQL
 
 1. Read [What is ACP?](getting-started/) for the system model.
 2. Use [Quick start](getting-started/quickstart-ui/) to create a project, agent, and session from the UI.
-3. Use [CLI Reference](getting-started/cli/) when you want repeatable automation from a terminal or CI job.
+3. Add a [Session Config Quickstart](getting-started/session-config/) repo when an agent needs shared instructions, Claude skills, or reusable team
+   context.
+4. Use [CLI Reference](getting-started/cli/) when you want repeatable automation from a terminal or CI job.
 
 ## Core objects
 

--- a/specs/platform/runner.spec.md
+++ b/specs/platform/runner.spec.md
@@ -480,6 +480,7 @@ All env vars are injected by the CP at pod creation time.
 | `AMBIENT_MCP_URL` | Ambient MCP sidecar URL (SSE transport) |
 | `REPOS_JSON` | JSON array of `{url, branch, autoPush}` repo configs |
 | `ACTIVE_WORKFLOW_GIT_URL` | Active workflow repo URL (overrides REPOS_JSON workspace setup) |
+| `SESSION_CONFIG_PATH` | Existing absolute path to a mounted session-config harness repo; appended to Claude SDK `add_dirs` and enables SDK skills |
 | `AGUI_TOKEN` | Session-scoped bearer token; when set, all non-health endpoints require `X-Ambient-Session-Token` header (constant-time comparison) |
 | `PAYLOAD_MCP_CONFIG_FILE` | Path to payload `.mcp.json` (default `/sandbox/.mcp.json`); merged on top of baked-in MCP config |
 | `SDK_OPTIONS` | JSON string of additional Claude SDK options |
@@ -515,6 +516,23 @@ Priority order:
 ```
 
 The resolved `(cwd_path, add_dirs)` tuple is passed to the Claude SDK via `ClaudeAgentAdapter`. Claude Code sees `cwd_path` as its working directory and `add_dirs` as additional indexed directories.
+
+If `SESSION_CONFIG_PATH` is set to an existing absolute directory, the runner
+SHALL append it to `add_dirs` without replacing `cwd_path`. This supports
+Git-backed session-config harness repositories mounted by sandbox payloads:
+
+```yaml
+payloads:
+  - sandbox_path: /sandbox/session-config
+    repo_url: https://github.com/example/team-session-config
+    ref: main
+environment:
+  SESSION_CONFIG_PATH: /sandbox/session-config
+```
+
+For Claude sessions, the bridge SHALL also enable SDK skills when
+`SESSION_CONFIG_PATH` resolves successfully so skills in the mounted harness can
+be discovered and activated by semantic prompt intent.
 
 ---
 


### PR DESCRIPTION
## Summary

- Treat `SESSION_CONFIG_PATH` as a mounted session-config harness directory when it points to an existing absolute directory.
- Add that directory to the Claude SDK `add_dirs` list so runner sessions can see harness content outside the work repo cwd.
- Enable Claude SDK skills when a session-config harness is present, and prevent user-provided `SDK_OPTIONS` from overriding the platform-controlled `skills` option.

## Verification

- `uv run ruff check ambient_runner/platform/config.py ambient_runner/platform/workspace.py ambient_runner/bridges/claude/bridge.py tests/test_session_config_harness.py tests/test_sdk_options.py`
- `uv run pytest tests/test_session_config_harness.py tests/test_sdk_options.py -q`
- Live Claude Agent SDK probe with a temp `session-config/.claude/skills/semantic-harness-probe/SKILL.md`; semantic prompt invoked the `Skill` tool and final answer matched the skill marker exactly.

## Notes

This intentionally keeps the patch small: no new harness manifest, no catalog/lab example changes, and no prompt text changes. The runner only wires the mounted session-config directory into Claude SDK filesystem and skill discovery.
