### PR TITLE
fix(tekton): build all Konflux components on every push to main

### DIFF
--- a/.tekton/acp-api-server-main-push.yaml
+++ b/.tekton/acp-api-server-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/ambient-api-server/***".pathChanged() || ".tekton/acp-api-server-main-push.yaml".pathChanged()
-      )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: acp-api-server-main

--- a/.tekton/acp-mcp-main-push.yaml
+++ b/.tekton/acp-mcp-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/ambient-mcp/***".pathChanged() || ".tekton/acp-mcp-main-push.yaml".pathChanged()
-      )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: acp-mcp-main

--- a/.tekton/acp-runner-main-push.yaml
+++ b/.tekton/acp-runner-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/runners/ambient-runner/***".pathChanged() || ".tekton/acp-runner-main-push.yaml".pathChanged()
-      )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: acp-runner-main

--- a/.tekton/acp-runner-openshell-main-push.yaml
+++ b/.tekton/acp-runner-openshell-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/runners/ambient-runner/***".pathChanged() || ".tekton/acp-runner-openshell-main-push.yaml".pathChanged()
-      || "components/runners/ambient-runner/Dockerfile.openshell".pathChanged() )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: acp-runner-openshell-main

--- a/.tekton/acp-ui-main-push.yaml
+++ b/.tekton/acp-ui-main-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/ambient-ui/***".pathChanged() || "components/ambient-sdk/ts-sdk/***".pathChanged()
-      || ".tekton/acp-ui-main-push.yaml".pathChanged() )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: acp-ui-main

--- a/.tekton/control-plane-main-push.yaml
+++ b/.tekton/control-plane-main-push.yaml
@@ -8,9 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/ambient-control-plane/***".pathChanged() || "components/ambient-api-server/***".pathChanged()
-      || "components/ambient-sdk/go-sdk/***".pathChanged() || ".tekton/control-plane-main-push.yaml".pathChanged()
-      )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: control-plane-main

--- a/.tekton/credential-github-main-push.yaml
+++ b/.tekton/credential-github-main-push.yaml
@@ -8,10 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/credential-sidecars/github/***".pathChanged()
-      || "components/credential-sidecars/entrypoint/***".pathChanged()
-      || "components/ambient-mcp/***".pathChanged()
-      || ".tekton/credential-github-main-push.yaml".pathChanged() )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: credential-github-main

--- a/.tekton/credential-google-main-push.yaml
+++ b/.tekton/credential-google-main-push.yaml
@@ -8,10 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/credential-sidecars/google/***".pathChanged()
-      || "components/credential-sidecars/entrypoint/***".pathChanged()
-      || "components/ambient-mcp/***".pathChanged()
-      || ".tekton/credential-google-main-push.yaml".pathChanged() )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: credential-google-main

--- a/.tekton/credential-jira-main-push.yaml
+++ b/.tekton/credential-jira-main-push.yaml
@@ -8,10 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/credential-sidecars/jira/***".pathChanged()
-      || "components/credential-sidecars/entrypoint/***".pathChanged()
-      || "components/ambient-mcp/***".pathChanged()
-      || ".tekton/credential-jira-main-push.yaml".pathChanged() )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: credential-jira-main

--- a/.tekton/credential-k8s-main-push.yaml
+++ b/.tekton/credential-k8s-main-push.yaml
@@ -8,10 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "components/credential-sidecars/k8s/***".pathChanged()
-      || "components/credential-sidecars/entrypoint/***".pathChanged()
-      || "components/ambient-mcp/***".pathChanged()
-      || ".tekton/credential-k8s-main-push.yaml".pathChanged() )
+      == "main"
   labels:
     appstudio.openshift.io/application: agent-control-plane-main
     appstudio.openshift.io/component: credential-k8s-main


### PR DESCRIPTION
## Summary
- Remove `pathChanged()` CEL filters from all 10 Konflux push-to-main pipelines so every merge to `main` builds all component images
- Fixes app-interface deployment failures where `saas.yaml` resolves `ref: main` to HEAD's commit SHA but not all component images exist for that SHA (because Konflux only built components whose source was touched)
- PR pipelines retain their path filters to avoid unnecessary CI on pull requests

## Test plan
- [ ] Verify all 10 push pipeline YAML files have `on-cel-expression: event == "push" && target_branch == "main"` with no `pathChanged()` clause
- [ ] Merge to main and confirm all 10 Konflux component builds trigger
- [ ] Verify all images appear in quay.io with the merged commit SHA as tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)