### PR TITLE
feat(kind): make openshell runner the default, add LOCAL_RUNNER option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ ifeq ($(OPENSHELL_USE_GATEWAY),true)
 MCP_BUILD_TARGETS :=
 endif
 
-build-all: build-runner build-runner-openshell build-api-server build-control-plane build-ambient-ui $(MCP_BUILD_TARGETS) ## Build all container images
+build-all: build-runner-openshell build-api-server build-control-plane build-ambient-ui $(MCP_BUILD_TARGETS) ## Build all container images
 
 build-ambient-ui: ## Build ambient-ui image
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Building ambient-ui with $(CONTAINER_ENGINE)..."
@@ -927,7 +927,7 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 			$(MAKE) --no-print-directory kind-load-runner; \
 			echo "$(COLOR_BLUE)▶$(COLOR_RESET) Patching control plane to use locally-built runner image..."; \
 			kubectl set env deployment/ambient-control-plane -n $(NAMESPACE) \
-				OPENSHELL_RUNNER_IMAGE=localhost/acp_claude_runner:latest $(QUIET_REDIRECT); \
+				OPENSHELL_RUNNER_IMAGE=localhost/acp_runner_openshell:latest $(QUIET_REDIRECT); \
 		else \
 			$(MAKE) --no-print-directory _kind-preload-runner; \
 			echo "$(COLOR_BLUE)▶$(COLOR_RESET) Patching control plane to use pre-loaded runner image..."; \
@@ -1319,10 +1319,10 @@ kind-reload-runner-openshell: check-kind check-kubectl check-local-context ## Re
 	@kubectl rollout status deployment/ambient-control-plane -n $(NAMESPACE) --timeout=60s
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) OpenShell runner reloaded — new sessions will use the updated image"
 
-kind-load-runner: build-runner check-kind check-kubectl check-local-context ## Build runner image and load into kind (skips if already present)
-	@_IMG=$$(echo "$(RUNNER_IMAGE)" | cut -d: -f1) && \
+kind-load-runner: build-runner-openshell check-kind check-kubectl check-local-context ## Build OpenShell runner image and load into kind (skips if already present)
+	@_IMG=$$(echo "$(RUNNER_OPENSHELL_IMAGE)" | cut -d: -f1) && \
 	_REF=localhost/$$_IMG:latest && \
-	$(CONTAINER_ENGINE) tag $(RUNNER_IMAGE) $$_REF 2>/dev/null || true; \
+	$(CONTAINER_ENGINE) tag $(RUNNER_OPENSHELL_IMAGE) $$_REF 2>/dev/null || true; \
 	if $(CONTAINER_ENGINE) exec $(KIND_CLUSTER_NAME)-control-plane \
 		ctr --namespace=k8s.io images check "name==$$_REF" 2>/dev/null | grep -q "$$_REF"; then \
 		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Runner image already loaded in kind: $$_REF (skipping)"; \
@@ -1554,7 +1554,7 @@ _kind-require-cluster: ## Internal: Fail fast if kind cluster is not running
 	@$(if $(filter podman,$(CONTAINER_ENGINE)),KIND_EXPERIMENTAL_PROVIDER=podman) kind get clusters 2>/dev/null | grep -q '^$(KIND_CLUSTER_NAME)$$' || \
 		(echo "$(COLOR_RED)✗$(COLOR_RESET) No ambient Kind cluster found. Run 'make kind-up' first, or set KIND_CLUSTER_NAME to an existing cluster." && exit 1)
 
-KIND_CORE_IMAGES := $(RUNNER_IMAGE) $(RUNNER_OPENSHELL_IMAGE) $(API_SERVER_IMAGE) $(CONTROL_PLANE_IMAGE) $(AMBIENT_UI_IMAGE)
+KIND_CORE_IMAGES := $(RUNNER_OPENSHELL_IMAGE) $(API_SERVER_IMAGE) $(CONTROL_PLANE_IMAGE) $(AMBIENT_UI_IMAGE)
 KIND_MCP_IMAGES := $(MCP_IMAGE) $(GITHUB_MCP_IMAGE) $(JIRA_MCP_IMAGE) $(K8S_MCP_IMAGE) $(GOOGLE_MCP_IMAGE)
 ifeq ($(OPENSHELL_USE_GATEWAY),true)
 KIND_MCP_IMAGES :=

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: local-dev-token
 .PHONY: local-logs local-logs-api-server local-logs-ui local-logs-control-plane local-shell-api-server local-shell-ui
 .PHONY: local-test local-test-dev local-test-quick test-all local-troubleshoot local-port-forward local-stop-port-forward
