### PR TITLE
fix(control-plane): merge _acp_internal policy after sandbox READY

### DIFF
--- a/components/ambient-control-plane/internal/openshell/grpc/openshell/v1/openshell.pb.go
+++ b/components/ambient-control-plane/internal/openshell/grpc/openshell/v1/openshell.pb.go
@@ -1484,14 +1484,15 @@ func (x *ExecSandboxExit) GetExitCode() int32 {
 }
 
 type UpdateConfigRequest struct {
-	state                   protoimpl.MessageState `protogen:"open.v1"`
-	Name                    string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Policy                  *v11.SandboxPolicy     `protobuf:"bytes,2,opt,name=policy,proto3" json:"policy,omitempty"`
-	SettingKey              string                 `protobuf:"bytes,3,opt,name=setting_key,json=settingKey,proto3" json:"setting_key,omitempty"`
-	SettingValue            *v11.SettingValue      `protobuf:"bytes,4,opt,name=setting_value,json=settingValue,proto3" json:"setting_value,omitempty"`
-	DeleteSetting           bool                   `protobuf:"varint,5,opt,name=delete_setting,json=deleteSetting,proto3" json:"delete_setting,omitempty"`
-	Global                  bool                   `protobuf:"varint,6,opt,name=global,proto3" json:"global,omitempty"`
-	ExpectedResourceVersion uint64                 `protobuf:"varint,8,opt,name=expected_resource_version,json=expectedResourceVersion,proto3" json:"expected_resource_version,omitempty"`
+	state                   protoimpl.MessageState  `protogen:"open.v1"`
+	Name                    string                  `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Policy                  *v11.SandboxPolicy      `protobuf:"bytes,2,opt,name=policy,proto3" json:"policy,omitempty"`
+	SettingKey              string                  `protobuf:"bytes,3,opt,name=setting_key,json=settingKey,proto3" json:"setting_key,omitempty"`
+	SettingValue            *v11.SettingValue       `protobuf:"bytes,4,opt,name=setting_value,json=settingValue,proto3" json:"setting_value,omitempty"`
+	DeleteSetting           bool                    `protobuf:"varint,5,opt,name=delete_setting,json=deleteSetting,proto3" json:"delete_setting,omitempty"`
+	Global                  bool                    `protobuf:"varint,6,opt,name=global,proto3" json:"global,omitempty"`
+	MergeOperations         []*PolicyMergeOperation `protobuf:"bytes,7,rep,name=merge_operations,json=mergeOperations,proto3" json:"merge_operations,omitempty"`
+	ExpectedResourceVersion uint64                  `protobuf:"varint,8,opt,name=expected_resource_version,json=expectedResourceVersion,proto3" json:"expected_resource_version,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -1568,11 +1569,492 @@ func (x *UpdateConfigRequest) GetGlobal() bool {
 	return false
 }
 
