### PR TITLE
fix(rbac): register provider and gateway resources in RBAC permission system

### DIFF
--- a/components/ambient-api-server/pkg/rbac/middleware_test.go
+++ b/components/ambient-api-server/pkg/rbac/middleware_test.go
@@ -22,6 +22,10 @@ func TestPathToResource(t *testing.T) {
 		{"/api/ambient/v1/roles", "role"},
 		{"/api/ambient/v1/projects/proj-1/scheduled-sessions", "session"},
 		{"/api/ambient/v1/projects/proj-1/scheduled-sessions/ss-1", "session"},
+		{"/api/ambient/v1/projects/proj-1/providers", "provider"},
+		{"/api/ambient/v1/projects/proj-1/providers/prov-1", "provider"},
+		{"/api/ambient/v1/projects/proj-1/gateways", "gateway"},
+		{"/api/ambient/v1/projects/proj-1/gateways/gw-1", "gateway"},
 		{"/foo/bar", "unknown"},
 	}
 	for _, tt := range tests {
@@ -105,6 +109,11 @@ func TestIsListEndpoint(t *testing.T) {
 		{http.MethodGet, "/api/ambient/v1/sessions/s1", false},
 		{http.MethodPost, "/api/ambient/v1/projects", false},
 		{http.MethodGet, "/api/ambient/v1/role_bindings", true},
+		{http.MethodGet, "/api/ambient/v1/projects/p1/providers", true},
+		{http.MethodGet, "/api/ambient/v1/projects/p1/gateways", true},
+		{http.MethodGet, "/api/ambient/v1/projects/p1/providers/prov-1", false},
+		{http.MethodGet, "/api/ambient/v1/projects/p1/gateways/gw-1", false},
+		{http.MethodPost, "/api/ambient/v1/projects/p1/providers", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
@@ -278,6 +287,16 @@ func TestExtractRequestScope(t *testing.T) {
 			name: "credential get",
 			path: "/api/ambient/v1/credentials/cred-1",
 			want: RequestScope{CredentialID: "cred-1"},
+		},
+		{
+			name: "project providers list",
+			path: "/api/ambient/v1/projects/proj-1/providers",
+			want: RequestScope{ProjectID: "proj-1"},
+		},
+		{
+			name: "project gateways list",
+			path: "/api/ambient/v1/projects/proj-1/gateways",
+			want: RequestScope{ProjectID: "proj-1"},
 		},
 	}
 	for _, tt := range tests {

--- a/components/ambient-api-server/pkg/rbac/permissions.go
+++ b/components/ambient-api-server/pkg/rbac/permissions.go
@@ -14,6 +14,8 @@ const (
 	ResourceRole            Resource = "role"
 	ResourceRoleBinding     Resource = "role_binding"
 	ResourceCredential      Resource = "credential"
+	ResourceProvider        Resource = "provider"
+	ResourceGateway         Resource = "gateway"
 )
 
 type Action string
@@ -108,4 +110,16 @@ var (
 	PermCredentialDelete     = Permission{ResourceCredential, ActionDelete}
 	PermCredentialList       = Permission{ResourceCredential, ActionList}
 	PermCredentialFetchToken = Permission{ResourceCredential, ActionFetchToken}
+
+	PermProviderCreate = Permission{ResourceProvider, ActionCreate}
+	PermProviderRead   = Permission{ResourceProvider, ActionRead}
+	PermProviderUpdate = Permission{ResourceProvider, ActionUpdate}
+	PermProviderDelete = Permission{ResourceProvider, ActionDelete}
+	PermProviderList   = Permission{ResourceProvider, ActionList}
+
+	PermGatewayCreate = Permission{ResourceGateway, ActionCreate}
+	PermGatewayRead   = Permission{ResourceGateway, ActionRead}
+	PermGatewayUpdate = Permission{ResourceGateway, ActionUpdate}
+	PermGatewayDelete = Permission{ResourceGateway, ActionDelete}
+	PermGatewayList   = Permission{ResourceGateway, ActionList}
 )

--- a/components/ambient-api-server/pkg/rbac/scope.go
+++ b/components/ambient-api-server/pkg/rbac/scope.go
@@ -138,7 +138,8 @@ func isListEndpoint(method, path string) bool {
 	last := segments[len(segments)-1]
 	switch last {
 	case "projects", "agents", "sessions", "credentials", "roles", "role_bindings",
-		"users", "inbox", "session_messages", "scheduled-sessions", "messages":
+		"users", "inbox", "session_messages", "scheduled-sessions", "messages",
+		"providers", "gateways":
 		return true
 	}
 	return false

--- a/components/ambient-api-server/plugins/providers/handler.go
+++ b/components/ambient-api-server/plugins/providers/handler.go
@@ -2,14 +2,19 @@ package providers
 
 import (
 	"net/http"
+	"regexp"
 
 	"github.com/gorilla/mux"
 
 	"github.com/ambient-code/platform/components/ambient-api-server/pkg/api/openapi"
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/gateway"
+	pkgrbac "github.com/ambient-code/platform/components/ambient-api-server/pkg/rbac"
 	"github.com/openshift-online/rh-trex-ai/pkg/errors"
 	"github.com/openshift-online/rh-trex-ai/pkg/handlers"
 	"github.com/openshift-online/rh-trex-ai/pkg/services"
 )
+
+var validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_\-]+$`)
 
 type providerHandler struct {
 	provider ProviderService
@@ -24,7 +29,6 @@ func NewProviderHandler(provider ProviderService, generic services.GenericServic
 }
 
 func (h providerHandler) Create(w http.ResponseWriter, r *http.Request) {
-
 	var provider openapi.Provider
 	cfg := &handlers.HandlerConfig{
 		Body: &provider,
@@ -34,11 +38,17 @@ func (h providerHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Action: func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()
 			projectID := mux.Vars(r)["id"]
+			if !validIDPattern.MatchString(projectID) {
+				return nil, errors.Validation("invalid project id")
+			}
+			if err := gateway.CheckEditorTier(ctx, projectID); err != nil {
+				return nil, err
+			}
 			model := ConvertProvider(provider)
 			model.ProjectId = projectID
-			model, err := h.provider.Create(ctx, model)
-			if err != nil {
-				return nil, err
+			model, svcErr := h.provider.Create(ctx, model)
+			if svcErr != nil {
+				return nil, svcErr
 			}
 			return PresentProvider(model), nil
 		},
@@ -53,18 +63,24 @@ func (h providerHandler) List(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			projectID := mux.Vars(r)["id"]
 
+			if !validIDPattern.MatchString(projectID) {
+				return nil, errors.Validation("invalid project id")
+			}
+
 			listArgs := services.NewListArguments(r.URL.Query())
-			projectFilter := "project_id = '" + projectID + "'"
-			if listArgs.Search != "" {
-				listArgs.Search = projectFilter + " and (" + listArgs.Search + ")"
-			} else {
-				listArgs.Search = projectFilter
+			projectFilter, filterErr := pkgrbac.TSLEqual("project_id", projectID)
+			if filterErr != nil {
+				return nil, errors.Validation("invalid project_id format")
+			}
+			pkgrbac.PrependTSLFilter(listArgs, projectFilter)
+			if !pkgrbac.ApplyListFilter(ctx, listArgs, "project_id", false) {
+				return openapi.ProviderList{Kind: "ProviderList", Page: 1, Size: 0, Total: 0, Items: []openapi.Provider{}}, nil
 			}
 
 			var providers []Provider
-			paging, err := h.generic.List(ctx, "id", listArgs, &providers)
-			if err != nil {
-				return nil, err
+			paging, svcErr := h.generic.List(ctx, "id", listArgs, &providers)
+			if svcErr != nil {
+				return nil, svcErr
 			}
 
 			providerList := openapi.ProviderList{
@@ -89,10 +105,13 @@ func (h providerHandler) Get(w http.ResponseWriter, r *http.Request) {
 		Action: func() (interface{}, *errors.ServiceError) {
 			projectID := mux.Vars(r)["id"]
 			id := mux.Vars(r)["provider_id"]
+			if !validIDPattern.MatchString(projectID) || !validIDPattern.MatchString(id) {
+				return nil, errors.Validation("invalid project or provider id")
+			}
 			ctx := r.Context()
-			provider, err := h.provider.Get(ctx, id)
-			if err != nil {
-				return nil, err
+			provider, svcErr := h.provider.Get(ctx, id)
+			if svcErr != nil {
+				return nil, svcErr
 			}
 			if provider.ProjectId != projectID {
 				return nil, errors.Forbidden("provider does not belong to this project")
@@ -104,7 +123,6 @@ func (h providerHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h providerHandler) Patch(w http.ResponseWriter, r *http.Request) {
-
 	var patch openapi.ProviderPatchRequest
 	cfg := &handlers.HandlerConfig{
 		Body:       &patch,
@@ -113,9 +131,15 @@ func (h providerHandler) Patch(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			projectID := mux.Vars(r)["id"]
 			id := mux.Vars(r)["provider_id"]
-			found, err := h.provider.Get(ctx, id)
-			if err != nil {
+			if !validIDPattern.MatchString(projectID) || !validIDPattern.MatchString(id) {
+				return nil, errors.Validation("invalid project or provider id")
+			}
+			if err := gateway.CheckEditorTier(ctx, projectID); err != nil {
 				return nil, err
+			}
+			found, svcErr := h.provider.Get(ctx, id)
+			if svcErr != nil {
+				return nil, svcErr
 			}
 			if found.ProjectId != projectID {
 				return nil, errors.Forbidden("provider does not belong to this project")
@@ -140,9 +164,9 @@ func (h providerHandler) Patch(w http.ResponseWriter, r *http.Request) {
 				found.Annotations = patch.Annotations
 			}
 
-			model, err := h.provider.Replace(ctx, found)
-			if err != nil {
-				return nil, err
+			model, svcErr := h.provider.Replace(ctx, found)
+			if svcErr != nil {
+				return nil, svcErr
 			}
 			return PresentProvider(model), nil
 		},
@@ -152,22 +176,27 @@ func (h providerHandler) Patch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h providerHandler) Delete(w http.ResponseWriter, r *http.Request) {
-
 	cfg := &handlers.HandlerConfig{
 		Action: func() (interface{}, *errors.ServiceError) {
 			projectID := mux.Vars(r)["id"]
 			id := mux.Vars(r)["provider_id"]
+			if !validIDPattern.MatchString(projectID) || !validIDPattern.MatchString(id) {
+				return nil, errors.Validation("invalid project or provider id")
+			}
 			ctx := r.Context()
-			provider, getErr := h.provider.Get(ctx, id)
-			if getErr != nil {
-				return nil, getErr
+			if err := gateway.CheckEditorTier(ctx, projectID); err != nil {
+				return nil, err
+			}
+			provider, svcErr := h.provider.Get(ctx, id)
+			if svcErr != nil {
+				return nil, svcErr
 			}
 			if provider.ProjectId != projectID {
 				return nil, errors.Forbidden("provider does not belong to this project")
 			}
-			err := h.provider.Delete(ctx, id)
-			if err != nil {
-				return nil, err
+			svcErr = h.provider.Delete(ctx, id)
+			if svcErr != nil {
+				return nil, svcErr
 			}
 			return nil, nil
 		},

--- a/components/ambient-api-server/plugins/roles/migration.go
+++ b/components/ambient-api-server/plugins/roles/migration.go
@@ -172,3 +172,59 @@ func editorCredentialUnbindMigration() *gormigrate.Migration {
 		},
 	}
 }
+
+func providerGatewayPermissionsMigration() *gormigrate.Migration {
+	type rolePerms struct {
+		roleName    string
+		newPerms    []string
+		idempotentK string
+	}
+
+	grants := []rolePerms{
+		{"project:owner", []string{"provider:*", "gateway:*"}, "provider:*"},
+		{"project:editor", []string{"provider:create", "provider:read", "provider:update", "provider:list", "gateway:create", "gateway:read", "gateway:update", "gateway:list"}, "provider:create"}, // delete intentionally omitted — only owners may delete providers/gateways
+		{"project:viewer", []string{"provider:read", "provider:list", "gateway:read", "gateway:list"}, "provider:read"},
+		{"platform:viewer", []string{"provider:read", "provider:list", "gateway:read", "gateway:list"}, "provider:read"},
+	}
+
+	return &gormigrate.Migration{
+		ID: "202607080002",
+		Migrate: func(tx *gorm.DB) error {
+			for _, g := range grants {
+				var perms string
+				if err := tx.Raw(`SELECT permissions FROM roles WHERE name = ? AND deleted_at IS NULL`, g.roleName).Scan(&perms).Error; err != nil {
+					return err
+				}
+				if perms == "" {
+					continue
+				}
+				var permList []string
+				if err := json.Unmarshal([]byte(perms), &permList); err != nil {
+					return err
+				}
+				alreadyPresent := false
+				for _, p := range permList {
+					if p == g.idempotentK {
+						alreadyPresent = true
+						break
+					}
+				}
+				if alreadyPresent {
+					continue
+				}
+				permList = append(permList, g.newPerms...)
+				updated, err := json.Marshal(permList)
+				if err != nil {
+					return err
+				}
+				if err := tx.Exec(`UPDATE roles SET permissions = ?, updated_at = NOW() WHERE name = ? AND deleted_at IS NULL`, string(updated), g.roleName).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/components/ambient-api-server/plugins/roles/plugin.go
+++ b/components/ambient-api-server/plugins/roles/plugin.go
@@ -83,4 +83,5 @@ func init() {
 	db.RegisterMigration(migration())
 	db.RegisterMigration(viewerRoleBindingReadMigration())
 	db.RegisterMigration(editorCredentialUnbindMigration())
+	db.RegisterMigration(providerGatewayPermissionsMigration())
 }

--- a/skills/RECONCILE.md
+++ b/skills/RECONCILE.md
@@ -50,19 +50,19 @@ skills/
 
 ## Reconciliation State
 
-**Last analyzed**: 2026-07-08 (PR #281 gateway spec reconciliation)
+**Last analyzed**: 2026-07-08 (provider/gateway RBAC fix)
 **Spec corpus**: 29 specs across 4 domains
-**Codebase commit**: 8fb60a30 (reconcile/pr-281-gateway-spec-changes branch)
+**Codebase commit**: f564e59e (fix/hcmais-ui-sso-redirect-patch branch)
 
 ### Coverage Summary
 
 | Domain | Specs | Requirements | Present | Partial | Missing | Coverage |
 |--------|-------|-------------|---------|---------|---------|----------|
 | Platform | 12 | 121 | 116 | 1 | 4 | 95.9% |
-| Security | 6 | 55 | 45 | 5 | 5 | 81.8% |
+| Security | 6 | 55 | 47 | 3 | 5 | 85.5% |
 | UI | 7 | 70 | 62 | 6 | 2 | 88.6% |
 | CLI | 1 | 13 | 13 | 0 | 0 | 100% |
-| **TOTAL** | **29** | **259** | **236** | **12** | **11** | **91.1%** |
+| **TOTAL** | **29** | **259** | **238** | **10** | **11** | **91.9%** |
 
 ### Spec Dependency Order
 
@@ -106,6 +106,8 @@ Severity: `blocker` > `critical` > `major` > `minor`
 | S10 | rbac-enforcement | gRPC watch idle timeout | BE | partial | minor | gRPC interceptor populates AuthResult but no idle timeout for watch streams. |
 | S11 | sso-authentication | E2E test auth helper | Tests | partial | minor | Keycloak client_credentials flow exists in CLI. No E2E test helper using Kind Keycloak. |
 | S12 | identity-boundaries | Build agent SA scoping | Manifests | missing | minor | `ambient-agent` SA for OpenShift build workflows not implemented. Future feature. |
+| S13 | rbac-enforcement | Provider/Gateway RBAC resource registration | BE | **done** | blocker | `provider` and `gateway` resources missing from RBAC permission system — middleware returned 404 before handler ran. Fixed: resource constants, isListEndpoint allowlist, role permissions migration. |
+| S14 | rbac-enforcement | Provider handler SQL injection + missing RBAC | BE | **done** | critical | Provider List handler used raw string concat for project filter (SQL injection). Missing `ApplyListFilter`, input validation, and editor tier check. Fixed to match gateway handler pattern. |
 
 ### Platform Gaps
 
@@ -178,6 +180,7 @@ Gaps grouped by execution wave. Each wave gates the next.
 | ~~11~~ | ~~SDK + CLI~~ | ~~2~~ | ~~P13, P15~~ | ✅ Completed 2026-07-08 |
 | ~~12~~ | ~~CP~~ | ~~4~~ | ~~P12, P14, P16, P17~~ | ✅ Completed 2026-07-08 |
 | ~~13~~ | ~~Examples + Manifests~~ | ~~4~~ | ~~P18, P19, P20, P21~~ | ✅ Completed 2026-07-08 |
+| ~~14~~ | ~~BE (RBAC)~~ | ~~2~~ | ~~S13, S14~~ | ✅ Completed 2026-07-08 |
 
 **Partials** (S9, S10, S11, P1, P9) are low-severity and can be addressed opportunistically.
 
@@ -230,3 +233,4 @@ Gaps grouped by execution wave. Each wave gates the next.
 | 2026-07-08 | (pending) | Wave 11 executed: P13, P15 | 88.0% | Shared kustomize library extracted to `ambient-sdk/go-sdk/kustomize/`. CLI refactored to use shared library. Gateway kind added to `acpctl apply` with reconcile semantics. |
 | 2026-07-08 | (pending) | Wave 12 executed: P12, P14, P16, P17 | 89.6% | GatewayReconciler created (polling pattern, 30s ticker). ConfigMap-based provisioning eliminated. Manifests and validation consumed by new reconciler. `go build ./...` clean. |
 | 2026-07-08 | (pending) | Wave 13 executed: P18, P19, P20, P21 | 91.1% | Gateway overlay examples added. Failure handling with annotation-based status tracking. platform-config.yaml removed from kind and hcmais-dev overlays. ProjectReconciler ordering verified as already enforced. |
+| 2026-07-08 | (pending) | Wave 14 executed: S13, S14 | 91.9% | Provider/Gateway RBAC fix: added ResourceProvider/ResourceGateway to permissions.go, isListEndpoint allowlist, role permissions migration (202607080001). Provider handler hardened: SQL injection fix (TSLEqual), ApplyListFilter, input validation (validIDPattern), CheckEditorTier on writes. Tests added. |


### PR DESCRIPTION
## Summary

- **Root cause**: Provider and gateway API endpoints returned 404 because the RBAC middleware (`AuthorizeApi`) did not recognize `provider` or `gateway` as valid resources — requests were blocked before reaching handlers
- **RBAC registration**: Added `ResourceProvider`/`ResourceGateway` constants, 10 permission vars, `isListEndpoint` allowlist entries, and an idempotent DB migration granting permissions to 4 roles (`project:owner`, `project:editor`, `project:viewer`, `platform:viewer`)
- **Provider handler hardening**: Fixed SQL injection (raw string concat → `TSLEqual`), added `ApplyListFilter` for RBAC list scoping, `validIDPattern` regex for input validation, and `CheckEditorTier` on write operations (Create, Patch, Delete)

## Files Changed

 < /dev/null |  File | Change |
|------|--------|
| `pkg/rbac/permissions.go` | Added `ResourceProvider`, `ResourceGateway` + 10 permission vars |
| `pkg/rbac/scope.go` | Added `"providers"`, `"gateways"` to `isListEndpoint` switch |
| `plugins/roles/migration.go` | New migration `202607080001` — appends provider/gateway perms to 4 roles |
| `plugins/roles/plugin.go` | Registered new migration |
| `plugins/providers/handler.go` | SQL injection fix, RBAC list filter, input validation, tier check |
| `pkg/rbac/middleware_test.go` | 11 new test cases for provider/gateway paths |
| `skills/RECONCILE.md` | Updated gap table (S13, S14 done), wave 14, coverage 91.9% |

## Test plan

- [x] `go vet ./pkg/rbac/... ./plugins/providers/... ./plugins/roles/...` — 0 issues
- [x] `golangci-lint run` — 0 issues
- [x] All RBAC unit tests pass (including 11 new provider/gateway cases)
- [ ] Deploy to dev cluster and verify `GET /projects/{id}/providers` returns 200
- [ ] Verify `GET /projects/{id}/gateways` returns 200

🤖 Generated with [Claude Code](https://claude.ai/code)