### PR TITLE
docs: add vTeam lab guide

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -11,3 +11,6 @@ BasedOnStyles = ACP
 # specific job. The platform name remains ACP everywhere else.
 [../examples/vteam-catalog/**/*.md]
 ACP.Terminology = NO
+
+[src/content/docs/guides/vteam-lab.md]
+ACP.Terminology = NO

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
         {
           label: 'Guides',
           items: [
+            { slug: 'guides/vteam-lab' },
             { slug: 'guides/custom-ca-bundle' },
             { slug: 'guides/work-tracking-annotations' },
           ],

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -40,6 +40,7 @@
     "NextJS",
     "OAuth",
     "OIDC",
+    "openshell",
     "OpenShift",
     "Opus",
     "Playwright",
@@ -63,6 +64,7 @@
     "teardown",
     "TypeScript",
     "unwatch",
+    "vTeam",
     "worktree",
     "YAML"
   ]

--- a/docs/src/content/docs/guides/vteam-lab.md
+++ b/docs/src/content/docs/guides/vteam-lab.md
@@ -21,7 +21,8 @@ ACP ships two catalog examples:
 | Product swarm | `vteam-product-swarm` | Cross-functional product delivery work with product, engineering, design, research, and writing roles. |
 | Codebase maintainers | `codebase-maintainers` | Internal codebase upkeep across implementation, runtime readiness, CI, security, docs, and release gates. |
 
