### PR TITLE
fix(runner): make /sandbox group-0 writable for OpenShift arbitrary UIDs

### DIFF
--- a/components/runners/ambient-runner/Dockerfile.openshell
+++ b/components/runners/ambient-runner/Dockerfile.openshell
@@ -150,6 +150,17 @@ RUN uv pip install --python /sandbox/.venv/bin/python '/runner/ambient-runner[al
 RUN mkdir -p /sandbox/workspace/artifacts /sandbox/workspace/file-uploads && \
     chown -R sandbox:sandbox /sandbox/workspace
 
+# OpenShift compatibility: the sandbox runs under the restricted-v2 SCC with an
+# arbitrarily-assigned UID that is always a member of GID 0 (the root group).
+# Every directory and file the agent writes to under $HOME (/sandbox) must
+# therefore be owned by group 0 and be group-writable. Without this, repo
+# payload extraction into /sandbox/* (e.g. session-config) fails with
+# "tar: ...: Cannot mkdir: Permission denied" because the arbitrary UID owns
+# none of the pre-created sandbox-user dirs. This mirrors the "chmod -R g=u"
+# treatment in the file-mode Dockerfile. See:
+# https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/images/creating-images#use-uid
+RUN chgrp -R 0 /sandbox && chmod -R g=u /sandbox
+
 ENV RUNNER_TYPE=claude-agent-sdk \
     HOME=/sandbox \
     SHELL=/bin/bash \


### PR DESCRIPTION
## What

Make the `/sandbox` tree group-0-owned and group-writable in the OpenShell
runner image so repo-payload extraction works when the sandbox runs under
OpenShift's `restricted-v2` SCC (arbitrary UID).

```dockerfile
RUN chgrp -R 0 /sandbox && chmod -R g=u /sandbox
```

## Why

Sessions using repo payloads (`sandbox_path` + `repo_url`, e.g. the
`vteam-catalog` agents pointing at `/sandbox/session-config`) fail at setup on
OpenShift with:

```
Setup Failed: payload upload failed: upload repo payload /sandbox/session-config:
tar extraction failed (stderr: tar: .ambient/workflows: Cannot mkdir: Permission denied
tar: .claude/agents: Cannot mkdir: Permission denied ... CLAUDE.md: Cannot open: Permission denied
Exiting with failure status due to previous errors): Process exited with status 2
```

Root cause: `Dockerfile.openshell` chowned all of `/sandbox` to
`sandbox:sandbox` (997:996) mode 755. Under `restricted-v2` the pod gets an
**arbitrary UID** (always a member of **GID 0**) that owns none of those dirs
and has no group-write bit, so the control plane's SSH extraction
(`mkdir -p <t> && tar xf - -C <t>`) can't create anything under the
pre-created `/sandbox/session-config`.

This is the canonical OpenShift *"support arbitrary user ids"* pattern
([docs](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/images/creating-images#use-uid)),
already applied via `chmod -R g=u` in the sibling file-mode `Dockerfile`. The
openshell image never got it.

It works on kind only because kind runs the sandbox as root/997 (the owner);
the failure is specific to restricted-SCC arbitrary UIDs.

## Reproducer (kind — simulates the arbitrary UID with `setpriv`)

```bash
POD=$(kubectl get pod -n tenant-a -o name | grep session- | head -1)
kubectl exec -n tenant-a $POD -c agent -- sh -c '
  mkdir -p /tmp/r/.ambient/workflows && echo x > /tmp/r/CLAUDE.md
  (cd /tmp/r && tar cf /tmp/p.tar .ambient CLAUDE.md)
  mkdir -p /sandbox/sc && chown 997:996 /sandbox/sc && chmod 755 /sandbox/sc   # pre-fix image state
  echo "--- arbitrary UID, BEFORE fix ---"
  setpriv --reuid 1000700000 --regid 0 --clear-groups sh -c "tar xf - -C /sandbox/sc" < /tmp/p.tar; echo "exit=$?"
  echo "--- apply fix, then retry ---"
  chgrp -R 0 /sandbox/sc && chmod -R g=u /sandbox/sc
  setpriv --reuid 1000700000 --regid 0 --clear-groups sh -c "tar xf - -C /sandbox/sc" < /tmp/p.tar; echo "exit=$?"
  rm -rf /sandbox/sc /tmp/r /tmp/p.tar'
# BEFORE: tar: Cannot mkdir: Permission denied ... exit=2
# AFTER:  exit=0 (full tree extracted)
```

## Verification

- Runtime behavior of the exact command validated on kind as above: **exit 2 → exit 0**.
- Not yet exercised via a full image rebuild under a real restricted-SCC cluster.

## Notes

- `fsGroup` does not help here: `/sandbox` is the sandbox rootfs (ext4), not a mounted volume.
- Alternative (not taken): pin sandbox `runAsUser: 997` via an `anyuid`/`nonroot` SCC.
