### PR TITLE
fix(ui): disable sidebar nav when no project selected and remove content max-width

### DIFF
--- a/components/ambient-ui/src/app/(dashboard)/layout.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/layout.tsx
@@ -104,7 +104,7 @@ export default function DashboardLayout({
             detailName={agentId ? (agent?.displayName ?? agent?.name ?? agentId) : null}
           />
           <PlatformHealthBanner />
-          <div className="flex-1 p-6 pb-10 max-w-7xl">{children}</div>
+          <div className="flex-1 p-6 pb-10">{children}</div>
           <StatusBar />
           <CommandPalette />
         </SidebarInset>

--- a/components/ambient-ui/src/components/app-sidebar.tsx
+++ b/components/ambient-ui/src/components/app-sidebar.tsx
@@ -75,6 +75,7 @@ function NavGroup({
         <SidebarMenu>
           {items.map((item) => {
             const isGlobal = item.global === true
+            const needsProject = !isGlobal && !effectiveProjectId
 
             const href = isGlobal
               ? item.href
@@ -94,16 +95,26 @@ function NavGroup({
 
             return (
               <SidebarMenuItem key={item.label}>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive}
-                  tooltip={item.label}
-                >
-                  <Link href={href}>
+                {needsProject ? (
+                  <SidebarMenuButton
+                    disabled
+                    tooltip={item.label}
+                  >
                     <item.icon />
                     <span>{item.label}</span>
-                  </Link>
-                </SidebarMenuButton>
+                  </SidebarMenuButton>
+                ) : (
+                  <SidebarMenuButton
+                    asChild
+                    isActive={isActive}
+                    tooltip={item.label}
+                  >
+                    <Link href={href}>
+                      <item.icon />
+                      <span>{item.label}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                )}
                 {badgeCount > 0 && (
                   <SidebarMenuBadge>{badgeCount}</SidebarMenuBadge>
                 )}


### PR DESCRIPTION
## Summary

- Sidebar nav items now render as disabled buttons (grayed out, non-clickable) when no project is selected, instead of silently redirecting every click to the project picker root page
- Removed the `max-w-7xl` constraint from the dashboard content wrapper so page content expands to fill available width when the sidebar is collapsed

## Test plan

- [ ] With no project selected, verify sidebar items appear visually disabled and are not clickable
- [ ] Select a project and verify sidebar items become active links again
- [ ] Toggle the sidebar closed and verify content expands to fill the freed space
- [ ] Check Settings page still constrains itself with its own `max-w-md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>