-The manifests live in `examples/vteam-catalog/`.
+The manifests live in
+[examples/vteam-catalog](https://github.com/openshift-online/agent-control-plane/tree/main/examples/vteam-catalog).
 
 For local Kind clusters, `make kind-up` includes `vteam-product-swarm` and
 `codebase-maintainers` in the default `OPENSHELL_TENANTS` list, so those
@@ -45,8 +46,10 @@ acpctl apply -k examples/vteam-catalog/codebase-maintainers \
 The apply step creates or updates ACP records. Provider credentials become
 runtime requirements when a session starts.
 
-See `examples/README.md` for the full examples inventory, including starter
-tenant examples and the shared gateway field reference.
+See
+[examples/README.md](https://github.com/openshift-online/agent-control-plane/blob/main/examples/README.md)
+for the full examples inventory, including starter tenant examples and the
+shared gateway field reference.
 
 ## Gateway and namespace behavior
 
@@ -97,5 +100,5 @@ kubectl get namespace codebase-maintainers
 kubectl get statefulset openshell-gateway -n codebase-maintainers
 ```
 
-For a hand-run local reload flow, use
-`examples/vteam-catalog/QUICKSTART.md`.
+For a hand-run local reload flow, use the
+[vTeam Catalog quickstart](https://github.com/openshift-online/agent-control-plane/blob/main/examples/vteam-catalog/QUICKSTART.md).

--- a/docs/src/content/docs/guides/vteam-lab.md
+++ b/docs/src/content/docs/guides/vteam-lab.md
@@ -23,6 +23,10 @@ ACP ships two catalog examples:
 
 The manifests live in `examples/vteam-catalog/`.
 
+For local Kind clusters, `make kind-up` includes `vteam-product-swarm` and
+`codebase-maintainers` in the default `OPENSHELL_TENANTS` list, so those
+namespaces are ready for the lab.
+
 ## Apply a catalog team
 
 Log in to ACP with `acpctl`, then apply one catalog directory to its matching
@@ -40,6 +44,9 @@ acpctl apply -k examples/vteam-catalog/codebase-maintainers \
 
 The apply step creates or updates ACP records. Provider credentials become
 runtime requirements when a session starts.
+
+See `examples/README.md` for the full examples inventory, including starter
+tenant examples and the shared gateway field reference.
 
 ## Gateway and namespace behavior
 
@@ -69,16 +76,25 @@ creates the gateway Kubernetes resources there.
 After applying a catalog team, check the ACP records:
 
 ```bash
+# Product swarm
 acpctl get project vteam-product-swarm
 acpctl agent list --project-id vteam-product-swarm
 acpctl provider list --project-id vteam-product-swarm
+
+# Codebase maintainers
+acpctl get project codebase-maintainers
+acpctl agent list --project-id codebase-maintainers
+acpctl provider list --project-id codebase-maintainers
 ```
 
-On a local Kind cluster, also check the project namespace:
+On a local Kind cluster, also check the project namespaces:
 
 ```bash
 kubectl get namespace vteam-product-swarm
 kubectl get statefulset openshell-gateway -n vteam-product-swarm
+
+kubectl get namespace codebase-maintainers
+kubectl get statefulset openshell-gateway -n codebase-maintainers
 ```
 
 For a hand-run local reload flow, use

--- a/docs/src/content/docs/guides/vteam-lab.md
+++ b/docs/src/content/docs/guides/vteam-lab.md
@@ -1,0 +1,85 @@
+---
+title: vTeam Lab
+description: Apply the bundled multi-agent catalog examples to an ACP project
+---
+
+The vTeam lab shows how to model a coordinated group of agents with current
+ACP resources. Each lab team uses a `Project` as the workspace, `Agent`
+records as team members, shared `Provider` records for runtime integrations,
+and a project-scoped `Gateway` for OpenShell sandbox execution.
+
+If you use hosted ACP, your platform administrators provide Vertex AI access.
+You only need to provide personal or team integration credentials, such as
+GitHub and Jira, for examples that use those providers.
+
+## Catalog options
+
+ACP ships two catalog examples:
+
+| Team | Project | Use it for |
+| --- | --- | --- |
+| Product swarm | `vteam-product-swarm` | Cross-functional product delivery work with product, engineering, design, research, and writing roles. |
+| Codebase maintainers | `codebase-maintainers` | Internal codebase upkeep across implementation, runtime readiness, CI, security, docs, and release gates. |
+
+The manifests live in `examples/vteam-catalog/`.
+
+## Apply a catalog team
+
+Log in to ACP with `acpctl`, then apply one catalog directory to its matching
+project.
+
+```bash
+acpctl apply -k examples/vteam-catalog/product-swarm \
+  --project vteam-product-swarm
+```
+
+```bash
+acpctl apply -k examples/vteam-catalog/codebase-maintainers \
+  --project codebase-maintainers
+```
+
+The apply step creates or updates ACP records. Provider credentials become
+runtime requirements when a session starts.
+
+## Gateway and namespace behavior
+
+Each catalog team declares an OpenShell `Gateway` named `openshell-gateway`.
+ACP deploys that gateway into the project namespace, not into a namespace named
+after the gateway.
+
+For example, the `product-swarm` catalog uses:
+
+```yaml
+kind: Project
+name: vteam-product-swarm
+```
+
+```yaml
+kind: Gateway
+name: openshell-gateway
+server_dns_names:
+  - openshell-gateway.vteam-product-swarm.svc.cluster.local
+```
+
+The control plane resolves the project namespace as `vteam-product-swarm` and
+creates the gateway Kubernetes resources there.
+
+## Verify
+
+After applying a catalog team, check the ACP records:
+
+```bash
+acpctl get project vteam-product-swarm
+acpctl agent list --project-id vteam-product-swarm
+acpctl provider list --project-id vteam-product-swarm
+```
+
+On a local Kind cluster, also check the project namespace:
+
+```bash
+kubectl get namespace vteam-product-swarm
+kubectl get statefulset openshell-gateway -n vteam-product-swarm
+```
+
+For a hand-run local reload flow, use
+`examples/vteam-catalog/QUICKSTART.md`.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -21,6 +21,7 @@ ACP is not a CRD data model. The API server is a Go service backed by PostgreSQL
 3. Add a [Session Config Quickstart](getting-started/session-config/) repo when an agent needs shared instructions, Claude skills, or reusable team
    context.
 4. Use [CLI Reference](getting-started/cli/) when you want repeatable automation from a terminal or CI job.
+5. Try the [catalog lab](guides/vteam-lab/) when you want to apply a bundled multi-agent catalog.
 
 ## Core objects
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,59 +7,9 @@ This directory contains example Agent, Provider, Gateway, and Credential definit
 
 ## Prerequisites
 
-All examples share the same prerequisites. Set these up once before applying any example.
-
-### Vertex AI (required by all agents)
-
-All agents use Vertex AI for inference. When running `make kind-up`, the Vertex AI credential is automatically installed into all tenant namespaces from your local `vertex.json` (or the path in `VERTEX_CRED`).
-
-To create the secret manually in a namespace:
-
-```bash
-kubectl create secret generic vertex-sa-key \
-  --namespace=tenant-a \
-  --from-literal=token="$(cat vertex.json)"
-```
-
-The secret key must be `token`. The value must be the raw JSON content of a Google Service Account key file or an ADC `authorized_user` credential file.
-
-### GitHub (required by `pr-reviewer`)
-
-Create the secret with a GitHub Personal Access Token (classic or fine-grained) in each namespace that needs GitHub access:
-
-```bash
-kubectl create secret generic github-creds \
-  --from-literal=token="$(cat ~/github-pat.txt)" \
-  -n tenant-b
-```
-
-The token needs at minimum: `repo` (read), `pull_requests` (read).
-
-### Jira (required by `jira-simple-whoami`, `jira-simple-whoami-with-skill-payload`, and `jira-issue-categorizer`)
-
-Create the secret in each namespace that needs Jira access:
-
-```bash
-kubectl create secret generic jira \
-  --from-literal=JIRA_USERNAME="your-email@example.com" \
-  --from-literal=JIRA_API_TOKEN=$(cat ~/jira-token.txt) \
-  -n tenant-a
-```
-
-Store your API token in `~/jira-token.txt` before running the command. Generate one at: https://id.atlassian.com/manage-profile/security/api-tokens
-
-### Credential Environment Variables
-
-Credential YAML files reference tokens via environment variables (expanded by `acpctl apply` at apply time):
-
-| Variable | Used by | Value |
-|----------|---------|-------|
-| `$VERTEX_SA_KEY` | `credential-vertex.yaml` | Vertex AI service account JSON |
-| `$GITHUB_PAT` | `credential-github.yaml` | GitHub Personal Access Token |
-| `$JIRA_API_TOKEN` | `credential-jira.yaml` | Jira API token |
-| `$JIRA_EMAIL` | `credential-jira.yaml` | Jira account email |
-
-Export these before running `acpctl apply`.
+If you are using a hosted ACP environment, your administrators provide Vertex
+AI access; you only need to supply your own integration credentials, such as
+GitHub and Jira, for examples that use those providers.
 
 ---
 
@@ -168,6 +118,7 @@ The simplest possible agent. Sends a greeting and demonstrates payload injection
 **What it does:** Says hello world, and — thanks to an injected payload — also tells you how to say hello in a different language.
 
 **Session prompt example:**
+
 ```
 Say hello
 ```
@@ -183,6 +134,7 @@ A code security auditor. Analyzes code snippets or repositories for common vulne
 **What it does:** Reviews code for injection attacks, authentication issues, insecure data handling, and other vulnerabilities. Reports findings with severity, location, and remediation guidance.
 
 **Session prompt example:**
+
 ```
 Review this Python function for security issues:
 
@@ -200,12 +152,13 @@ looks up the authenticated user's profile.
 
 **Providers:** `vertex`, `jira`
 
-**Prerequisites:** `jira` secret in the tenant namespace (see above).
+**Prerequisites:** Jira credentials for the project.
 
 **What it does:** Uses the Jira Model Context Protocol tools to call the Jira
 API. Returns the current user's username and profile information.
 
 **Session prompt example:**
+
 ```
 Who am I in Jira?
 ```
@@ -218,11 +171,12 @@ Same as `jira-simple-whoami` but demonstrates the payload injection pattern: a s
 
 **Providers:** `vertex`, `jira`
 
-**Prerequisites:** `jira` secret in the tenant namespace (see above).
+**Prerequisites:** Jira credentials for the project.
 
 **What it does:** Looks up the Jira user profile and responds in olde English, as instructed by the injected skill payload.
 
 **Session prompt example:**
+
 ```
 Who am I in Jira?
 ```
@@ -237,9 +191,10 @@ report.
 
 **Providers:** `vertex`, `github`
 
-**Prerequisites:** `github-creds` secret in the tenant namespace (see above).
+**Prerequisites:** GitHub credentials for the project.
 
 **What it does:**
+
 1. Fetches PR metadata (title, description, author, branches)
 2. Retrieves changed files and full diffs
 3. Reads existing review comments for context
@@ -248,6 +203,7 @@ report.
 6. Ends with an overall recommendation: `APPROVE` / `REQUEST_CHANGES` / `COMMENT`
 
 **Session prompt example:**
+
 ```
 Review PR #42 in my-org/my-repo
 ```
@@ -260,9 +216,11 @@ Automatically categorizes Jira issues into Sankey Activity Types using AI. Inspi
 
 **Providers:** `vertex`, `jira`
 
-**Prerequisites:** `jira` secret in the tenant namespace (see above). The Jira URL is pre-configured to `https://redhat.atlassian.net` in the agent definition.
+**Prerequisites:** Jira credentials for the project. The Jira URL is
+pre-configured to `https://redhat.atlassian.net` in the agent definition.
 
 **What it does:**
+
 1. Searches for issues in the specified project(s) using JQL
 2. Reads each issue's summary and description
 3. Classifies it into one of six Sankey Activity Types using an injected classification guide:
@@ -276,12 +234,15 @@ Automatically categorizes Jira issues into Sankey Activity Types using AI. Inspi
 5. Optionally supports hierarchical propagation: propagates the Activity Type from parent issues down to all descendants
 
 **Session prompt examples:**
+
 ```
 Categorize issues in project RHCLOUD. Dry-run mode ON.
 ```
+
 ```
 Categorize issues in project RHCLOUD for components Clowder and Bonfire. Dry-run mode ON.
 ```
+
 ```
 Categorize issues in project HPSTRAT using hierarchical mode. Apply changes.
 ```
@@ -319,6 +280,7 @@ acpctl apply -k examples/vteam-catalog/codebase-maintainers --project codebase-m
 Each overlay declares a project-scoped OpenShell gateway in `gateway.yaml`. The gateway is reconciled by the GatewayReconciler into Kubernetes resources (StatefulSet, Service, RBAC, certgen Job).
 
 Key fields:
+
 - `image` — gateway container image (defaults to `OPENSHELL_GATEWAY_IMAGE` if omitted)
 - `server_dns_names` — DNS names for TLS certificate generation, scoped to the tenant namespace
 - `config` — optional TOML configuration for the gateway


### PR DESCRIPTION
## Summary

- Add a Starlight guide for the vTeam lab catalog added around PR #279
- Link the guide from the docs homepage and Guides sidebar
- Simplify the examples prerequisite section so hosted ACP users see Vertex as admin-provided and only need their own GitHub/Jira-style integration credentials
- Document that OpenShell gateway resources deploy into the project namespace, not a namespace named after the gateway

## Verification

- `npx --yes markdownlint-cli2@latest --config docs/.markdownlint.json "docs/src/content/docs/**/*.md" "examples/README.md"`
- `npx --yes cspell@latest lint --no-progress --config docs/cspell.json "docs/src/content/docs/**/*.md"`
- `cd docs && vale src/content/docs/guides/vteam-lab.md src/content/docs/index.md`

## Not run

- `npm run build` could not be completed locally because `npm ci` fails with `ENOSPC` on this machine. The partial `docs/node_modules` install was removed after the failed attempts.
