### PR TITLE
fix(kind): restart ambient-ui after SSO config in kind-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -989,6 +989,9 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 		./scripts/bootstrap-workspace.sh || \
 		echo "$(COLOR_YELLOW)⚠$(COLOR_RESET)  Bootstrap failed (non-fatal). Run 'make dev-bootstrap' manually."; \
 	fi
+	@kubectl rollout restart deployment/ambient-ui -n $(NAMESPACE) >/dev/null 2>&1
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for ambient-ui to pick up SSO config..."
+	@kubectl wait --for=condition=ready pod -l app=ambient-ui -n $(NAMESPACE) --timeout=60s >/dev/null 2>&1
 	@$(MAKE) --no-print-directory _kind-start-port-forward
 	@echo ""
 	@echo "$(COLOR_BOLD)Access the platform:$(COLOR_RESET)"


### PR DESCRIPTION
## Summary

- `kind-up` patches the `sso-credentials` Secret and restarts Keycloak but never restarts `ambient-ui`, so the pod keeps stale SSO env vars and the UI fails on first connect
- The `kind-port-forward` target already handles this correctly (restart + readiness wait); this mirrors those same two steps into `kind-up` before starting port-forwards

## Test plan

- [ ] Run `make kind-up` from scratch and verify the Ambient UI is accessible on first attempt without needing `make kind-port-forward`
- [ ] Verify `make kind-port-forward` still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)