+func (x *UpdateConfigRequest) GetMergeOperations() []*PolicyMergeOperation {
+	if x != nil {
+		return x.MergeOperations
+	}
+	return nil
+}
+
 func (x *UpdateConfigRequest) GetExpectedResourceVersion() uint64 {
 	if x != nil {
 		return x.ExpectedResourceVersion
 	}
 	return 0
+}
+
+type PolicyMergeOperation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Operation:
+	//
+	//	*PolicyMergeOperation_AddRule
+	//	*PolicyMergeOperation_RemoveEndpoint
+	//	*PolicyMergeOperation_RemoveRule
+	//	*PolicyMergeOperation_AddDenyRules
+	//	*PolicyMergeOperation_AddAllowRules
+	//	*PolicyMergeOperation_RemoveBinary
+	Operation     isPolicyMergeOperation_Operation `protobuf_oneof:"operation"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicyMergeOperation) Reset() {
+	*x = PolicyMergeOperation{}
+	mi := &file_openshell_v1_openshell_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicyMergeOperation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyMergeOperation) ProtoMessage() {}
+
+func (x *PolicyMergeOperation) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_v1_openshell_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyMergeOperation.ProtoReflect.Descriptor instead.
+func (*PolicyMergeOperation) Descriptor() ([]byte, []int) {
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *PolicyMergeOperation) GetOperation() isPolicyMergeOperation_Operation {
+	if x != nil {
+		return x.Operation
+	}
+	return nil
+}
+
+func (x *PolicyMergeOperation) GetAddRule() *AddNetworkRule {
+	if x != nil {
+		if x, ok := x.Operation.(*PolicyMergeOperation_AddRule); ok {
+			return x.AddRule
+		}
+	}
+	return nil
+}
+
+func (x *PolicyMergeOperation) GetRemoveEndpoint() *RemoveNetworkEndpoint {
+	if x != nil {
+		if x, ok := x.Operation.(*PolicyMergeOperation_RemoveEndpoint); ok {
+			return x.RemoveEndpoint
+		}
+	}
+	return nil
+}
+
+func (x *PolicyMergeOperation) GetRemoveRule() *RemoveNetworkRule {
+	if x != nil {
+		if x, ok := x.Operation.(*PolicyMergeOperation_RemoveRule); ok {
+			return x.RemoveRule
+		}
+	}
+	return nil
+}
+
+func (x *PolicyMergeOperation) GetAddDenyRules() *AddDenyRules {
+	if x != nil {
+		if x, ok := x.Operation.(*PolicyMergeOperation_AddDenyRules); ok {
+			return x.AddDenyRules
+		}
+	}
+	return nil
+}
+
+func (x *PolicyMergeOperation) GetAddAllowRules() *AddAllowRules {
+	if x != nil {
+		if x, ok := x.Operation.(*PolicyMergeOperation_AddAllowRules); ok {
+			return x.AddAllowRules
+		}
+	}
+	return nil
+}
+
+func (x *PolicyMergeOperation) GetRemoveBinary() *RemoveNetworkBinary {
+	if x != nil {
+		if x, ok := x.Operation.(*PolicyMergeOperation_RemoveBinary); ok {
+			return x.RemoveBinary
+		}
+	}
+	return nil
+}
+
+type isPolicyMergeOperation_Operation interface {
+	isPolicyMergeOperation_Operation()
+}
+
+type PolicyMergeOperation_AddRule struct {
+	AddRule *AddNetworkRule `protobuf:"bytes,1,opt,name=add_rule,json=addRule,proto3,oneof"`
+}
+
+type PolicyMergeOperation_RemoveEndpoint struct {
+	RemoveEndpoint *RemoveNetworkEndpoint `protobuf:"bytes,2,opt,name=remove_endpoint,json=removeEndpoint,proto3,oneof"`
+}
+
+type PolicyMergeOperation_RemoveRule struct {
+	RemoveRule *RemoveNetworkRule `protobuf:"bytes,3,opt,name=remove_rule,json=removeRule,proto3,oneof"`
+}
+
+type PolicyMergeOperation_AddDenyRules struct {
+	AddDenyRules *AddDenyRules `protobuf:"bytes,4,opt,name=add_deny_rules,json=addDenyRules,proto3,oneof"`
+}
+
+type PolicyMergeOperation_AddAllowRules struct {
+	AddAllowRules *AddAllowRules `protobuf:"bytes,5,opt,name=add_allow_rules,json=addAllowRules,proto3,oneof"`
+}
+
+type PolicyMergeOperation_RemoveBinary struct {
+	RemoveBinary *RemoveNetworkBinary `protobuf:"bytes,6,opt,name=remove_binary,json=removeBinary,proto3,oneof"`
+}
+
+func (*PolicyMergeOperation_AddRule) isPolicyMergeOperation_Operation() {}
+
+func (*PolicyMergeOperation_RemoveEndpoint) isPolicyMergeOperation_Operation() {}
+
+func (*PolicyMergeOperation_RemoveRule) isPolicyMergeOperation_Operation() {}
+
+func (*PolicyMergeOperation_AddDenyRules) isPolicyMergeOperation_Operation() {}
+
+func (*PolicyMergeOperation_AddAllowRules) isPolicyMergeOperation_Operation() {}
+
+func (*PolicyMergeOperation_RemoveBinary) isPolicyMergeOperation_Operation() {}
+
+type AddNetworkRule struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuleName      string                 `protobuf:"bytes,1,opt,name=rule_name,json=ruleName,proto3" json:"rule_name,omitempty"`
+	Rule          *v11.NetworkPolicyRule `protobuf:"bytes,2,opt,name=rule,proto3" json:"rule,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddNetworkRule) Reset() {
+	*x = AddNetworkRule{}
+	mi := &file_openshell_v1_openshell_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddNetworkRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddNetworkRule) ProtoMessage() {}
+
+func (x *AddNetworkRule) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_v1_openshell_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddNetworkRule.ProtoReflect.Descriptor instead.
+func (*AddNetworkRule) Descriptor() ([]byte, []int) {
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *AddNetworkRule) GetRuleName() string {
+	if x != nil {
+		return x.RuleName
+	}
+	return ""
+}
+
+func (x *AddNetworkRule) GetRule() *v11.NetworkPolicyRule {
+	if x != nil {
+		return x.Rule
+	}
+	return nil
+}
+
+type RemoveNetworkEndpoint struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuleName      string                 `protobuf:"bytes,1,opt,name=rule_name,json=ruleName,proto3" json:"rule_name,omitempty"`
+	Host          string                 `protobuf:"bytes,2,opt,name=host,proto3" json:"host,omitempty"`
+	Port          uint32                 `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveNetworkEndpoint) Reset() {
+	*x = RemoveNetworkEndpoint{}
+	mi := &file_openshell_v1_openshell_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveNetworkEndpoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveNetworkEndpoint) ProtoMessage() {}
+
+func (x *RemoveNetworkEndpoint) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_v1_openshell_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveNetworkEndpoint.ProtoReflect.Descriptor instead.
+func (*RemoveNetworkEndpoint) Descriptor() ([]byte, []int) {
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *RemoveNetworkEndpoint) GetRuleName() string {
+	if x != nil {
+		return x.RuleName
+	}
+	return ""
+}
+
+func (x *RemoveNetworkEndpoint) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *RemoveNetworkEndpoint) GetPort() uint32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+type RemoveNetworkRule struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuleName      string                 `protobuf:"bytes,1,opt,name=rule_name,json=ruleName,proto3" json:"rule_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveNetworkRule) Reset() {
+	*x = RemoveNetworkRule{}
+	mi := &file_openshell_v1_openshell_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveNetworkRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveNetworkRule) ProtoMessage() {}
+
+func (x *RemoveNetworkRule) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_v1_openshell_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveNetworkRule.ProtoReflect.Descriptor instead.
+func (*RemoveNetworkRule) Descriptor() ([]byte, []int) {
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *RemoveNetworkRule) GetRuleName() string {
+	if x != nil {
+		return x.RuleName
+	}
+	return ""
+}
+
+type AddDenyRules struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Port          uint32                 `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	DenyRules     []*v11.L7DenyRule      `protobuf:"bytes,3,rep,name=deny_rules,json=denyRules,proto3" json:"deny_rules,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddDenyRules) Reset() {
+	*x = AddDenyRules{}
+	mi := &file_openshell_v1_openshell_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddDenyRules) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddDenyRules) ProtoMessage() {}
+
+func (x *AddDenyRules) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_v1_openshell_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddDenyRules.ProtoReflect.Descriptor instead.
+func (*AddDenyRules) Descriptor() ([]byte, []int) {
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *AddDenyRules) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *AddDenyRules) GetPort() uint32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+func (x *AddDenyRules) GetDenyRules() []*v11.L7DenyRule {
+	if x != nil {
+		return x.DenyRules
+	}
+	return nil
+}
+
+type AddAllowRules struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Port          uint32                 `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	Rules         []*v11.L7Rule          `protobuf:"bytes,3,rep,name=rules,proto3" json:"rules,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddAllowRules) Reset() {
+	*x = AddAllowRules{}
+	mi := &file_openshell_v1_openshell_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddAllowRules) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddAllowRules) ProtoMessage() {}
+
+func (x *AddAllowRules) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_v1_openshell_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddAllowRules.ProtoReflect.Descriptor instead.
+func (*AddAllowRules) Descriptor() ([]byte, []int) {
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *AddAllowRules) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *AddAllowRules) GetPort() uint32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+func (x *AddAllowRules) GetRules() []*v11.L7Rule {
+	if x != nil {
+		return x.Rules
+	}
+	return nil
+}
+
+type RemoveNetworkBinary struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuleName      string                 `protobuf:"bytes,1,opt,name=rule_name,json=ruleName,proto3" json:"rule_name,omitempty"`
+	BinaryPath    string                 `protobuf:"bytes,2,opt,name=binary_path,json=binaryPath,proto3" json:"binary_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveNetworkBinary) Reset() {
+	*x = RemoveNetworkBinary{}
+	mi := &file_openshell_v1_openshell_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveNetworkBinary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveNetworkBinary) ProtoMessage() {}
+
+func (x *RemoveNetworkBinary) ProtoReflect() protoreflect.Message {
+	mi := &file_openshell_v1_openshell_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RemoveNetworkBinary.ProtoReflect.Descriptor instead.
+func (*RemoveNetworkBinary) Descriptor() ([]byte, []int) {
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *RemoveNetworkBinary) GetRuleName() string {
+	if x != nil {
+		return x.RuleName
+	}
+	return ""
+}
+
+func (x *RemoveNetworkBinary) GetBinaryPath() string {
+	if x != nil {
+		return x.BinaryPath
+	}
+	return ""
 }
 
 type UpdateConfigResponse struct {
@@ -1587,7 +2069,7 @@ type UpdateConfigResponse struct {
 
 func (x *UpdateConfigResponse) Reset() {
 	*x = UpdateConfigResponse{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[24]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1599,7 +2081,7 @@ func (x *UpdateConfigResponse) String() string {
 func (*UpdateConfigResponse) ProtoMessage() {}
 
 func (x *UpdateConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[24]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1612,7 +2094,7 @@ func (x *UpdateConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateConfigResponse.ProtoReflect.Descriptor instead.
 func (*UpdateConfigResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{24}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *UpdateConfigResponse) GetVersion() uint32 {
@@ -1660,7 +2142,7 @@ type ProviderCredentialRefreshStatus struct {
 
 func (x *ProviderCredentialRefreshStatus) Reset() {
 	*x = ProviderCredentialRefreshStatus{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[25]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1672,7 +2154,7 @@ func (x *ProviderCredentialRefreshStatus) String() string {
 func (*ProviderCredentialRefreshStatus) ProtoMessage() {}
 
 func (x *ProviderCredentialRefreshStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[25]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1685,7 +2167,7 @@ func (x *ProviderCredentialRefreshStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderCredentialRefreshStatus.ProtoReflect.Descriptor instead.
 func (*ProviderCredentialRefreshStatus) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{25}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ProviderCredentialRefreshStatus) GetProviderName() string {
@@ -1765,7 +2247,7 @@ type ConfigureProviderRefreshRequest struct {
 
 func (x *ConfigureProviderRefreshRequest) Reset() {
 	*x = ConfigureProviderRefreshRequest{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[26]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1777,7 +2259,7 @@ func (x *ConfigureProviderRefreshRequest) String() string {
 func (*ConfigureProviderRefreshRequest) ProtoMessage() {}
 
 func (x *ConfigureProviderRefreshRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[26]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1790,7 +2272,7 @@ func (x *ConfigureProviderRefreshRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureProviderRefreshRequest.ProtoReflect.Descriptor instead.
 func (*ConfigureProviderRefreshRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{26}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ConfigureProviderRefreshRequest) GetProvider() string {
@@ -1844,7 +2326,7 @@ type ConfigureProviderRefreshResponse struct {
 
 func (x *ConfigureProviderRefreshResponse) Reset() {
 	*x = ConfigureProviderRefreshResponse{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[27]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1856,7 +2338,7 @@ func (x *ConfigureProviderRefreshResponse) String() string {
 func (*ConfigureProviderRefreshResponse) ProtoMessage() {}
 
 func (x *ConfigureProviderRefreshResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[27]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1869,7 +2351,7 @@ func (x *ConfigureProviderRefreshResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigureProviderRefreshResponse.ProtoReflect.Descriptor instead.
 func (*ConfigureProviderRefreshResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{27}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ConfigureProviderRefreshResponse) GetStatus() *ProviderCredentialRefreshStatus {
@@ -1889,7 +2371,7 @@ type RotateProviderCredentialRequest struct {
 
 func (x *RotateProviderCredentialRequest) Reset() {
 	*x = RotateProviderCredentialRequest{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[28]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1901,7 +2383,7 @@ func (x *RotateProviderCredentialRequest) String() string {
 func (*RotateProviderCredentialRequest) ProtoMessage() {}
 
 func (x *RotateProviderCredentialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[28]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1914,7 +2396,7 @@ func (x *RotateProviderCredentialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateProviderCredentialRequest.ProtoReflect.Descriptor instead.
 func (*RotateProviderCredentialRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{28}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RotateProviderCredentialRequest) GetProvider() string {
@@ -1940,7 +2422,7 @@ type RotateProviderCredentialResponse struct {
 
 func (x *RotateProviderCredentialResponse) Reset() {
 	*x = RotateProviderCredentialResponse{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[29]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1952,7 +2434,7 @@ func (x *RotateProviderCredentialResponse) String() string {
 func (*RotateProviderCredentialResponse) ProtoMessage() {}
 
 func (x *RotateProviderCredentialResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[29]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1965,7 +2447,7 @@ func (x *RotateProviderCredentialResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateProviderCredentialResponse.ProtoReflect.Descriptor instead.
 func (*RotateProviderCredentialResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{29}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *RotateProviderCredentialResponse) GetStatus() *ProviderCredentialRefreshStatus {
@@ -1984,7 +2466,7 @@ type CreateSshSessionRequest struct {
 
 func (x *CreateSshSessionRequest) Reset() {
 	*x = CreateSshSessionRequest{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[30]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1996,7 +2478,7 @@ func (x *CreateSshSessionRequest) String() string {
 func (*CreateSshSessionRequest) ProtoMessage() {}
 
 func (x *CreateSshSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[30]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2009,7 +2491,7 @@ func (x *CreateSshSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSshSessionRequest.ProtoReflect.Descriptor instead.
 func (*CreateSshSessionRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{30}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CreateSshSessionRequest) GetSandboxId() string {
@@ -2034,7 +2516,7 @@ type CreateSshSessionResponse struct {
 
 func (x *CreateSshSessionResponse) Reset() {
 	*x = CreateSshSessionResponse{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[31]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2046,7 +2528,7 @@ func (x *CreateSshSessionResponse) String() string {
 func (*CreateSshSessionResponse) ProtoMessage() {}
 
 func (x *CreateSshSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[31]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2059,7 +2541,7 @@ func (x *CreateSshSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSshSessionResponse.ProtoReflect.Descriptor instead.
 func (*CreateSshSessionResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{31}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CreateSshSessionResponse) GetSandboxId() string {
@@ -2127,7 +2609,7 @@ type TcpForwardInit struct {
 
 func (x *TcpForwardInit) Reset() {
 	*x = TcpForwardInit{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[32]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2139,7 +2621,7 @@ func (x *TcpForwardInit) String() string {
 func (*TcpForwardInit) ProtoMessage() {}
 
 func (x *TcpForwardInit) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[32]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2152,7 +2634,7 @@ func (x *TcpForwardInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpForwardInit.ProtoReflect.Descriptor instead.
 func (*TcpForwardInit) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{32}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *TcpForwardInit) GetSandboxId() string {
@@ -2230,7 +2712,7 @@ type TcpForwardFrame struct {
 
 func (x *TcpForwardFrame) Reset() {
 	*x = TcpForwardFrame{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[33]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2242,7 +2724,7 @@ func (x *TcpForwardFrame) String() string {
 func (*TcpForwardFrame) ProtoMessage() {}
 
 func (x *TcpForwardFrame) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[33]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2255,7 +2737,7 @@ func (x *TcpForwardFrame) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpForwardFrame.ProtoReflect.Descriptor instead.
 func (*TcpForwardFrame) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{33}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *TcpForwardFrame) GetPayload() isTcpForwardFrame_Payload {
@@ -2307,7 +2789,7 @@ type SshRelayTarget struct {
 
 func (x *SshRelayTarget) Reset() {
 	*x = SshRelayTarget{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[34]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2319,7 +2801,7 @@ func (x *SshRelayTarget) String() string {
 func (*SshRelayTarget) ProtoMessage() {}
 
 func (x *SshRelayTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[34]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2332,7 +2814,7 @@ func (x *SshRelayTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SshRelayTarget.ProtoReflect.Descriptor instead.
 func (*SshRelayTarget) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{34}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{41}
 }
 
 type TcpRelayTarget struct {
@@ -2345,7 +2827,7 @@ type TcpRelayTarget struct {
 
 func (x *TcpRelayTarget) Reset() {
 	*x = TcpRelayTarget{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[35]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2357,7 +2839,7 @@ func (x *TcpRelayTarget) String() string {
 func (*TcpRelayTarget) ProtoMessage() {}
 
 func (x *TcpRelayTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[35]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2370,7 +2852,7 @@ func (x *TcpRelayTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TcpRelayTarget.ProtoReflect.Descriptor instead.
 func (*TcpRelayTarget) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{35}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *TcpRelayTarget) GetHost() string {
@@ -2405,7 +2887,7 @@ type WatchSandboxRequest struct {
 
 func (x *WatchSandboxRequest) Reset() {
 	*x = WatchSandboxRequest{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[36]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2417,7 +2899,7 @@ func (x *WatchSandboxRequest) String() string {
 func (*WatchSandboxRequest) ProtoMessage() {}
 
 func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[36]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2430,7 +2912,7 @@ func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxRequest.ProtoReflect.Descriptor instead.
 func (*WatchSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{36}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *WatchSandboxRequest) GetId() string {
@@ -2518,7 +3000,7 @@ type SandboxStreamEvent struct {
 
 func (x *SandboxStreamEvent) Reset() {
 	*x = SandboxStreamEvent{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[37]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2530,7 +3012,7 @@ func (x *SandboxStreamEvent) String() string {
 func (*SandboxStreamEvent) ProtoMessage() {}
 
 func (x *SandboxStreamEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[37]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2543,7 +3025,7 @@ func (x *SandboxStreamEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStreamEvent.ProtoReflect.Descriptor instead.
 func (*SandboxStreamEvent) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{37}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SandboxStreamEvent) GetPayload() isSandboxStreamEvent_Payload {
@@ -2632,7 +3114,7 @@ type SandboxLogLine struct {
 
 func (x *SandboxLogLine) Reset() {
 	*x = SandboxLogLine{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[38]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2644,7 +3126,7 @@ func (x *SandboxLogLine) String() string {
 func (*SandboxLogLine) ProtoMessage() {}
 
 func (x *SandboxLogLine) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[38]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2657,7 +3139,7 @@ func (x *SandboxLogLine) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxLogLine.ProtoReflect.Descriptor instead.
 func (*SandboxLogLine) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{38}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *SandboxLogLine) GetSandboxId() string {
@@ -2723,7 +3205,7 @@ type PlatformEvent struct {
 
 func (x *PlatformEvent) Reset() {
 	*x = PlatformEvent{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[39]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2735,7 +3217,7 @@ func (x *PlatformEvent) String() string {
 func (*PlatformEvent) ProtoMessage() {}
 
 func (x *PlatformEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[39]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2748,7 +3230,7 @@ func (x *PlatformEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlatformEvent.ProtoReflect.Descriptor instead.
 func (*PlatformEvent) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{39}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *PlatformEvent) GetTimestampMs() int64 {
@@ -2802,7 +3284,7 @@ type SandboxStreamWarning struct {
 
 func (x *SandboxStreamWarning) Reset() {
 	*x = SandboxStreamWarning{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[40]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2814,7 +3296,7 @@ func (x *SandboxStreamWarning) String() string {
 func (*SandboxStreamWarning) ProtoMessage() {}
 
 func (x *SandboxStreamWarning) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[40]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2827,7 +3309,7 @@ func (x *SandboxStreamWarning) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxStreamWarning.ProtoReflect.Descriptor instead.
 func (*SandboxStreamWarning) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{40}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *SandboxStreamWarning) GetMessage() string {
@@ -2850,7 +3332,7 @@ type GetSandboxLogsRequest struct {
 
 func (x *GetSandboxLogsRequest) Reset() {
 	*x = GetSandboxLogsRequest{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[41]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2862,7 +3344,7 @@ func (x *GetSandboxLogsRequest) String() string {
 func (*GetSandboxLogsRequest) ProtoMessage() {}
 
 func (x *GetSandboxLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[41]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2875,7 +3357,7 @@ func (x *GetSandboxLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetSandboxLogsRequest) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{41}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetSandboxLogsRequest) GetSandboxId() string {
@@ -2923,7 +3405,7 @@ type GetSandboxLogsResponse struct {
 
 func (x *GetSandboxLogsResponse) Reset() {
 	*x = GetSandboxLogsResponse{}
-	mi := &file_openshell_v1_openshell_proto_msgTypes[42]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2935,7 +3417,7 @@ func (x *GetSandboxLogsResponse) String() string {
 func (*GetSandboxLogsResponse) ProtoMessage() {}
 
 func (x *GetSandboxLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_openshell_v1_openshell_proto_msgTypes[42]
+	mi := &file_openshell_v1_openshell_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2948,7 +3430,7 @@ func (x *GetSandboxLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSandboxLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetSandboxLogsResponse) Descriptor() ([]byte, []int) {
-	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{42}
+	return file_openshell_v1_openshell_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetSandboxLogsResponse) GetLogs() []*SandboxLogLine {
@@ -3079,7 +3561,7 @@ const file_openshell_v1_openshell_proto_rawDesc = "" +
 	"\x11ExecSandboxStderr\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\".\n" +
 	"\x0fExecSandboxExit\x12\x1b\n" +
-	"\texit_code\x18\x01 \x01(\x05R\bexitCode\"\xcb\x02\n" +
+	"\texit_code\x18\x01 \x01(\x05R\bexitCode\"\x9a\x03\n" +
 	"\x13UpdateConfigRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12;\n" +
 	"\x06policy\x18\x02 \x01(\v2#.openshell.sandbox.v1.SandboxPolicyR\x06policy\x12\x1f\n" +
@@ -3087,8 +3569,40 @@ const file_openshell_v1_openshell_proto_rawDesc = "" +
 	"settingKey\x12G\n" +
 	"\rsetting_value\x18\x04 \x01(\v2\".openshell.sandbox.v1.SettingValueR\fsettingValue\x12%\n" +
 	"\x0edelete_setting\x18\x05 \x01(\bR\rdeleteSetting\x12\x16\n" +
-	"\x06global\x18\x06 \x01(\bR\x06global\x12:\n" +
-	"\x19expected_resource_version\x18\b \x01(\x04R\x17expectedResourceVersion\"\x98\x01\n" +
+	"\x06global\x18\x06 \x01(\bR\x06global\x12M\n" +
+	"\x10merge_operations\x18\a \x03(\v2\".openshell.v1.PolicyMergeOperationR\x0fmergeOperations\x12:\n" +
+	"\x19expected_resource_version\x18\b \x01(\x04R\x17expectedResourceVersion\"\xc7\x03\n" +
+	"\x14PolicyMergeOperation\x129\n" +
+	"\badd_rule\x18\x01 \x01(\v2\x1c.openshell.v1.AddNetworkRuleH\x00R\aaddRule\x12N\n" +
+	"\x0fremove_endpoint\x18\x02 \x01(\v2#.openshell.v1.RemoveNetworkEndpointH\x00R\x0eremoveEndpoint\x12B\n" +
+	"\vremove_rule\x18\x03 \x01(\v2\x1f.openshell.v1.RemoveNetworkRuleH\x00R\n" +
+	"removeRule\x12B\n" +
+	"\x0eadd_deny_rules\x18\x04 \x01(\v2\x1a.openshell.v1.AddDenyRulesH\x00R\faddDenyRules\x12E\n" +
+	"\x0fadd_allow_rules\x18\x05 \x01(\v2\x1b.openshell.v1.AddAllowRulesH\x00R\raddAllowRules\x12H\n" +
+	"\rremove_binary\x18\x06 \x01(\v2!.openshell.v1.RemoveNetworkBinaryH\x00R\fremoveBinaryB\v\n" +
+	"\toperation\"j\n" +
+	"\x0eAddNetworkRule\x12\x1b\n" +
+	"\trule_name\x18\x01 \x01(\tR\bruleName\x12;\n" +
+	"\x04rule\x18\x02 \x01(\v2'.openshell.sandbox.v1.NetworkPolicyRuleR\x04rule\"\\\n" +
+	"\x15RemoveNetworkEndpoint\x12\x1b\n" +
+	"\trule_name\x18\x01 \x01(\tR\bruleName\x12\x12\n" +
+	"\x04host\x18\x02 \x01(\tR\x04host\x12\x12\n" +
+	"\x04port\x18\x03 \x01(\rR\x04port\"0\n" +
+	"\x11RemoveNetworkRule\x12\x1b\n" +
+	"\trule_name\x18\x01 \x01(\tR\bruleName\"w\n" +
+	"\fAddDenyRules\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\rR\x04port\x12?\n" +
+	"\n" +
+	"deny_rules\x18\x03 \x03(\v2 .openshell.sandbox.v1.L7DenyRuleR\tdenyRules\"k\n" +
+	"\rAddAllowRules\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\rR\x04port\x122\n" +
+	"\x05rules\x18\x03 \x03(\v2\x1c.openshell.sandbox.v1.L7RuleR\x05rules\"S\n" +
+	"\x13RemoveNetworkBinary\x12\x1b\n" +
+	"\trule_name\x18\x01 \x01(\tR\bruleName\x12\x1f\n" +
+	"\vbinary_path\x18\x02 \x01(\tR\n" +
+	"binaryPath\"\x98\x01\n" +
 	"\x14UpdateConfigResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\rR\aversion\x12\x1f\n" +
 	"\vpolicy_hash\x18\x02 \x01(\tR\n" +
@@ -3257,7 +3771,7 @@ func file_openshell_v1_openshell_proto_rawDescGZIP() []byte {
 }
 
 var file_openshell_v1_openshell_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_openshell_v1_openshell_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
+var file_openshell_v1_openshell_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
 var file_openshell_v1_openshell_proto_goTypes = []any{
 	(SandboxPhase)(0),                        // 0: openshell.v1.SandboxPhase
 	(ProviderCredentialRefreshStrategy)(0),   // 1: openshell.v1.ProviderCredentialRefreshStrategy
@@ -3285,116 +3799,136 @@ var file_openshell_v1_openshell_proto_goTypes = []any{
 	(*ExecSandboxStderr)(nil),                // 23: openshell.v1.ExecSandboxStderr
 	(*ExecSandboxExit)(nil),                  // 24: openshell.v1.ExecSandboxExit
 	(*UpdateConfigRequest)(nil),              // 25: openshell.v1.UpdateConfigRequest
-	(*UpdateConfigResponse)(nil),             // 26: openshell.v1.UpdateConfigResponse
-	(*ProviderCredentialRefreshStatus)(nil),  // 27: openshell.v1.ProviderCredentialRefreshStatus
-	(*ConfigureProviderRefreshRequest)(nil),  // 28: openshell.v1.ConfigureProviderRefreshRequest
-	(*ConfigureProviderRefreshResponse)(nil), // 29: openshell.v1.ConfigureProviderRefreshResponse
-	(*RotateProviderCredentialRequest)(nil),  // 30: openshell.v1.RotateProviderCredentialRequest
-	(*RotateProviderCredentialResponse)(nil), // 31: openshell.v1.RotateProviderCredentialResponse
-	(*CreateSshSessionRequest)(nil),          // 32: openshell.v1.CreateSshSessionRequest
-	(*CreateSshSessionResponse)(nil),         // 33: openshell.v1.CreateSshSessionResponse
-	(*TcpForwardInit)(nil),                   // 34: openshell.v1.TcpForwardInit
-	(*TcpForwardFrame)(nil),                  // 35: openshell.v1.TcpForwardFrame
-	(*SshRelayTarget)(nil),                   // 36: openshell.v1.SshRelayTarget
-	(*TcpRelayTarget)(nil),                   // 37: openshell.v1.TcpRelayTarget
-	(*WatchSandboxRequest)(nil),              // 38: openshell.v1.WatchSandboxRequest
-	(*SandboxStreamEvent)(nil),               // 39: openshell.v1.SandboxStreamEvent
-	(*SandboxLogLine)(nil),                   // 40: openshell.v1.SandboxLogLine
-	(*PlatformEvent)(nil),                    // 41: openshell.v1.PlatformEvent
-	(*SandboxStreamWarning)(nil),             // 42: openshell.v1.SandboxStreamWarning
-	(*GetSandboxLogsRequest)(nil),            // 43: openshell.v1.GetSandboxLogsRequest
-	(*GetSandboxLogsResponse)(nil),           // 44: openshell.v1.GetSandboxLogsResponse
-	nil,                                      // 45: openshell.v1.SandboxSpec.EnvironmentEntry
-	nil,                                      // 46: openshell.v1.SandboxTemplate.LabelsEntry
-	nil,                                      // 47: openshell.v1.SandboxTemplate.AnnotationsEntry
-	nil,                                      // 48: openshell.v1.SandboxTemplate.EnvironmentEntry
-	nil,                                      // 49: openshell.v1.CreateSandboxRequest.LabelsEntry
-	nil,                                      // 50: openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
-	nil,                                      // 51: openshell.v1.ExecSandboxRequest.EnvironmentEntry
-	nil,                                      // 52: openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
-	nil,                                      // 53: openshell.v1.SandboxLogLine.FieldsEntry
-	nil,                                      // 54: openshell.v1.PlatformEvent.MetadataEntry
-	(*v1.ObjectMeta)(nil),                    // 55: openshell.datamodel.v1.ObjectMeta
-	(*v11.SandboxPolicy)(nil),                // 56: openshell.sandbox.v1.SandboxPolicy
-	(*v1.Provider)(nil),                      // 57: openshell.datamodel.v1.Provider
-	(*v11.SettingValue)(nil),                 // 58: openshell.sandbox.v1.SettingValue
+	(*PolicyMergeOperation)(nil),             // 26: openshell.v1.PolicyMergeOperation
+	(*AddNetworkRule)(nil),                   // 27: openshell.v1.AddNetworkRule
+	(*RemoveNetworkEndpoint)(nil),            // 28: openshell.v1.RemoveNetworkEndpoint
+	(*RemoveNetworkRule)(nil),                // 29: openshell.v1.RemoveNetworkRule
+	(*AddDenyRules)(nil),                     // 30: openshell.v1.AddDenyRules
+	(*AddAllowRules)(nil),                    // 31: openshell.v1.AddAllowRules
+	(*RemoveNetworkBinary)(nil),              // 32: openshell.v1.RemoveNetworkBinary
+	(*UpdateConfigResponse)(nil),             // 33: openshell.v1.UpdateConfigResponse
+	(*ProviderCredentialRefreshStatus)(nil),  // 34: openshell.v1.ProviderCredentialRefreshStatus
+	(*ConfigureProviderRefreshRequest)(nil),  // 35: openshell.v1.ConfigureProviderRefreshRequest
+	(*ConfigureProviderRefreshResponse)(nil), // 36: openshell.v1.ConfigureProviderRefreshResponse
+	(*RotateProviderCredentialRequest)(nil),  // 37: openshell.v1.RotateProviderCredentialRequest
+	(*RotateProviderCredentialResponse)(nil), // 38: openshell.v1.RotateProviderCredentialResponse
+	(*CreateSshSessionRequest)(nil),          // 39: openshell.v1.CreateSshSessionRequest
+	(*CreateSshSessionResponse)(nil),         // 40: openshell.v1.CreateSshSessionResponse
+	(*TcpForwardInit)(nil),                   // 41: openshell.v1.TcpForwardInit
+	(*TcpForwardFrame)(nil),                  // 42: openshell.v1.TcpForwardFrame
+	(*SshRelayTarget)(nil),                   // 43: openshell.v1.SshRelayTarget
+	(*TcpRelayTarget)(nil),                   // 44: openshell.v1.TcpRelayTarget
+	(*WatchSandboxRequest)(nil),              // 45: openshell.v1.WatchSandboxRequest
+	(*SandboxStreamEvent)(nil),               // 46: openshell.v1.SandboxStreamEvent
+	(*SandboxLogLine)(nil),                   // 47: openshell.v1.SandboxLogLine
+	(*PlatformEvent)(nil),                    // 48: openshell.v1.PlatformEvent
+	(*SandboxStreamWarning)(nil),             // 49: openshell.v1.SandboxStreamWarning
+	(*GetSandboxLogsRequest)(nil),            // 50: openshell.v1.GetSandboxLogsRequest
+	(*GetSandboxLogsResponse)(nil),           // 51: openshell.v1.GetSandboxLogsResponse
+	nil,                                      // 52: openshell.v1.SandboxSpec.EnvironmentEntry
+	nil,                                      // 53: openshell.v1.SandboxTemplate.LabelsEntry
+	nil,                                      // 54: openshell.v1.SandboxTemplate.AnnotationsEntry
+	nil,                                      // 55: openshell.v1.SandboxTemplate.EnvironmentEntry
+	nil,                                      // 56: openshell.v1.CreateSandboxRequest.LabelsEntry
+	nil,                                      // 57: openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
+	nil,                                      // 58: openshell.v1.ExecSandboxRequest.EnvironmentEntry
+	nil,                                      // 59: openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
+	nil,                                      // 60: openshell.v1.SandboxLogLine.FieldsEntry
+	nil,                                      // 61: openshell.v1.PlatformEvent.MetadataEntry
+	(*v1.ObjectMeta)(nil),                    // 62: openshell.datamodel.v1.ObjectMeta
+	(*v11.SandboxPolicy)(nil),                // 63: openshell.sandbox.v1.SandboxPolicy
+	(*v1.Provider)(nil),                      // 64: openshell.datamodel.v1.Provider
+	(*v11.SettingValue)(nil),                 // 65: openshell.sandbox.v1.SettingValue
+	(*v11.NetworkPolicyRule)(nil),            // 66: openshell.sandbox.v1.NetworkPolicyRule
+	(*v11.L7DenyRule)(nil),                   // 67: openshell.sandbox.v1.L7DenyRule
+	(*v11.L7Rule)(nil),                       // 68: openshell.sandbox.v1.L7Rule
 }
 var file_openshell_v1_openshell_proto_depIdxs = []int32{
-	55, // 0: openshell.v1.Sandbox.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
+	62, // 0: openshell.v1.Sandbox.metadata:type_name -> openshell.datamodel.v1.ObjectMeta
 	3,  // 1: openshell.v1.Sandbox.spec:type_name -> openshell.v1.SandboxSpec
 	5,  // 2: openshell.v1.Sandbox.status:type_name -> openshell.v1.SandboxStatus
-	45, // 3: openshell.v1.SandboxSpec.environment:type_name -> openshell.v1.SandboxSpec.EnvironmentEntry
+	52, // 3: openshell.v1.SandboxSpec.environment:type_name -> openshell.v1.SandboxSpec.EnvironmentEntry
 	4,  // 4: openshell.v1.SandboxSpec.template:type_name -> openshell.v1.SandboxTemplate
-	56, // 5: openshell.v1.SandboxSpec.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	46, // 6: openshell.v1.SandboxTemplate.labels:type_name -> openshell.v1.SandboxTemplate.LabelsEntry
-	47, // 7: openshell.v1.SandboxTemplate.annotations:type_name -> openshell.v1.SandboxTemplate.AnnotationsEntry
-	48, // 8: openshell.v1.SandboxTemplate.environment:type_name -> openshell.v1.SandboxTemplate.EnvironmentEntry
+	63, // 5: openshell.v1.SandboxSpec.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	53, // 6: openshell.v1.SandboxTemplate.labels:type_name -> openshell.v1.SandboxTemplate.LabelsEntry
+	54, // 7: openshell.v1.SandboxTemplate.annotations:type_name -> openshell.v1.SandboxTemplate.AnnotationsEntry
+	55, // 8: openshell.v1.SandboxTemplate.environment:type_name -> openshell.v1.SandboxTemplate.EnvironmentEntry
 	6,  // 9: openshell.v1.SandboxStatus.conditions:type_name -> openshell.v1.SandboxCondition
 	0,  // 10: openshell.v1.SandboxStatus.phase:type_name -> openshell.v1.SandboxPhase
 	3,  // 11: openshell.v1.CreateSandboxRequest.spec:type_name -> openshell.v1.SandboxSpec
-	49, // 12: openshell.v1.CreateSandboxRequest.labels:type_name -> openshell.v1.CreateSandboxRequest.LabelsEntry
+	56, // 12: openshell.v1.CreateSandboxRequest.labels:type_name -> openshell.v1.CreateSandboxRequest.LabelsEntry
 	2,  // 13: openshell.v1.SandboxResponse.sandbox:type_name -> openshell.v1.Sandbox
-	57, // 14: openshell.v1.CreateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
-	57, // 15: openshell.v1.UpdateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
-	50, // 16: openshell.v1.UpdateProviderRequest.credential_expires_at_ms:type_name -> openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
-	57, // 17: openshell.v1.ProviderResponse.provider:type_name -> openshell.datamodel.v1.Provider
-	57, // 18: openshell.v1.ListProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
-	51, // 19: openshell.v1.ExecSandboxRequest.environment:type_name -> openshell.v1.ExecSandboxRequest.EnvironmentEntry
+	64, // 14: openshell.v1.CreateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
+	64, // 15: openshell.v1.UpdateProviderRequest.provider:type_name -> openshell.datamodel.v1.Provider
+	57, // 16: openshell.v1.UpdateProviderRequest.credential_expires_at_ms:type_name -> openshell.v1.UpdateProviderRequest.CredentialExpiresAtMsEntry
+	64, // 17: openshell.v1.ProviderResponse.provider:type_name -> openshell.datamodel.v1.Provider
+	64, // 18: openshell.v1.ListProvidersResponse.providers:type_name -> openshell.datamodel.v1.Provider
+	58, // 19: openshell.v1.ExecSandboxRequest.environment:type_name -> openshell.v1.ExecSandboxRequest.EnvironmentEntry
 	22, // 20: openshell.v1.ExecSandboxEvent.stdout:type_name -> openshell.v1.ExecSandboxStdout
 	23, // 21: openshell.v1.ExecSandboxEvent.stderr:type_name -> openshell.v1.ExecSandboxStderr
 	24, // 22: openshell.v1.ExecSandboxEvent.exit:type_name -> openshell.v1.ExecSandboxExit
-	56, // 23: openshell.v1.UpdateConfigRequest.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
-	58, // 24: openshell.v1.UpdateConfigRequest.setting_value:type_name -> openshell.sandbox.v1.SettingValue
-	1,  // 25: openshell.v1.ProviderCredentialRefreshStatus.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	1,  // 26: openshell.v1.ConfigureProviderRefreshRequest.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
-	52, // 27: openshell.v1.ConfigureProviderRefreshRequest.material:type_name -> openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
-	27, // 28: openshell.v1.ConfigureProviderRefreshResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
-	27, // 29: openshell.v1.RotateProviderCredentialResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
-	36, // 30: openshell.v1.TcpForwardInit.ssh:type_name -> openshell.v1.SshRelayTarget
-	37, // 31: openshell.v1.TcpForwardInit.tcp:type_name -> openshell.v1.TcpRelayTarget
-	34, // 32: openshell.v1.TcpForwardFrame.init:type_name -> openshell.v1.TcpForwardInit
-	2,  // 33: openshell.v1.SandboxStreamEvent.sandbox:type_name -> openshell.v1.Sandbox
-	40, // 34: openshell.v1.SandboxStreamEvent.log:type_name -> openshell.v1.SandboxLogLine
-	41, // 35: openshell.v1.SandboxStreamEvent.event:type_name -> openshell.v1.PlatformEvent
-	42, // 36: openshell.v1.SandboxStreamEvent.warning:type_name -> openshell.v1.SandboxStreamWarning
-	53, // 37: openshell.v1.SandboxLogLine.fields:type_name -> openshell.v1.SandboxLogLine.FieldsEntry
-	54, // 38: openshell.v1.PlatformEvent.metadata:type_name -> openshell.v1.PlatformEvent.MetadataEntry
-	40, // 39: openshell.v1.GetSandboxLogsResponse.logs:type_name -> openshell.v1.SandboxLogLine
-	7,  // 40: openshell.v1.OpenShell.CreateSandbox:input_type -> openshell.v1.CreateSandboxRequest
-	8,  // 41: openshell.v1.OpenShell.GetSandbox:input_type -> openshell.v1.GetSandboxRequest
-	9,  // 42: openshell.v1.OpenShell.DeleteSandbox:input_type -> openshell.v1.DeleteSandboxRequest
-	32, // 43: openshell.v1.OpenShell.CreateSshSession:input_type -> openshell.v1.CreateSshSessionRequest
-	20, // 44: openshell.v1.OpenShell.ExecSandbox:input_type -> openshell.v1.ExecSandboxRequest
-	35, // 45: openshell.v1.OpenShell.ForwardTcp:input_type -> openshell.v1.TcpForwardFrame
-	12, // 46: openshell.v1.OpenShell.CreateProvider:input_type -> openshell.v1.CreateProviderRequest
-	15, // 47: openshell.v1.OpenShell.UpdateProvider:input_type -> openshell.v1.UpdateProviderRequest
-	13, // 48: openshell.v1.OpenShell.GetProvider:input_type -> openshell.v1.GetProviderRequest
-	14, // 49: openshell.v1.OpenShell.ListProviders:input_type -> openshell.v1.ListProvidersRequest
-	25, // 50: openshell.v1.OpenShell.UpdateConfig:input_type -> openshell.v1.UpdateConfigRequest
-	28, // 51: openshell.v1.OpenShell.ConfigureProviderRefresh:input_type -> openshell.v1.ConfigureProviderRefreshRequest
-	30, // 52: openshell.v1.OpenShell.RotateProviderCredential:input_type -> openshell.v1.RotateProviderCredentialRequest
-	38, // 53: openshell.v1.OpenShell.WatchSandbox:input_type -> openshell.v1.WatchSandboxRequest
-	43, // 54: openshell.v1.OpenShell.GetSandboxLogs:input_type -> openshell.v1.GetSandboxLogsRequest
-	10, // 55: openshell.v1.OpenShell.CreateSandbox:output_type -> openshell.v1.SandboxResponse
-	10, // 56: openshell.v1.OpenShell.GetSandbox:output_type -> openshell.v1.SandboxResponse
-	11, // 57: openshell.v1.OpenShell.DeleteSandbox:output_type -> openshell.v1.DeleteSandboxResponse
-	33, // 58: openshell.v1.OpenShell.CreateSshSession:output_type -> openshell.v1.CreateSshSessionResponse
-	21, // 59: openshell.v1.OpenShell.ExecSandbox:output_type -> openshell.v1.ExecSandboxEvent
-	35, // 60: openshell.v1.OpenShell.ForwardTcp:output_type -> openshell.v1.TcpForwardFrame
-	16, // 61: openshell.v1.OpenShell.CreateProvider:output_type -> openshell.v1.ProviderResponse
-	16, // 62: openshell.v1.OpenShell.UpdateProvider:output_type -> openshell.v1.ProviderResponse
-	16, // 63: openshell.v1.OpenShell.GetProvider:output_type -> openshell.v1.ProviderResponse
-	17, // 64: openshell.v1.OpenShell.ListProviders:output_type -> openshell.v1.ListProvidersResponse
-	26, // 65: openshell.v1.OpenShell.UpdateConfig:output_type -> openshell.v1.UpdateConfigResponse
-	29, // 66: openshell.v1.OpenShell.ConfigureProviderRefresh:output_type -> openshell.v1.ConfigureProviderRefreshResponse
-	31, // 67: openshell.v1.OpenShell.RotateProviderCredential:output_type -> openshell.v1.RotateProviderCredentialResponse
-	39, // 68: openshell.v1.OpenShell.WatchSandbox:output_type -> openshell.v1.SandboxStreamEvent
-	44, // 69: openshell.v1.OpenShell.GetSandboxLogs:output_type -> openshell.v1.GetSandboxLogsResponse
-	55, // [55:70] is the sub-list for method output_type
-	40, // [40:55] is the sub-list for method input_type
-	40, // [40:40] is the sub-list for extension type_name
-	40, // [40:40] is the sub-list for extension extendee
-	0,  // [0:40] is the sub-list for field type_name
+	63, // 23: openshell.v1.UpdateConfigRequest.policy:type_name -> openshell.sandbox.v1.SandboxPolicy
+	65, // 24: openshell.v1.UpdateConfigRequest.setting_value:type_name -> openshell.sandbox.v1.SettingValue
+	26, // 25: openshell.v1.UpdateConfigRequest.merge_operations:type_name -> openshell.v1.PolicyMergeOperation
+	27, // 26: openshell.v1.PolicyMergeOperation.add_rule:type_name -> openshell.v1.AddNetworkRule
+	28, // 27: openshell.v1.PolicyMergeOperation.remove_endpoint:type_name -> openshell.v1.RemoveNetworkEndpoint
+	29, // 28: openshell.v1.PolicyMergeOperation.remove_rule:type_name -> openshell.v1.RemoveNetworkRule
+	30, // 29: openshell.v1.PolicyMergeOperation.add_deny_rules:type_name -> openshell.v1.AddDenyRules
+	31, // 30: openshell.v1.PolicyMergeOperation.add_allow_rules:type_name -> openshell.v1.AddAllowRules
+	32, // 31: openshell.v1.PolicyMergeOperation.remove_binary:type_name -> openshell.v1.RemoveNetworkBinary
+	66, // 32: openshell.v1.AddNetworkRule.rule:type_name -> openshell.sandbox.v1.NetworkPolicyRule
+	67, // 33: openshell.v1.AddDenyRules.deny_rules:type_name -> openshell.sandbox.v1.L7DenyRule
+	68, // 34: openshell.v1.AddAllowRules.rules:type_name -> openshell.sandbox.v1.L7Rule
+	1,  // 35: openshell.v1.ProviderCredentialRefreshStatus.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
+	1,  // 36: openshell.v1.ConfigureProviderRefreshRequest.strategy:type_name -> openshell.v1.ProviderCredentialRefreshStrategy
+	59, // 37: openshell.v1.ConfigureProviderRefreshRequest.material:type_name -> openshell.v1.ConfigureProviderRefreshRequest.MaterialEntry
+	34, // 38: openshell.v1.ConfigureProviderRefreshResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
+	34, // 39: openshell.v1.RotateProviderCredentialResponse.status:type_name -> openshell.v1.ProviderCredentialRefreshStatus
+	43, // 40: openshell.v1.TcpForwardInit.ssh:type_name -> openshell.v1.SshRelayTarget
+	44, // 41: openshell.v1.TcpForwardInit.tcp:type_name -> openshell.v1.TcpRelayTarget
+	41, // 42: openshell.v1.TcpForwardFrame.init:type_name -> openshell.v1.TcpForwardInit
+	2,  // 43: openshell.v1.SandboxStreamEvent.sandbox:type_name -> openshell.v1.Sandbox
+	47, // 44: openshell.v1.SandboxStreamEvent.log:type_name -> openshell.v1.SandboxLogLine
+	48, // 45: openshell.v1.SandboxStreamEvent.event:type_name -> openshell.v1.PlatformEvent
+	49, // 46: openshell.v1.SandboxStreamEvent.warning:type_name -> openshell.v1.SandboxStreamWarning
+	60, // 47: openshell.v1.SandboxLogLine.fields:type_name -> openshell.v1.SandboxLogLine.FieldsEntry
+	61, // 48: openshell.v1.PlatformEvent.metadata:type_name -> openshell.v1.PlatformEvent.MetadataEntry
+	47, // 49: openshell.v1.GetSandboxLogsResponse.logs:type_name -> openshell.v1.SandboxLogLine
+	7,  // 50: openshell.v1.OpenShell.CreateSandbox:input_type -> openshell.v1.CreateSandboxRequest
+	8,  // 51: openshell.v1.OpenShell.GetSandbox:input_type -> openshell.v1.GetSandboxRequest
+	9,  // 52: openshell.v1.OpenShell.DeleteSandbox:input_type -> openshell.v1.DeleteSandboxRequest
+	39, // 53: openshell.v1.OpenShell.CreateSshSession:input_type -> openshell.v1.CreateSshSessionRequest
+	20, // 54: openshell.v1.OpenShell.ExecSandbox:input_type -> openshell.v1.ExecSandboxRequest
+	42, // 55: openshell.v1.OpenShell.ForwardTcp:input_type -> openshell.v1.TcpForwardFrame
+	12, // 56: openshell.v1.OpenShell.CreateProvider:input_type -> openshell.v1.CreateProviderRequest
+	15, // 57: openshell.v1.OpenShell.UpdateProvider:input_type -> openshell.v1.UpdateProviderRequest
+	13, // 58: openshell.v1.OpenShell.GetProvider:input_type -> openshell.v1.GetProviderRequest
+	14, // 59: openshell.v1.OpenShell.ListProviders:input_type -> openshell.v1.ListProvidersRequest
+	25, // 60: openshell.v1.OpenShell.UpdateConfig:input_type -> openshell.v1.UpdateConfigRequest
+	35, // 61: openshell.v1.OpenShell.ConfigureProviderRefresh:input_type -> openshell.v1.ConfigureProviderRefreshRequest
+	37, // 62: openshell.v1.OpenShell.RotateProviderCredential:input_type -> openshell.v1.RotateProviderCredentialRequest
+	45, // 63: openshell.v1.OpenShell.WatchSandbox:input_type -> openshell.v1.WatchSandboxRequest
+	50, // 64: openshell.v1.OpenShell.GetSandboxLogs:input_type -> openshell.v1.GetSandboxLogsRequest
+	10, // 65: openshell.v1.OpenShell.CreateSandbox:output_type -> openshell.v1.SandboxResponse
+	10, // 66: openshell.v1.OpenShell.GetSandbox:output_type -> openshell.v1.SandboxResponse
+	11, // 67: openshell.v1.OpenShell.DeleteSandbox:output_type -> openshell.v1.DeleteSandboxResponse
+	40, // 68: openshell.v1.OpenShell.CreateSshSession:output_type -> openshell.v1.CreateSshSessionResponse
+	21, // 69: openshell.v1.OpenShell.ExecSandbox:output_type -> openshell.v1.ExecSandboxEvent
+	42, // 70: openshell.v1.OpenShell.ForwardTcp:output_type -> openshell.v1.TcpForwardFrame
+	16, // 71: openshell.v1.OpenShell.CreateProvider:output_type -> openshell.v1.ProviderResponse
+	16, // 72: openshell.v1.OpenShell.UpdateProvider:output_type -> openshell.v1.ProviderResponse
+	16, // 73: openshell.v1.OpenShell.GetProvider:output_type -> openshell.v1.ProviderResponse
+	17, // 74: openshell.v1.OpenShell.ListProviders:output_type -> openshell.v1.ListProvidersResponse
+	33, // 75: openshell.v1.OpenShell.UpdateConfig:output_type -> openshell.v1.UpdateConfigResponse
+	36, // 76: openshell.v1.OpenShell.ConfigureProviderRefresh:output_type -> openshell.v1.ConfigureProviderRefreshResponse
+	38, // 77: openshell.v1.OpenShell.RotateProviderCredential:output_type -> openshell.v1.RotateProviderCredentialResponse
+	46, // 78: openshell.v1.OpenShell.WatchSandbox:output_type -> openshell.v1.SandboxStreamEvent
+	51, // 79: openshell.v1.OpenShell.GetSandboxLogs:output_type -> openshell.v1.GetSandboxLogsResponse
+	65, // [65:80] is the sub-list for method output_type
+	50, // [50:65] is the sub-list for method input_type
+	50, // [50:50] is the sub-list for extension type_name
+	50, // [50:50] is the sub-list for extension extendee
+	0,  // [0:50] is the sub-list for field type_name
 }
 
 func init() { file_openshell_v1_openshell_proto_init() }
@@ -3407,16 +3941,24 @@ func file_openshell_v1_openshell_proto_init() {
 		(*ExecSandboxEvent_Stderr)(nil),
 		(*ExecSandboxEvent_Exit)(nil),
 	}
-	file_openshell_v1_openshell_proto_msgTypes[26].OneofWrappers = []any{}
-	file_openshell_v1_openshell_proto_msgTypes[32].OneofWrappers = []any{
+	file_openshell_v1_openshell_proto_msgTypes[24].OneofWrappers = []any{
+		(*PolicyMergeOperation_AddRule)(nil),
+		(*PolicyMergeOperation_RemoveEndpoint)(nil),
+		(*PolicyMergeOperation_RemoveRule)(nil),
+		(*PolicyMergeOperation_AddDenyRules)(nil),
+		(*PolicyMergeOperation_AddAllowRules)(nil),
+		(*PolicyMergeOperation_RemoveBinary)(nil),
+	}
+	file_openshell_v1_openshell_proto_msgTypes[33].OneofWrappers = []any{}
+	file_openshell_v1_openshell_proto_msgTypes[39].OneofWrappers = []any{
 		(*TcpForwardInit_Ssh)(nil),
 		(*TcpForwardInit_Tcp)(nil),
 	}
-	file_openshell_v1_openshell_proto_msgTypes[33].OneofWrappers = []any{
+	file_openshell_v1_openshell_proto_msgTypes[40].OneofWrappers = []any{
 		(*TcpForwardFrame_Init)(nil),
 		(*TcpForwardFrame_Data)(nil),
 	}
-	file_openshell_v1_openshell_proto_msgTypes[37].OneofWrappers = []any{
+	file_openshell_v1_openshell_proto_msgTypes[44].OneofWrappers = []any{
 		(*SandboxStreamEvent_Sandbox)(nil),
 		(*SandboxStreamEvent_Log)(nil),
 		(*SandboxStreamEvent_Event)(nil),
@@ -3428,7 +3970,7 @@ func file_openshell_v1_openshell_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_openshell_v1_openshell_proto_rawDesc), len(file_openshell_v1_openshell_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   53,
+			NumMessages:   60,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -357,6 +357,9 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	existing, err := r.gateway.GetSandbox(ctx, namespace, sbxName)
 	if err == nil && existing != nil && existing.Sandbox != nil {
 		r.logger.Debug().Str("sandbox", sbxName).Msg("sandbox already exists")
+		if err := r.injectACPInternalPolicy(ctx, namespace, sbxName); err != nil {
+			return fmt.Errorf("injecting ACP internal policy into existing sandbox %s: %w", sbxName, err)
+		}
 		if err := r.patchSandboxDNSConfig(ctx, namespace, sbxName); err != nil {
 			r.logger.Warn().Err(err).Str("sandbox", sbxName).Msg("failed to patch sandbox dnsConfig; DNS resolution for external FQDNs may fail")
 		}
@@ -387,7 +390,6 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	if policyErr != nil {
 		return fmt.Errorf("resolving sandbox policy: %w", policyErr)
 	}
-	sandboxPolicy = ensureACPInternalPolicy(sandboxPolicy, r.cfg.CPRuntimeNamespace)
 
 	req := &openshellpb.CreateSandboxRequest{
 		Name: sbxName,
@@ -431,6 +433,22 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads)
 
 	r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
+	return nil
+}
+
+func (r *SimpleKubeReconciler) injectACPInternalPolicy(ctx context.Context, namespace, sandboxName string) error {
+	_, err := r.gateway.UpdateConfig(ctx, namespace, &openshellpb.UpdateConfigRequest{
+		Name:            sandboxName,
+		MergeOperations: []*openshellpb.PolicyMergeOperation{acpInternalMergeOperation(r.cfg.CPRuntimeNamespace)},
+	})
+	if err != nil {
+		return fmt.Errorf("UpdateConfig merge for %s: %w", acpInternalPolicyKey, err)
+	}
+	r.logger.Info().
+		Str("sandbox", sandboxName).
+		Str("namespace", namespace).
+		Str("cp_namespace", r.cfg.CPRuntimeNamespace).
+		Msg("injected _acp_internal policy via merge operation")
 	return nil
 }
 
@@ -717,8 +735,24 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				Str("sandbox", sbxName).
 				Str("sandbox_id", sandboxID).
 				Str("session_id", sessionID).
+				Msg("sandbox is ready, configuring policy")
+
+			// Inject _acp_internal policy AFTER the sandbox is READY.
+			// The supervisor syncs the image's default policy on boot;
+			// injecting earlier would merge onto an empty base, squashing
+			// the default rules.
+			if err := r.injectACPInternalPolicy(pollCtx, namespace, sbxName); err != nil {
+				r.logger.Error().Err(err).Str("sandbox", sbxName).Str("session_id", sessionID).Msg("failed to inject ACP internal policy")
+				failSession(fmt.Sprintf("failed to inject ACP internal policy: %v", err))
+				return
+			}
+
+			r.logger.Info().
+				Str("sandbox", sbxName).
+				Str("sandbox_id", sandboxID).
+				Str("session_id", sessionID).
 				Strs("entrypoint", entrypoint).
-				Msg("sandbox is ready, executing entrypoint")
+				Msg("policy configured, executing entrypoint")
 
 			// Transition session from Creating → Running now that the
 			// sandbox is ready and we are about to exec the entrypoint.

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -357,9 +357,6 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	existing, err := r.gateway.GetSandbox(ctx, namespace, sbxName)
 	if err == nil && existing != nil && existing.Sandbox != nil {
 		r.logger.Debug().Str("sandbox", sbxName).Msg("sandbox already exists")
-		if err := r.injectACPInternalPolicy(ctx, namespace, sbxName); err != nil {
-			return fmt.Errorf("injecting ACP internal policy into existing sandbox %s: %w", sbxName, err)
-		}
 		if err := r.patchSandboxDNSConfig(ctx, namespace, sbxName); err != nil {
 			r.logger.Warn().Err(err).Str("sandbox", sbxName).Msg("failed to patch sandbox dnsConfig; DNS resolution for external FQDNs may fail")
 		}
@@ -442,7 +439,7 @@ func (r *SimpleKubeReconciler) injectACPInternalPolicy(ctx context.Context, name
 		MergeOperations: []*openshellpb.PolicyMergeOperation{acpInternalMergeOperation(r.cfg.CPRuntimeNamespace)},
 	})
 	if err != nil {
-		return fmt.Errorf("UpdateConfig merge for %s: %w", acpInternalPolicyKey, err)
+		return fmt.Errorf("UpdateConfig merge for ACP internal policy: %w", err)
 	}
 	r.logger.Info().
 		Str("sandbox", sandboxName).

--- a/components/ambient-control-plane/internal/reconciler/sandbox_policy.go
+++ b/components/ambient-control-plane/internal/reconciler/sandbox_policy.go
@@ -1,14 +1,11 @@
 package reconciler
 
 import (
-	"strings"
-
 	sandboxpb "github.com/ambient-code/platform/components/ambient-control-plane/internal/openshell/grpc/openshell/sandbox/v1"
+	openshellpb "github.com/ambient-code/platform/components/ambient-control-plane/internal/openshell/grpc/openshell/v1"
 )
 
 const acpInternalPolicyKey = "_acp_internal"
-
-var acpServiceNames = []string{"ambient-control-plane", "ambient-api-server"}
 
 func acpInternalRule(namespace string) *sandboxpb.NetworkPolicyRule {
 	return &sandboxpb.NetworkPolicyRule{
@@ -30,39 +27,16 @@ func acpInternalRule(namespace string) *sandboxpb.NetworkPolicyRule {
 	}
 }
 
-func ensureACPInternalPolicy(policy *sandboxpb.SandboxPolicy, namespace string) *sandboxpb.SandboxPolicy {
-	if policy == nil {
-		policy = &sandboxpb.SandboxPolicy{}
+// acpInternalMergeOperation builds a PolicyMergeOperation that adds the
+// _acp_internal network rule using namespace-specific endpoints. The gateway
+// applies this additively — existing default policy rules are preserved.
+func acpInternalMergeOperation(namespace string) *openshellpb.PolicyMergeOperation {
+	return &openshellpb.PolicyMergeOperation{
+		Operation: &openshellpb.PolicyMergeOperation_AddRule{
+			AddRule: &openshellpb.AddNetworkRule{
+				RuleName: acpInternalPolicyKey,
+				Rule:     acpInternalRule(namespace),
+			},
+		},
 	}
-	if policy.NetworkPolicies == nil {
-		policy.NetworkPolicies = make(map[string]*sandboxpb.NetworkPolicyRule)
-	}
-
-	if existing, ok := policy.NetworkPolicies[acpInternalPolicyKey]; ok {
-		rewriteACPEndpointNamespace(existing, namespace)
-	} else {
-		policy.NetworkPolicies[acpInternalPolicyKey] = acpInternalRule(namespace)
-	}
-
-	return policy
-}
-
-func rewriteACPEndpointNamespace(rule *sandboxpb.NetworkPolicyRule, namespace string) {
-	for _, ep := range rule.Endpoints {
-		ep.Host = rewriteServiceHostNamespace(ep.Host, namespace)
-	}
-}
-
-func rewriteServiceHostNamespace(host, namespace string) string {
-	for _, svc := range acpServiceNames {
-		prefix := svc + "."
-		if !strings.HasPrefix(host, prefix) {
-			continue
-		}
-		remainder := host[len(prefix):]
-		if idx := strings.Index(remainder, ".svc"); idx >= 0 {
-			return prefix + namespace + remainder[idx:]
-		}
-	}
-	return host
 }

--- a/components/ambient-control-plane/internal/reconciler/sandbox_policy_test.go
+++ b/components/ambient-control-plane/internal/reconciler/sandbox_policy_test.go
@@ -1,55 +1,32 @@
 package reconciler
 
 import (
+	"strings"
 	"testing"
-
-	sandboxpb "github.com/ambient-code/platform/components/ambient-control-plane/internal/openshell/grpc/openshell/sandbox/v1"
 )
 
-func TestRewriteServiceHostNamespace(t *testing.T) {
-	tests := []struct {
-		name      string
-		host      string
-		namespace string
-		want      string
-	}{
-		{"cp short", "ambient-control-plane.ambient-code.svc", "ambient-dev", "ambient-control-plane.ambient-dev.svc"},
-		{"cp fqdn", "ambient-control-plane.ambient-code.svc.cluster.local", "ambient-dev", "ambient-control-plane.ambient-dev.svc.cluster.local"},
-		{"api short", "ambient-api-server.ambient-code.svc", "pr-42", "ambient-api-server.pr-42.svc"},
-		{"api fqdn", "ambient-api-server.ambient-code.svc.cluster.local", "pr-42", "ambient-api-server.pr-42.svc.cluster.local"},
-		{"already correct", "ambient-control-plane.ambient-dev.svc", "ambient-dev", "ambient-control-plane.ambient-dev.svc"},
-		{"unknown service", "some-other-service.ambient-code.svc", "ambient-dev", "some-other-service.ambient-code.svc"},
-		{"external host", "api.anthropic.com", "ambient-dev", "api.anthropic.com"},
-		{"empty host", "", "ambient-dev", ""},
+func TestACPInternalMergeOperation(t *testing.T) {
+	op := acpInternalMergeOperation("pr-42")
+	addRule := op.GetAddRule()
+	if addRule == nil {
+		t.Fatal("expected AddRule operation")
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := rewriteServiceHostNamespace(tt.host, tt.namespace)
-			if got != tt.want {
-				t.Errorf("rewriteServiceHostNamespace(%q, %q) = %q, want %q", tt.host, tt.namespace, got, tt.want)
-			}
-		})
+	if addRule.RuleName != acpInternalPolicyKey {
+		t.Errorf("rule name = %q, want %q", addRule.RuleName, acpInternalPolicyKey)
 	}
-}
-
-func TestEnsureACPInternalPolicy_NilPolicy(t *testing.T) {
-	result := ensureACPInternalPolicy(nil, "ambient-dev")
-	if result == nil {
-		t.Fatal("expected non-nil policy")
-	}
-	rule, ok := result.NetworkPolicies[acpInternalPolicyKey]
-	if !ok {
-		t.Fatal("expected _acp_internal rule")
+	rule := addRule.Rule
+	if rule == nil {
+		t.Fatal("expected non-nil rule")
 	}
 	if rule.Name != "acp-internal" {
-		t.Errorf("rule name = %q, want %q", rule.Name, "acp-internal")
+		t.Errorf("rule.Name = %q, want %q", rule.Name, "acp-internal")
 	}
 	if len(rule.Endpoints) != 6 {
 		t.Errorf("endpoints count = %d, want 6", len(rule.Endpoints))
 	}
 	for _, ep := range rule.Endpoints {
-		if !contains(ep.Host, "ambient-dev") {
-			t.Errorf("endpoint host %q does not contain namespace ambient-dev", ep.Host)
+		if !strings.Contains(ep.Host, "pr-42") {
+			t.Errorf("endpoint host %q does not contain namespace pr-42", ep.Host)
 		}
 	}
 	if len(rule.Binaries) != 4 {
@@ -57,113 +34,49 @@ func TestEnsureACPInternalPolicy_NilPolicy(t *testing.T) {
 	}
 }
 
-func TestEnsureACPInternalPolicy_EmptyNetworkPolicies(t *testing.T) {
-	policy := &sandboxpb.SandboxPolicy{}
-	result := ensureACPInternalPolicy(policy, "my-ns")
-	rule := result.NetworkPolicies[acpInternalPolicyKey]
-	if rule == nil {
-		t.Fatal("expected _acp_internal rule to be injected")
-	}
-	if rule.Endpoints[0].Host != "ambient-control-plane.my-ns.svc" {
-		t.Errorf("first endpoint host = %q, want ambient-control-plane.my-ns.svc", rule.Endpoints[0].Host)
-	}
-}
+func TestACPInternalMergeOperation_EndpointPorts(t *testing.T) {
+	op := acpInternalMergeOperation("test-ns")
+	rule := op.GetAddRule().Rule
 
-func TestEnsureACPInternalPolicy_RewritesExisting(t *testing.T) {
-	policy := &sandboxpb.SandboxPolicy{
-		NetworkPolicies: map[string]*sandboxpb.NetworkPolicyRule{
-			"_acp_internal": {
-				Name: "acp-internal",
-				Endpoints: []*sandboxpb.NetworkEndpoint{
-					{Host: "ambient-control-plane.ambient-code.svc", Port: 8080},
-					{Host: "ambient-control-plane.ambient-code.svc.cluster.local", Port: 8080},
-					{Host: "ambient-api-server.ambient-code.svc", Port: 8000},
-					{Host: "ambient-api-server.ambient-code.svc.cluster.local", Port: 8000},
-					{Host: "ambient-api-server.ambient-code.svc", Port: 9000},
-					{Host: "ambient-api-server.ambient-code.svc.cluster.local", Port: 9000},
-				},
-				Binaries: []*sandboxpb.NetworkBinary{
-					{Path: "/sandbox/.venv/bin/python"},
-				},
-			},
-			"claude_code_vertex": {
-				Name: "claude-code-vertex",
-				Endpoints: []*sandboxpb.NetworkEndpoint{
-					{Host: "us-east5-aiplatform.googleapis.com", Port: 443},
-				},
-			},
-		},
+	expectedEndpoints := []struct {
+		host string
+		port uint32
+	}{
+		{"ambient-control-plane.test-ns.svc", 8080},
+		{"ambient-control-plane.test-ns.svc.cluster.local", 8080},
+		{"ambient-api-server.test-ns.svc", 8000},
+		{"ambient-api-server.test-ns.svc.cluster.local", 8000},
+		{"ambient-api-server.test-ns.svc", 9000},
+		{"ambient-api-server.test-ns.svc.cluster.local", 9000},
 	}
 
-	result := ensureACPInternalPolicy(policy, "ambient-dev")
-
-	rule := result.NetworkPolicies[acpInternalPolicyKey]
-	expectedHosts := []string{
-		"ambient-control-plane.ambient-dev.svc",
-		"ambient-control-plane.ambient-dev.svc.cluster.local",
-		"ambient-api-server.ambient-dev.svc",
-		"ambient-api-server.ambient-dev.svc.cluster.local",
-		"ambient-api-server.ambient-dev.svc",
-		"ambient-api-server.ambient-dev.svc.cluster.local",
-	}
-	for i, ep := range rule.Endpoints {
-		if ep.Host != expectedHosts[i] {
-			t.Errorf("endpoint[%d].Host = %q, want %q", i, ep.Host, expectedHosts[i])
+	for i, want := range expectedEndpoints {
+		if rule.Endpoints[i].Host != want.host {
+			t.Errorf("endpoint[%d].Host = %q, want %q", i, rule.Endpoints[i].Host, want.host)
+		}
+		if rule.Endpoints[i].Port != want.port {
+			t.Errorf("endpoint[%d].Port = %d, want %d", i, rule.Endpoints[i].Port, want.port)
 		}
 	}
-
-	if len(rule.Binaries) != 1 {
-		t.Errorf("binaries should be preserved, got %d", len(rule.Binaries))
-	}
-
-	vertex := result.NetworkPolicies["claude_code_vertex"]
-	if vertex == nil {
-		t.Fatal("other rules should be preserved")
-	}
-	if vertex.Endpoints[0].Host != "us-east5-aiplatform.googleapis.com" {
-		t.Error("other rule endpoints should not be modified")
-	}
 }
 
-func TestEnsureACPInternalPolicy_PreservesOtherFields(t *testing.T) {
-	policy := &sandboxpb.SandboxPolicy{
-		Version: 2,
-		Filesystem: &sandboxpb.FilesystemPolicy{
-			ReadOnly:  []string{"/usr"},
-			ReadWrite: []string{"/tmp"},
-		},
-		Process: &sandboxpb.ProcessPolicy{
-			RunAsUser:  "sandbox",
-			RunAsGroup: "sandbox",
-		},
+func TestACPInternalMergeOperation_Binaries(t *testing.T) {
+	op := acpInternalMergeOperation("ns")
+	rule := op.GetAddRule().Rule
+
+	expectedBinaries := []string{
+		"/sandbox/.venv/bin/python",
+		"/sandbox/.venv/bin/python3",
+		"/sandbox/.venv/bin/uvicorn",
+		"/sandbox/.uv/python/cpython-*/bin/python*",
 	}
 
-	result := ensureACPInternalPolicy(policy, "test-ns")
-
-	if result.Version != 2 {
-		t.Errorf("version = %d, want 2", result.Version)
+	if len(rule.Binaries) != len(expectedBinaries) {
+		t.Fatalf("binaries count = %d, want %d", len(rule.Binaries), len(expectedBinaries))
 	}
-	if result.Filesystem == nil || result.Filesystem.ReadOnly[0] != "/usr" {
-		t.Error("filesystem policy should be preserved")
-	}
-	if result.Process == nil || result.Process.RunAsUser != "sandbox" {
-		t.Error("process policy should be preserved")
-	}
-	if _, ok := result.NetworkPolicies[acpInternalPolicyKey]; !ok {
-		t.Error("_acp_internal should be injected")
-	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > 0 && len(substr) > 0 && containsStr(s, substr)))
-}
-
-func containsStr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
+	for i, want := range expectedBinaries {
+		if rule.Binaries[i].Path != want {
+			t.Errorf("binary[%d].Path = %q, want %q", i, rule.Binaries[i].Path, want)
 		}
 	}
-	return false
 }

--- a/components/ambient-control-plane/proto/openshell/v1/openshell.proto
+++ b/components/ambient-control-plane/proto/openshell/v1/openshell.proto
@@ -181,7 +181,51 @@ message UpdateConfigRequest {
   openshell.sandbox.v1.SettingValue setting_value = 4;
   bool delete_setting = 5;
   bool global = 6;
+  repeated PolicyMergeOperation merge_operations = 7;
   uint64 expected_resource_version = 8;
+}
+
+message PolicyMergeOperation {
+  oneof operation {
+    AddNetworkRule add_rule = 1;
+    RemoveNetworkEndpoint remove_endpoint = 2;
+    RemoveNetworkRule remove_rule = 3;
+    AddDenyRules add_deny_rules = 4;
+    AddAllowRules add_allow_rules = 5;
+    RemoveNetworkBinary remove_binary = 6;
+  }
+}
+
+message AddNetworkRule {
+  string rule_name = 1;
+  openshell.sandbox.v1.NetworkPolicyRule rule = 2;
+}
+
+message RemoveNetworkEndpoint {
+  string rule_name = 1;
+  string host = 2;
+  uint32 port = 3;
+}
+
+message RemoveNetworkRule {
+  string rule_name = 1;
+}
+
+message AddDenyRules {
+  string host = 1;
+  uint32 port = 2;
+  repeated openshell.sandbox.v1.L7DenyRule deny_rules = 3;
+}
+
+message AddAllowRules {
+  string host = 1;
+  uint32 port = 2;
+  repeated openshell.sandbox.v1.L7Rule rules = 3;
+}
+
+message RemoveNetworkBinary {
+  string rule_name = 1;
+  string binary_path = 2;
 }
 
 message UpdateConfigResponse {

--- a/examples/base/agents/kustomization.yaml
+++ b/examples/base/agents/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - jira-simple-whoami-with-skill-payload.yaml
   - pr-reviewer.yaml
   - jira-issue-categorizer.yaml
+  - test-agent-with-no-providers.yaml

--- a/examples/base/agents/test-agent-with-no-providers.yaml
+++ b/examples/base/agents/test-agent-with-no-providers.yaml
@@ -1,0 +1,5 @@
+kind: Agent
+name: test-agent-with-no-providers
+prompt: "Say hello"
+labels:
+  purpose: e2e-lifecycle-test

--- a/examples/base/agents/test-agent-with-no-providers.yaml
+++ b/examples/base/agents/test-agent-with-no-providers.yaml
@@ -1,5 +1,0 @@
-kind: Agent
-name: test-agent-with-no-providers
-prompt: "Say hello"
-labels:
-  purpose: e2e-lifecycle-test

--- a/specs/platform/agent-sandbox-config.spec.md
+++ b/specs/platform/agent-sandbox-config.spec.md
@@ -533,6 +533,67 @@ The agent YAML SHALL reference a sandbox policy by name. The control plane SHALL
 
 ---
 
+### Requirement: ACP Internal Policy Injection
+
+The control plane SHALL inject the `_acp_internal` network policy rule **after** sandbox creation using OpenShell's `UpdateConfig` RPC with `merge_operations`, NOT by embedding the rule in the `CreateSandboxRequest.Spec.Policy` field. This preserves the sandbox's default policy while ensuring the runner can reach ACP platform services.
+
+**Rationale:** Sandboxes have a default policy applied at creation time by OpenShell (based on the sandbox image and gateway configuration). Including `_acp_internal` in the `CreateSandbox` request's `Policy` field replaces the entire default policy, stripping non-ACP rules the sandbox depends on. The `merge_operations` field on `UpdateConfig` (equivalent to `openshell policy update --add-allow`) performs an additive merge — only the targeted rule is added or replaced while all other rules are preserved.
+
+#### Scenario: ACP internal policy injected after sandbox creation
+
+- GIVEN a sandbox has been created via `CreateSandbox`
+- AND the sandbox has received its default policy from OpenShell
+- WHEN the control plane prepares the sandbox for runner execution
+- THEN it SHALL call `UpdateConfig` with `merge_operations` to add the `_acp_internal` network policy rule
+- AND the `_acp_internal` rule SHALL include endpoints for the control plane (port 8080) and API server (ports 8000, 9000) using the deployment namespace
+- AND the `_acp_internal` rule SHALL include allowed binaries for the runner's Python processes
+- AND the `CreateSandboxRequest.Spec.Policy` field SHALL NOT contain the `_acp_internal` rule
+
+#### Scenario: Default sandbox policy preserved
+
+- GIVEN a sandbox's default policy contains rules `default_dns` and `default_metrics`
+- WHEN the control plane injects `_acp_internal` via `UpdateConfig` merge operations
+- THEN the sandbox's effective policy SHALL contain `default_dns`, `default_metrics`, AND `_acp_internal`
+- AND the `default_dns` and `default_metrics` rules SHALL be unmodified
+
+#### Scenario: Existing `_acp_internal` in default policy is overwritten
+
+- GIVEN a sandbox's default policy already contains an `_acp_internal` rule (e.g., with placeholder endpoints)
+- WHEN the control plane injects `_acp_internal` via `UpdateConfig` merge operations
+- THEN the control plane's `_acp_internal` rule SHALL replace the existing `_acp_internal` entry
+- AND all other rules in the default policy SHALL be preserved
+
+#### Scenario: Agent with named policy plus ACP internal injection
+
+- GIVEN an agent declares `sandbox_policy: restricted`
+- AND the `restricted` policy is passed to `CreateSandbox`
+- WHEN the sandbox is created
+- THEN the control plane SHALL subsequently inject `_acp_internal` via `UpdateConfig` merge operations
+- AND the `restricted` policy's rules SHALL be preserved alongside `_acp_internal`
+
+#### Scenario: Agent with no named policy
+
+- GIVEN an agent declaration with no `sandbox_policy` field
+- WHEN a session starts
+- THEN the sandbox SHALL be created without a policy in `CreateSandboxRequest` (receiving its default policy from OpenShell)
+- AND the control plane SHALL subsequently inject `_acp_internal` via `UpdateConfig` merge operations
+- AND the sandbox's default policy rules SHALL be preserved
+
+#### Scenario: Namespace rewriting in injected policy
+
+- GIVEN the control plane is deployed in namespace `pr-42` (`CP_RUNTIME_NAMESPACE=pr-42`)
+- WHEN the control plane injects `_acp_internal`
+- THEN the endpoint hostnames SHALL use namespace `pr-42` (e.g., `ambient-control-plane.pr-42.svc.cluster.local:8080`)
+
+#### Scenario: ACP internal injection failure
+
+- GIVEN the `UpdateConfig` call to inject `_acp_internal` fails
+- WHEN the control plane handles the error
+- THEN the session SHALL transition to `Failed` with a descriptive error
+- AND the error SHALL NOT expose internal endpoint hostnames or policy details
+
+---
+
 ### Requirement: Sandbox Template
 
 The agent YAML SHALL declare compute and runtime configuration for the sandbox container via the `sandbox_template` field.

--- a/specs/platform/openshell-sandbox-provisioning.spec.md
+++ b/specs/platform/openshell-sandbox-provisioning.spec.md
@@ -514,33 +514,45 @@ The supervisor automatically injects proxy and TLS environment variables into pr
 - AND the SSH path is stricter because it calls `env_clear()` (the entrypoint inherits the supervisor's environment minus 4 supervisor-only vars: `SANDBOX_TOKEN`, `SANDBOX_TOKEN_FILE`, `K8S_SA_TOKEN_FILE`, `PROVIDER_SPIFFE_WORKLOAD_API_SOCKET`)
 - AND the `ns_fd` for `setns()` can silently be `None` if the namespace file open fails (the supervisor logs a warning and falls back to running without network namespace isolation)
 
-### Requirement: OPA Network Policy for ACP Internal Traffic
+### Requirement: ACP Internal Network Policy Injection
 
-The sandbox OPA network policy SHALL permit the runner process (Python/uvicorn) to reach the ACP control plane and API server through the supervisor proxy. Without this, all cluster-internal traffic from the runner will be denied by the OPA policy engine with `DENIED FORWARD`.
+The control plane SHALL inject an `_acp_internal` network policy rule into the sandbox **after creation** using OpenShell's `UpdateConfig` RPC with `merge_operations`. This permits the runner process (Python/uvicorn) to reach the ACP control plane and API server through the supervisor proxy. Without this, all cluster-internal traffic from the runner will be denied by the OPA policy engine with `DENIED FORWARD`.
 
-#### Scenario: ACP internal endpoints whitelisted
+The `_acp_internal` rule SHALL NOT be included in the `CreateSandboxRequest.Spec.Policy` field, because doing so replaces the sandbox's entire default policy — stripping rules the sandbox depends on. The `merge_operations` approach (equivalent to `openshell policy update <sandbox-name> --add-allow`) is additive: it adds or replaces only the `_acp_internal` rule while preserving all other rules in the sandbox's default policy.
 
-- GIVEN the runner process runs inside the sandbox network namespace
+#### Scenario: ACP internal endpoints injected post-creation
+
+- GIVEN a sandbox has been created via `CreateSandbox` and has received its default policy from OpenShell
+- AND the runner process will run inside the sandbox network namespace
 - AND all traffic routes through the supervisor's HTTP CONNECT proxy at `10.200.0.1:3128`
 - AND the proxy evaluates each CONNECT request against the OPA policy
-- WHEN the runner attempts to reach the control plane token endpoint or the API server gRPC/HTTP endpoints
-- THEN the OPA policy SHALL include an `acp_internal` network policy section that allows:
+- WHEN the control plane injects the `_acp_internal` rule via `UpdateConfig` merge operations
+- THEN the `_acp_internal` network policy rule SHALL allow traffic to:
 
 | Endpoint | Port | Purpose |
 |----------|------|---------|
-| `ambient-control-plane.ambient-code.svc` | 8080 | CP token endpoint |
-| `ambient-control-plane.ambient-code.svc.cluster.local` | 8080 | CP token endpoint (FQDN) |
-| `ambient-api-server.ambient-code.svc` | 8000 | API server HTTP |
-| `ambient-api-server.ambient-code.svc.cluster.local` | 8000 | API server HTTP (FQDN) |
-| `ambient-api-server.ambient-code.svc` | 9000 | API server gRPC |
-| `ambient-api-server.ambient-code.svc.cluster.local` | 9000 | API server gRPC (FQDN) |
+| `ambient-control-plane.{namespace}.svc` | 8080 | CP token endpoint |
+| `ambient-control-plane.{namespace}.svc.cluster.local` | 8080 | CP token endpoint (FQDN) |
+| `ambient-api-server.{namespace}.svc` | 8000 | API server HTTP |
+| `ambient-api-server.{namespace}.svc.cluster.local` | 8000 | API server HTTP (FQDN) |
+| `ambient-api-server.{namespace}.svc` | 9000 | API server gRPC |
+| `ambient-api-server.{namespace}.svc.cluster.local` | 9000 | API server gRPC (FQDN) |
 
-- AND allowed binaries SHALL include `/sandbox/.venv/bin/python`, `/sandbox/.venv/bin/python3`, and `/sandbox/.venv/bin/uvicorn`
+- AND `{namespace}` SHALL be the control plane's runtime namespace (`CP_RUNTIME_NAMESPACE`)
+- AND allowed binaries SHALL include `/sandbox/.venv/bin/python`, `/sandbox/.venv/bin/python3`, `/sandbox/.venv/bin/uvicorn`, and `/sandbox/.uv/python/cpython-*/bin/python*`
 - AND both short (`svc`) and fully-qualified (`svc.cluster.local`) hostnames SHALL be listed because the proxy resolves based on the exact hostname in the CONNECT request
+- AND all other rules in the sandbox's default policy SHALL be preserved
+
+#### Scenario: Default sandbox policy preserved during injection
+
+- GIVEN a sandbox's default policy contains rules for provider traffic, DNS, or other platform concerns
+- WHEN the control plane injects `_acp_internal` via `UpdateConfig` merge operations
+- THEN the existing default policy rules SHALL remain intact and unmodified
+- AND the `_acp_internal` rule SHALL be added alongside them
 
 #### Scenario: Missing ACP internal policy causes runner failure
 
-- GIVEN the OPA policy does not include the `acp_internal` section
+- GIVEN the `_acp_internal` network policy rule has not been injected (e.g., `UpdateConfig` merge failed)
 - WHEN the runner starts and attempts to fetch a CP token via `AMBIENT_CP_TOKEN_URL`
 - THEN the supervisor proxy SHALL deny the CONNECT request
 - AND the runner SHALL fail to authenticate and exit with a non-zero exit code

--- a/specs/platform/runner.spec.md
+++ b/specs/platform/runner.spec.md
@@ -741,17 +741,19 @@ The runner does not need to set proxy or TLS CA vars for general cluster traffic
 
 #### OPA Network Policy for ACP Internal Traffic
 
-The runner's OPA policy (`policy.yaml`) MUST include an `acp_internal` network policy section that whitelists the control plane and API server endpoints for the runner's Python binaries. Without this, the supervisor proxy denies all cluster-internal traffic from the runner with `DENIED FORWARD`.
+The sandbox's OPA network policy MUST include an `_acp_internal` network policy rule that whitelists the control plane and API server endpoints for the runner's Python binaries. Without this, the supervisor proxy denies all cluster-internal traffic from the runner with `DENIED FORWARD`.
 
-Required endpoints:
+The runner image bundles a default `policy.yaml` (via `Dockerfile.openshell`) that includes a static `_acp_internal` entry with hardcoded `ambient-code` namespace endpoints. In gateway mode, this baked-in policy becomes the sandbox's default policy. The control plane **overwrites** the `_acp_internal` entry after sandbox creation using OpenShell's `UpdateConfig` RPC with `merge_operations` (equivalent to `openshell policy update --add-allow`) to set the correct namespace-specific endpoints. All other rules in the baked-in default policy (e.g., `claude_code_vertex`, `github_ssh_over_https`, `pypi`) are preserved. See `agent-sandbox-config.spec.md` (ACP Internal Policy Injection) and `openshell-sandbox-provisioning.spec.md` (ACP Internal Network Policy Injection) for the injection mechanism.
+
+Required endpoints (namespace varies by deployment):
 
 | Host | Port | Purpose |
 |------|------|---------|
-| `ambient-control-plane.ambient-code.svc[.cluster.local]` | 8080 | CP token endpoint |
-| `ambient-api-server.ambient-code.svc[.cluster.local]` | 8000 | API server HTTP |
-| `ambient-api-server.ambient-code.svc[.cluster.local]` | 9000 | API server gRPC |
+| `ambient-control-plane.{namespace}.svc[.cluster.local]` | 8080 | CP token endpoint |
+| `ambient-api-server.{namespace}.svc[.cluster.local]` | 8000 | API server HTTP |
+| `ambient-api-server.{namespace}.svc[.cluster.local]` | 9000 | API server gRPC |
 
-Allowed binaries: `/sandbox/.venv/bin/python`, `/sandbox/.venv/bin/python3`, `/sandbox/.venv/bin/uvicorn`
+Allowed binaries: `/sandbox/.venv/bin/python`, `/sandbox/.venv/bin/python3`, `/sandbox/.venv/bin/uvicorn`, `/sandbox/.uv/python/cpython-*/bin/python*`
 
 Both short (`svc`) and fully-qualified (`svc.cluster.local`) hostnames must be listed because the proxy matches on the exact hostname in the CONNECT request.
 

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -2,11 +2,13 @@
 # E2E test: full gateway agent flow
 #
 # Validates the golden path:
-#   acpctl apply -k  ->  acpctl start  ->  sandbox provisioned  ->  session active
+#   acpctl apply -k  ->  acpctl start  ->  sandbox provisioned  ->  session Running
+#   ->  runner starts inside sandbox  ->  AG-UI RUN_STARTED event emitted
 #
 # This test does NOT require a real LLM API key — it validates the platform
-# plumbing up to session start and sandbox creation.  If VERTEX_SA_KEY or
-# ANTHROPIC_API_KEY is available, it also checks that a runner pod is spawned.
+# plumbing from session creation through runner startup.  The runner emits
+# RUN_STARTED before contacting any inference service, so this proves the
+# full lifecycle works without a real LLM backend.
 #
 # Prerequisites:
 #   - kind-up with OPENSHELL_USE_GATEWAY=true (default)
@@ -570,6 +572,94 @@ if [ -n "$REPO_AGENT_ID" ]; then
   fi
 else
   fail "Repo payload verification requires agent 'repo-clone-workspace' (not found)"
+fi
+
+section "11. Runner lifecycle verification"
+
+# Verify the runner process started inside the sandbox and is processing.
+# The runner emits RUN_STARTED via AG-UI before contacting any LLM, so this
+# works without a real inference service.
+if [ -n "$CREATED_SESSION_ID" ]; then
+
+  # 11a. Session reaches Running phase (explicit assertion, not just a gate)
+  LIFECYCLE_PHASE=""
+  for i in $(seq 1 60); do
+    LIFECYCLE_PHASE=$(api GET "/api/ambient/v1/sessions/${CREATED_SESSION_ID}" 2>/dev/null \
+      | jq -r '.phase // empty' 2>/dev/null || echo "")
+    if [ "$LIFECYCLE_PHASE" = "Running" ] || [ "$LIFECYCLE_PHASE" = "Succeeded" ] || [ "$LIFECYCLE_PHASE" = "Failed" ]; then
+      break
+    fi
+    sleep 2
+  done
+
+  if [ "$LIFECYCLE_PHASE" = "Running" ] || [ "$LIFECYCLE_PHASE" = "Succeeded" ]; then
+    pass "Session reached Running phase"
+  elif [ "$LIFECYCLE_PHASE" = "Failed" ]; then
+    # Failed is acceptable if the runner started — it means inference failed,
+    # not that the runner never came up.  Check messages to confirm.
+    pass "Session reached terminal phase (${LIFECYCLE_PHASE}) — checking runner messages"
+  else
+    fail "Session did not reach Running phase within 120s (phase: ${LIFECYCLE_PHASE:-unknown})"
+  fi
+
+  # 11b. Runner emitted RUN_STARTED event (proves runner process is alive)
+  # The runner pushes AG-UI events to the API server via gRPC.  RUN_STARTED
+  # fires before the LLM is contacted, so it always appears if the runner
+  # started successfully.
+  RUN_STARTED_FOUND=false
+  for i in $(seq 1 30); do
+    MESSAGES_RESP=$(api GET "/api/ambient/v1/sessions/${CREATED_SESSION_ID}/messages" || echo "")
+    if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "RUN_STARTED")' >/dev/null 2>&1; then
+      RUN_STARTED_FOUND=true
+      break
+    fi
+    # Also check the operational lifecycle event (alternative event name)
+    if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "lifecycle") | .payload' 2>/dev/null \
+       | grep -q 'run_started' 2>/dev/null; then
+      RUN_STARTED_FOUND=true
+      break
+    fi
+    sleep 2
+  done
+
+  if [ "$RUN_STARTED_FOUND" = "true" ]; then
+    pass "Runner emitted RUN_STARTED event (runner is alive inside sandbox)"
+  else
+    fail "RUN_STARTED event not found in session messages within 60s"
+    # Dump available event types for debugging
+    EVENT_TYPES=$(echo "$MESSAGES_RESP" | jq -r '.[].event_type' 2>/dev/null | sort -u | head -10)
+    if [ -n "$EVENT_TYPES" ]; then
+      echo "  Available event types: ${EVENT_TYPES}"
+    else
+      echo "  No messages found for session"
+    fi
+    # Show control plane logs for diagnosis
+    echo "  Control plane logs (last 20 lines):"
+    kubectl logs -n "${NAMESPACE}" -l app=ambient-control-plane --tail=20 2>&1 | sed 's/^/    /'
+  fi
+
+  # 11c. Initial prompt delivered to session messages
+  # The runner reads /tmp/initial_prompt.txt and pushes a user message
+  # containing the prompt text via gRPC before starting the AG-UI run.
+  PROMPT_FOUND=false
+  if [ -n "$MESSAGES_RESP" ]; then
+    if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "user")' >/dev/null 2>&1; then
+      PROMPT_FOUND=true
+    fi
+  fi
+
+  if [ "$PROMPT_FOUND" = "true" ]; then
+    pass "Initial prompt delivered as user message"
+  elif [ "$RUN_STARTED_FOUND" = "true" ]; then
+    # RUN_STARTED proves the runner is alive; the user message may arrive via
+    # a different path (HTTP vs gRPC) depending on configuration.
+    skip "Initial prompt user message" "RUN_STARTED confirmed runner is alive; prompt delivery path may differ"
+  else
+    fail "Initial prompt not found in session messages"
+  fi
+
+else
+  skip "Runner lifecycle verification" "session not created"
 fi
 
 section "Cleanup"

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -578,13 +578,28 @@ section "11. Runner lifecycle verification"
 
 # Verify the runner process started inside the sandbox and is processing.
 # The runner emits RUN_STARTED via AG-UI before contacting any LLM, so this
-# works without a real inference service.
-if [ -n "$CREATED_SESSION_ID" ]; then
+# works without a real inference service.  Uses a dedicated agent with no
+# bound providers to avoid credential-related provisioning failures.
+LIFECYCLE_AGENT_NAME="test-agent-with-no-providers"
+$ACPCTL apply -f "$REPO_ROOT/examples/base/agents/test-agent-with-no-providers.yaml" \
+  --project "$TENANT" >/dev/null 2>&1 || true
+LIFECYCLE_AGENTS_RESP=$(api GET "/api/ambient/v1/projects/${PROJECT_ID}/agents?size=50" || echo "")
+LIFECYCLE_AGENT_ID=$(echo "$LIFECYCLE_AGENTS_RESP" \
+  | jq -r ".items[] | select(.name == \"${LIFECYCLE_AGENT_NAME}\") | .id" 2>/dev/null | head -1 || echo "")
+
+if [ -n "$LIFECYCLE_AGENT_ID" ]; then
+  LIFECYCLE_START_RESP=$(api POST "/api/ambient/v1/projects/${PROJECT_ID}/agents/${LIFECYCLE_AGENT_ID}/start" \
+    -d '{"prompt": "gateway-e2e-test: runner lifecycle check"}' || echo "")
+  LIFECYCLE_SESSION_ID=$(echo "$LIFECYCLE_START_RESP" \
+    | jq -r '.session.id // empty' 2>/dev/null || echo "")
+fi
+
+if [ -n "$LIFECYCLE_SESSION_ID" ]; then
 
   # 11a. Session reaches Running phase (explicit assertion, not just a gate)
   LIFECYCLE_PHASE=""
   for i in $(seq 1 60); do
-    LIFECYCLE_PHASE=$(api GET "/api/ambient/v1/sessions/${CREATED_SESSION_ID}" 2>/dev/null \
+    LIFECYCLE_PHASE=$(api GET "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}" 2>/dev/null \
       | jq -r '.phase // empty' 2>/dev/null || echo "")
     if [ "$LIFECYCLE_PHASE" = "Running" ] || [ "$LIFECYCLE_PHASE" = "Succeeded" ] || [ "$LIFECYCLE_PHASE" = "Failed" ]; then
       break
@@ -608,7 +623,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
   # started successfully.
   RUN_STARTED_FOUND=false
   for i in $(seq 1 30); do
-    MESSAGES_RESP=$(api GET "/api/ambient/v1/sessions/${CREATED_SESSION_ID}/messages" || echo "")
+    MESSAGES_RESP=$(api GET "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}/messages" || echo "")
     if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "RUN_STARTED")' >/dev/null 2>&1; then
       RUN_STARTED_FOUND=true
       break
@@ -666,7 +681,7 @@ section "Cleanup"
 
 if [ "$SKIP_CLEANUP" = "true" ]; then
   echo -e "  ${YELLOW}Skipping cleanup (--skip-cleanup)${NC}"
-  for _sid in "$CREATED_SESSION_ID" "$REPO_SESSION_ID"; do
+  for _sid in "$CREATED_SESSION_ID" "$REPO_SESSION_ID" "$LIFECYCLE_SESSION_ID"; do
     [ -z "$_sid" ] && continue
     _pod="session-$(echo "${_sid:0:40}" | tr '[:upper:]' '[:lower:]')"
     _phase=$(kubectl get pod "$_pod" -n "$TENANT" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
@@ -686,6 +701,11 @@ else
     api DELETE "/api/ambient/v1/sessions/${REPO_SESSION_ID}" >/dev/null 2>&1 && \
       echo "  Deleted repo session ${REPO_SESSION_ID}" || \
       echo "  Could not delete repo session (non-fatal)"
+  fi
+  if [ -n "$LIFECYCLE_SESSION_ID" ]; then
+    api DELETE "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}" >/dev/null 2>&1 && \
+      echo "  Deleted lifecycle session ${LIFECYCLE_SESSION_ID}" || \
+      echo "  Could not delete lifecycle session (non-fatal)"
   fi
 fi
 

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -6,9 +6,7 @@
 #   ->  runner starts inside sandbox  ->  runner /health endpoint responds
 #
 # This test does NOT require a real LLM API key — it validates the platform
-# plumbing from session creation through runner startup.  The runner's /health
-# endpoint responds before contacting any inference service, so this proves
-# the full lifecycle works without a real LLM backend.
+# plumbing from session creation through sandbox provisioning.
 #
 # Prerequisites:
 #   - kind-up with OPENSHELL_USE_GATEWAY=true (default)
@@ -574,104 +572,11 @@ else
   fail "Repo payload verification requires agent 'repo-clone-workspace' (not found)"
 fi
 
-section "11. Runner lifecycle verification"
-
-# Verify the runner process started inside the sandbox and is processing.
-# The runner emits RUN_STARTED via AG-UI before contacting any LLM, so this
-# works without a real inference service.  Uses a dedicated agent with no
-# bound providers to avoid credential-related provisioning failures.
-LIFECYCLE_AGENT_NAME="test-agent-with-no-providers"
-$ACPCTL apply -f "$REPO_ROOT/examples/base/agents/test-agent-with-no-providers.yaml" \
-  --project "$TENANT" >/dev/null 2>&1 || true
-LIFECYCLE_AGENTS_RESP=$(api GET "/api/ambient/v1/projects/${PROJECT_ID}/agents?size=50" || echo "")
-LIFECYCLE_AGENT_ID=$(echo "$LIFECYCLE_AGENTS_RESP" \
-  | jq -r ".items[] | select(.name == \"${LIFECYCLE_AGENT_NAME}\") | .id" 2>/dev/null | head -1 || echo "")
-
-if [ -n "$LIFECYCLE_AGENT_ID" ]; then
-  LIFECYCLE_START_RESP=$(api POST "/api/ambient/v1/projects/${PROJECT_ID}/agents/${LIFECYCLE_AGENT_ID}/start" \
-    -d '{"prompt": "gateway-e2e-test: runner lifecycle check"}' || echo "")
-  LIFECYCLE_SESSION_ID=$(echo "$LIFECYCLE_START_RESP" \
-    | jq -r '.session.id // empty' 2>/dev/null || echo "")
-fi
-
-if [ -n "$LIFECYCLE_SESSION_ID" ]; then
-
-  # 11a. Session reaches Running phase (explicit assertion, not just a gate)
-  LIFECYCLE_PHASE=""
-  for i in $(seq 1 60); do
-    LIFECYCLE_PHASE=$(api GET "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}" 2>/dev/null \
-      | jq -r '.phase // empty' 2>/dev/null || echo "")
-    if [ "$LIFECYCLE_PHASE" = "Running" ] || [ "$LIFECYCLE_PHASE" = "Succeeded" ] || [ "$LIFECYCLE_PHASE" = "Failed" ]; then
-      break
-    fi
-    sleep 2
-  done
-
-  if [ "$LIFECYCLE_PHASE" = "Running" ] || [ "$LIFECYCLE_PHASE" = "Succeeded" ]; then
-    pass "Session reached Running phase"
-  elif [ "$LIFECYCLE_PHASE" = "Failed" ]; then
-    # Failed is acceptable if the runner started — it means inference failed,
-    # not that the runner never came up.  Check messages to confirm.
-    pass "Session reached terminal phase (${LIFECYCLE_PHASE}) — checking runner messages"
-  else
-    fail "Session did not reach Running phase within 120s (phase: ${LIFECYCLE_PHASE:-unknown})"
-  fi
-
-  # 11b. Runner health endpoint responds (proves runner process is alive)
-  # Hit GET /health on port 8001 inside the sandbox pod directly — this is
-  # faster and more reliable than waiting for AG-UI events to propagate
-  # through gRPC to the API server's message store.
-  LIFECYCLE_SBX_NAME="session-$(echo "${LIFECYCLE_SESSION_ID:0:40}" | tr '[:upper:]' '[:lower:]')"
-  RUNNER_HEALTHY=false
-  for i in $(seq 1 60); do
-    HEALTH_RESP=$(kubectl exec -n "$TENANT" "$LIFECYCLE_SBX_NAME" -- \
-      curl -sf --max-time 2 http://localhost:8001/health 2>/dev/null || echo "")
-    if echo "$HEALTH_RESP" | grep -q '"healthy"' 2>/dev/null; then
-      RUNNER_HEALTHY=true
-      break
-    fi
-    sleep 2
-  done
-
-  if [ "$RUNNER_HEALTHY" = "true" ]; then
-    pass "Runner health endpoint responded (runner is alive inside sandbox)"
-  else
-    fail "Runner /health did not respond within 120s"
-    echo "  Last response: ${HEALTH_RESP:-<empty>}"
-    echo "  Control plane logs (last 20 lines):"
-    kubectl logs -n "${NAMESPACE}" -l app=ambient-control-plane --tail=20 2>&1 | sed 's/^/    /'
-  fi
-
-  # 11c. Initial prompt delivered to session messages
-  # The runner reads /tmp/initial_prompt.txt and pushes a user message
-  # containing the prompt text via gRPC before starting the AG-UI run.
-  PROMPT_FOUND=false
-  MESSAGES_RESP=$(api GET "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}/messages" || echo "")
-  if [ -n "$MESSAGES_RESP" ]; then
-    if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "user")' >/dev/null 2>&1; then
-      PROMPT_FOUND=true
-    fi
-  fi
-
-  if [ "$PROMPT_FOUND" = "true" ]; then
-    pass "Initial prompt delivered as user message"
-  elif [ "$RUNNER_HEALTHY" = "true" ]; then
-    # Health check proves the runner is alive; the user message may arrive via
-    # a different path (HTTP vs gRPC) depending on configuration.
-    skip "Initial prompt user message" "health check confirmed runner is alive; prompt delivery path may differ"
-  else
-    fail "Initial prompt not found in session messages"
-  fi
-
-else
-  skip "Runner lifecycle verification" "session not created"
-fi
-
 section "Cleanup"
 
 if [ "$SKIP_CLEANUP" = "true" ]; then
   echo -e "  ${YELLOW}Skipping cleanup (--skip-cleanup)${NC}"
-  for _sid in "$CREATED_SESSION_ID" "$REPO_SESSION_ID" "$LIFECYCLE_SESSION_ID"; do
+  for _sid in "$CREATED_SESSION_ID" "$REPO_SESSION_ID"; do
     [ -z "$_sid" ] && continue
     _pod="session-$(echo "${_sid:0:40}" | tr '[:upper:]' '[:lower:]')"
     _phase=$(kubectl get pod "$_pod" -n "$TENANT" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
@@ -691,11 +596,6 @@ else
     api DELETE "/api/ambient/v1/sessions/${REPO_SESSION_ID}" >/dev/null 2>&1 && \
       echo "  Deleted repo session ${REPO_SESSION_ID}" || \
       echo "  Could not delete repo session (non-fatal)"
-  fi
-  if [ -n "$LIFECYCLE_SESSION_ID" ]; then
-    api DELETE "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}" >/dev/null 2>&1 && \
-      echo "  Deleted lifecycle session ${LIFECYCLE_SESSION_ID}" || \
-      echo "  Could not delete lifecycle session (non-fatal)"
   fi
 fi
 

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -3,12 +3,12 @@
 #
 # Validates the golden path:
 #   acpctl apply -k  ->  acpctl start  ->  sandbox provisioned  ->  session Running
-#   ->  runner starts inside sandbox  ->  AG-UI RUN_STARTED event emitted
+#   ->  runner starts inside sandbox  ->  runner /health endpoint responds
 #
 # This test does NOT require a real LLM API key — it validates the platform
-# plumbing from session creation through runner startup.  The runner emits
-# RUN_STARTED before contacting any inference service, so this proves the
-# full lifecycle works without a real LLM backend.
+# plumbing from session creation through runner startup.  The runner's /health
+# endpoint responds before contacting any inference service, so this proves
+# the full lifecycle works without a real LLM backend.
 #
 # Prerequisites:
 #   - kind-up with OPENSHELL_USE_GATEWAY=true (default)
@@ -617,38 +617,27 @@ if [ -n "$LIFECYCLE_SESSION_ID" ]; then
     fail "Session did not reach Running phase within 120s (phase: ${LIFECYCLE_PHASE:-unknown})"
   fi
 
-  # 11b. Runner emitted RUN_STARTED event (proves runner process is alive)
-  # The runner pushes AG-UI events to the API server via gRPC.  RUN_STARTED
-  # fires before the LLM is contacted, so it always appears if the runner
-  # started successfully.
-  RUN_STARTED_FOUND=false
-  for i in $(seq 1 30); do
-    MESSAGES_RESP=$(api GET "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}/messages" || echo "")
-    if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "RUN_STARTED")' >/dev/null 2>&1; then
-      RUN_STARTED_FOUND=true
-      break
-    fi
-    # Also check the operational lifecycle event (alternative event name)
-    if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "lifecycle") | .payload' 2>/dev/null \
-       | grep -q 'run_started' 2>/dev/null; then
-      RUN_STARTED_FOUND=true
+  # 11b. Runner health endpoint responds (proves runner process is alive)
+  # Hit GET /health on port 8001 inside the sandbox pod directly — this is
+  # faster and more reliable than waiting for AG-UI events to propagate
+  # through gRPC to the API server's message store.
+  LIFECYCLE_SBX_NAME="session-$(echo "${LIFECYCLE_SESSION_ID:0:40}" | tr '[:upper:]' '[:lower:]')"
+  RUNNER_HEALTHY=false
+  for i in $(seq 1 60); do
+    HEALTH_RESP=$(kubectl exec -n "$TENANT" "$LIFECYCLE_SBX_NAME" -- \
+      curl -sf --max-time 2 http://localhost:8001/health 2>/dev/null || echo "")
+    if echo "$HEALTH_RESP" | grep -q '"healthy"' 2>/dev/null; then
+      RUNNER_HEALTHY=true
       break
     fi
     sleep 2
   done
 
-  if [ "$RUN_STARTED_FOUND" = "true" ]; then
-    pass "Runner emitted RUN_STARTED event (runner is alive inside sandbox)"
+  if [ "$RUNNER_HEALTHY" = "true" ]; then
+    pass "Runner health endpoint responded (runner is alive inside sandbox)"
   else
-    fail "RUN_STARTED event not found in session messages within 60s"
-    # Dump available event types for debugging
-    EVENT_TYPES=$(echo "$MESSAGES_RESP" | jq -r '.[].event_type' 2>/dev/null | sort -u | head -10)
-    if [ -n "$EVENT_TYPES" ]; then
-      echo "  Available event types: ${EVENT_TYPES}"
-    else
-      echo "  No messages found for session"
-    fi
-    # Show control plane logs for diagnosis
+    fail "Runner /health did not respond within 120s"
+    echo "  Last response: ${HEALTH_RESP:-<empty>}"
     echo "  Control plane logs (last 20 lines):"
     kubectl logs -n "${NAMESPACE}" -l app=ambient-control-plane --tail=20 2>&1 | sed 's/^/    /'
   fi
@@ -657,6 +646,7 @@ if [ -n "$LIFECYCLE_SESSION_ID" ]; then
   # The runner reads /tmp/initial_prompt.txt and pushes a user message
   # containing the prompt text via gRPC before starting the AG-UI run.
   PROMPT_FOUND=false
+  MESSAGES_RESP=$(api GET "/api/ambient/v1/sessions/${LIFECYCLE_SESSION_ID}/messages" || echo "")
   if [ -n "$MESSAGES_RESP" ]; then
     if echo "$MESSAGES_RESP" | jq -e '.[] | select(.event_type == "user")' >/dev/null 2>&1; then
       PROMPT_FOUND=true
@@ -665,10 +655,10 @@ if [ -n "$LIFECYCLE_SESSION_ID" ]; then
 
   if [ "$PROMPT_FOUND" = "true" ]; then
     pass "Initial prompt delivered as user message"
-  elif [ "$RUN_STARTED_FOUND" = "true" ]; then
-    # RUN_STARTED proves the runner is alive; the user message may arrive via
+  elif [ "$RUNNER_HEALTHY" = "true" ]; then
+    # Health check proves the runner is alive; the user message may arrive via
     # a different path (HTTP vs gRPC) depending on configuration.
-    skip "Initial prompt user message" "RUN_STARTED confirmed runner is alive; prompt delivery path may differ"
+    skip "Initial prompt user message" "health check confirmed runner is alive; prompt delivery path may differ"
   else
     fail "Initial prompt not found in session messages"
   fi


### PR DESCRIPTION
## Summary

- **Fix**: `_acp_internal` policy injection was running immediately after `CreateSandbox`, before the supervisor synced the image's default policy. The merge started from an empty base, squashing all default network rules (claude_code_vertex, gcloud, github, pypi, etc.). Moved injection into `execAfterReady` — after the sandbox reaches READY and the supervisor has synced the baked-in policy.
- **Fix (review feedback)**: The existing-sandbox fast-path also called `injectACPInternalPolicy` immediately on sandbox discovery, before confirming READY — reintroducing the same race. Removed the premature call; `execAfterReady` handles injection for both paths.
- **Fix (review feedback)**: Error message in `injectACPInternalPolicy` leaked the internal policy key name `_acp_internal` to users. Replaced with generic label.
- **Proto**: Added `merge_operations` field and `PolicyMergeOperation` types to vendored OpenShell proto stubs, regenerated Go code.
- **Dead code removed**: `ensureACPInternalPolicy`, `rewriteACPEndpointNamespace`, `rewriteServiceHostNamespace` replaced by the merge operation approach.
- **Specs**: Updated `agent-sandbox-config.spec.md`, `openshell-sandbox-provisioning.spec.md`, and `runner.spec.md` to document post-creation policy injection via `UpdateConfig` with `merge_operations`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./internal/reconciler/...` pass
- [ ] Deploy to Kind cluster, start a session, verify `openshell policy get --gateway --full` shows all default rules preserved alongside `_acp_internal`
- [ ] Run `tests/e2e/gateway-e2e-test.sh` — sections 1-10 pass
- [ ] CI `test-local-dev` workflow passes

> **Note:** Runner lifecycle e2e test (section 11) was backed out due to flakiness — will be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)