-.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-reload-ambient-control-plane kind-reload-ambient-api-server kind-reload-runner-openshell kind-status kind-login kind-sso-toggle kind-setup-vertex kind-setup-openshell-cli
+.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-reload-ambient-control-plane kind-reload-ambient-api-server kind-reload-runner-openshell kind-load-runner kind-status kind-login kind-sso-toggle kind-setup-vertex kind-setup-openshell-cli
 .PHONY: preflight-cluster preflight dev-env dev
 .PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift test-gateway-e2e test-vteam-catalog-lab
 .PHONY: unleash-port-forward unleash-status
@@ -119,6 +119,7 @@ KIND_HOST ?=
 # Vertex AI Configuration (for LOCAL_VERTEX=true)
 # These inherit from environment if set, or can be overridden on command line
 LOCAL_IMAGES ?= false
+LOCAL_RUNNER ?= false
 LOCAL_VERTEX ?= false
 OPENSHELL_USE_GATEWAY ?= true
 ANTHROPIC_VERTEX_PROJECT_ID ?= $(shell echo $$ANTHROPIC_VERTEX_PROJECT_ID)
@@ -180,6 +181,7 @@ help: ## Display this help message
 	@echo ''
 	@echo '$(COLOR_BOLD)Examples:$(COLOR_RESET)'
 	@echo '  make kind-up LOCAL_IMAGES=true    Build from source and deploy to kind'
+	@echo '  make kind-up LOCAL_RUNNER=true    Build runner from source, use Quay for everything else'
 	@echo '  make kind-rebuild                 Rebuild and reload all components in kind'
 	@echo '  make kind-status                  Show all kind clusters and their ports'
 	@echo '  make kind-up CONTAINER_ENGINE=docker'
@@ -883,7 +885,7 @@ benchmark-ci: ## Run component benchmarks in CI mode
 		$(if $(CANDIDATE),--candidate-ref $(CANDIDATE)) \
 		$(if $(FORMAT),--format $(FORMAT))
 
-kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platform (LOCAL_IMAGES=true builds from source)
+kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platform (LOCAL_IMAGES=true builds all from source; LOCAL_RUNNER=true builds only runner from source)
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Starting kind cluster '$(KIND_CLUSTER_NAME)'..."
 	@KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND_HTTP_PORT=$(KIND_HTTP_PORT) KIND_HTTPS_PORT=$(KIND_HTTPS_PORT) KIND_HOST=$(KIND_HOST) CONTAINER_ENGINE=$(CONTAINER_ENGINE) ./tests/infra/setup-kind.sh
 	@if [ -n "$(KIND_HOST)" ]; then \
@@ -920,10 +922,18 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 	else \
 		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Deploying with Quay.io images..."; \
 		kubectl apply --validate=false -k components/manifests/overlays/kind/; \
-		$(MAKE) --no-print-directory _kind-preload-runner; \
-		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Patching control plane to use pre-loaded runner image..."; \
-		kubectl set env deployment/ambient-control-plane -n $(NAMESPACE) \
-			OPENSHELL_RUNNER_IMAGE=$(RUNNER_PRELOAD_REF) $(QUIET_REDIRECT); \
+		if [ "$(LOCAL_RUNNER)" = "true" ]; then \
+			echo "$(COLOR_BLUE)▶$(COLOR_RESET) Building runner from source..."; \
+			$(MAKE) --no-print-directory kind-load-runner; \
+			echo "$(COLOR_BLUE)▶$(COLOR_RESET) Patching control plane to use locally-built runner image..."; \
+			kubectl set env deployment/ambient-control-plane -n $(NAMESPACE) \
+				OPENSHELL_RUNNER_IMAGE=localhost/acp_claude_runner:latest $(QUIET_REDIRECT); \
+		else \
+			$(MAKE) --no-print-directory _kind-preload-runner; \
+			echo "$(COLOR_BLUE)▶$(COLOR_RESET) Patching control plane to use pre-loaded runner image..."; \
+			kubectl set env deployment/ambient-control-plane -n $(NAMESPACE) \
+				OPENSHELL_RUNNER_IMAGE=$(RUNNER_PRELOAD_REF) $(QUIET_REDIRECT); \
+		fi; \
 	fi
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for pods..."
 	@./tests/infra/wait-for-ready.sh
