### PR TITLE
fix(ci): align codeql-action SHAs and fix model-discovery test path

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,10 +51,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      - uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
       - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           category: /language:go
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: javascript-typescript
       - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: python
       - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: actions
       - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/tests/unit/test_model_discovery.py
+++ b/tests/unit/test_model_discovery.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 # Import model-discovery.py as a module (it has a hyphen in the name)
 _spec = importlib.util.spec_from_file_location(
     "model_discovery",
-    Path(__file__).resolve().parent.parent / ".github" / "scripts" / "model-discovery.py",
+    Path(__file__).resolve().parent.parent.parent / ".github" / "scripts" / "model-discovery.py",
 )
 _mod = importlib.util.module_from_spec(_spec)
 sys.modules["model_discovery"] = _mod


### PR DESCRIPTION
## Summary
- Align all `github/codeql-action` sub-actions (`init`, `autobuild`) to the same v4.37.0 SHA that Dependabot set for `analyze`, fixing the version mismatch CI error
- Fix `test_model_discovery.py` import path — added missing `.parent` so path resolves to repo root `.github/scripts/` instead of `tests/.github/scripts/`

## Test plan
- [x] `python tests/unit/test_model_discovery.py -v` — all 24 tests pass locally
- [ ] CodeQL workflow runs without version mismatch error
- [ ] Model-discovery unit test job passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)