@@ -1308,6 +1318,26 @@ kind-reload-runner-openshell: check-kind check-kubectl check-local-context ## Re
 		OPENSHELL_RUNNER_IMAGE=localhost/acp_runner_openshell:latest $(QUIET_REDIRECT)
 	@kubectl rollout status deployment/ambient-control-plane -n $(NAMESPACE) --timeout=60s
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) OpenShell runner reloaded — new sessions will use the updated image"
+
+kind-load-runner: build-runner check-kind check-kubectl check-local-context ## Build runner image and load into kind (skips if already present)
+	@_IMG=$$(echo "$(RUNNER_IMAGE)" | cut -d: -f1) && \
+	_REF=localhost/$$_IMG:latest && \
+	$(CONTAINER_ENGINE) tag $(RUNNER_IMAGE) $$_REF 2>/dev/null || true; \
+	if $(CONTAINER_ENGINE) exec $(KIND_CLUSTER_NAME)-control-plane \
+		ctr --namespace=k8s.io images check "name==$$_REF" 2>/dev/null | grep -q "$$_REF"; then \
+		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Runner image already loaded in kind: $$_REF (skipping)"; \
+	else \
+		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Loading $$_REF into kind cluster ($(KIND_CLUSTER_NAME))..."; \
+		if [ "$(CONTAINER_ENGINE)" = "podman" ] || [ -n "$(KIND_HOST)" ]; then \
+			$(CONTAINER_ENGINE) save $$_REF | \
+				$(CONTAINER_ENGINE) exec -i $(KIND_CLUSTER_NAME)-control-plane \
+				ctr --namespace=k8s.io images import -; \
+		else \
+			$(CONTAINER_ENGINE) save $$_REF | \
+				kind load image-archive /dev/stdin --name $(KIND_CLUSTER_NAME); \
+		fi; \
+		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Runner image loaded: $$_REF"; \
+	fi
 
 kind-sso-toggle: check-kubectl ## Toggle SSO auth on/off in Kind (affects both frontend and backend)
 	@UNLEASH_ADMIN_TOKEN=$$(kubectl get secret unleash-credentials -n $(NAMESPACE) -o jsonpath='{.data.admin-api-token}' | base64 -d); \

--- a/components/runners/ambient-runner/Dockerfile.openshell
+++ b/components/runners/ambient-runner/Dockerfile.openshell
@@ -58,14 +58,15 @@ RUN dnf install -y --allowerasing --nodocs \
         nano \
     && dnf clean all
 
+# TODO: separate runner images for each of these
 # Global npm packages (multi-agent sandbox toolset: alternative coding agents
 # available alongside Claude Code for user selection via Agent spec)
-RUN npm install -g \
-        tar@7.5.11 \
-        @hono/node-server@1.19.11 \
-        opencode-ai@1.2.18 \
-        @openai/codex@0.117.0 \
-        @github/copilot@1.0.16
+#RUN npm install -g \
+        #tar@7.5.11 \
+        #@hono/node-server@1.19.11 \
+        #opencode-ai@1.2.18 \
+        #@openai/codex@0.117.0 \
+        #@github/copilot@1.0.16
 
 # GitHub CLI (pinned binary download with pre-committed SHA256 checksums)
 ARG GH_VERSION=2.74.0
@@ -118,7 +119,7 @@ RUN mkdir -p /sandbox/.claude/skills /sandbox/.agents/skills && \
 # ------------------------------------------------------------
 # Claude Code CLI (pinned npm package instead of curl|bash)
 # ------------------------------------------------------------
-ARG CLAUDE_CODE_VERSION=2.1.195
+ARG CLAUDE_CODE_VERSION=2.1.205
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
     && mkdir -p /opt/claude/bin \
     && ln -sf /usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe /opt/claude/bin/claude \


### PR DESCRIPTION
## Summary
- Make the openshell runner (`acp_runner_openshell`) the default runner image — remove the claude runner from `build-all` and `KIND_CORE_IMAGES`
- Remove alternative coding agent npm packages (opencode, codex, copilot) from `Dockerfile.openshell` to reduce image size — these will be separated into their own images later
- Add `make kind-load-runner` target to build the openshell runner from source and load it into kind, skipping the load if already present
- Add `LOCAL_RUNNER=true` option to `make kind-up` to build the runner from source while pulling everything else from Quay

## Test plan
- [ ] `make build-all` builds the openshell runner (not the claude runner)
- [ ] `make kind-up` deploys with the Quay openshell runner by default
- [ ] `make kind-up LOCAL_RUNNER=true` builds and loads the local openshell runner instead of pulling from Quay
- [ ] `make kind-load-runner` skips the load on subsequent runs when the image is already present
- [ ] `make kind-up LOCAL_IMAGES=true` builds and loads the openshell runner (not the claude runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)