### PR TITLE
feat(ui): add phase-aware empty states and thinking indicator to chat

### DIFF
--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/chat-tab.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/chat-tab.tsx
@@ -11,6 +11,7 @@ import {
   ChatItemsList,
   ChatInput,
   buildChatItems,
+  isRunActive,
 } from '@/components/chat-messages'
 import { useChatSidebar } from '@/components/chat-sidebar-context'
 import { useLiveTail, LiveIndicator } from './live-tail-indicator'
@@ -25,6 +26,10 @@ export function ChatTab({ session }: { session: DomainSession }) {
   const chatItems = useMemo(() => {
     return buildChatItems(data?.items ?? [])
   }, [data])
+
+  const isThinking = useMemo(() => {
+    return session.phase === 'Running' && isRunActive(data?.items ?? [])
+  }, [data, session.phase])
 
   const chatItemCount = chatItems.length
 
@@ -126,7 +131,7 @@ export function ChatTab({ session }: { session: DomainSession }) {
             aria-label="Chat messages"
             onScroll={handleScroll}
           >
-            <ChatItemsList items={chatItems} isLoading={isLoading} />
+            <ChatItemsList items={chatItems} isLoading={isLoading} phase={session.phase} isThinking={isThinking} />
             <div ref={sentinelRef} className="h-1" aria-hidden="true" />
           </div>
 

--- a/components/ambient-ui/src/app/globals.css
+++ b/components/ambient-ui/src/app/globals.css
@@ -238,3 +238,8 @@
     @apply bg-background text-foreground antialiased;
   }
 }
+
+@keyframes thinking-dot {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}

--- a/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
+++ b/components/ambient-ui/src/components/__tests__/chat-messages.test.ts
@@ -7,6 +7,7 @@ import {
   filterEmptyMessages,
   groupChatItems,
   buildChatItems,
+  isRunActive,
 } from '../chat-messages'
 
 // ---- Factory ----
@@ -407,5 +408,105 @@ describe('buildChatItems', () => {
 
   it('returns empty array when given no messages', () => {
     expect(buildChatItems([])).toEqual([])
+  })
+})
+
+// ---- isRunActive ----
+
+describe('isRunActive', () => {
+  it('returns false on empty message list', () => {
+    expect(isRunActive([])).toBe(false)
+  })
+
+  it('returns false when last relevant event is assistant message', () => {
+    const messages = [
+      makeMsg({ eventType: 'user', payload: 'hello' }),
+      makeMsg({ eventType: 'assistant', payload: 'hi there' }),
+    ]
+    expect(isRunActive(messages)).toBe(false)
+  })
+
+  it('returns true when run_started lifecycle follows user message', () => {
+    const messages = [
+      makeMsg({ eventType: 'user', payload: 'fix the bug' }),
+      makeMsg({
+        eventType: 'lifecycle',
+        payload: JSON.stringify({ event: 'run_started' }),
+      }),
+    ]
+    expect(isRunActive(messages)).toBe(true)
+  })
+
+  it('returns false when run_finished lifecycle received', () => {
+    const messages = [
+      makeMsg({ eventType: 'user', payload: 'fix the bug' }),
+      makeMsg({
+        eventType: 'lifecycle',
+        payload: JSON.stringify({ event: 'run_started' }),
+      }),
+      makeMsg({
+        eventType: 'lifecycle',
+        payload: JSON.stringify({ event: 'run_finished' }),
+      }),
+    ]
+    expect(isRunActive(messages)).toBe(false)
+  })
+
+  it('does not trigger on bare user message without run_started', () => {
+    const messages = [
+      makeMsg({ eventType: 'user', payload: 'hello' }),
+    ]
+    expect(isRunActive(messages)).toBe(false)
+  })
+
+  it('indicator persists through tool_use and tool_result messages', () => {
+    const messages = [
+      makeMsg({ eventType: 'user', payload: 'fix the bug' }),
+      makeMsg({
+        eventType: 'lifecycle',
+        payload: JSON.stringify({ event: 'run_started' }),
+      }),
+      makeMsg({
+        eventType: 'tool_use',
+        payload: JSON.stringify({ tool: 'Read', tool_call_id: 'tc-1' }),
+      }),
+      makeMsg({
+        eventType: 'tool_result',
+        payload: JSON.stringify({ tool_call_id: 'tc-1', result: 'data' }),
+      }),
+    ]
+    expect(isRunActive(messages)).toBe(true)
+  })
+
+  it('handles malformed lifecycle payload gracefully', () => {
+    const messages = [
+      makeMsg({ eventType: 'lifecycle', payload: 'not valid json' }),
+    ]
+    expect(isRunActive(messages)).toBe(false)
+  })
+
+  it('returns false when assistant message follows run_started', () => {
+    const messages = [
+      makeMsg({
+        eventType: 'lifecycle',
+        payload: JSON.stringify({ event: 'run_started' }),
+      }),
+      makeMsg({ eventType: 'assistant', payload: 'Here is the fix' }),
+    ]
+    expect(isRunActive(messages)).toBe(false)
+  })
+
+  it('ignores unrelated lifecycle events', () => {
+    const messages = [
+      makeMsg({
+        eventType: 'lifecycle',
+        payload: JSON.stringify({ event: 'run_started' }),
+      }),
+      makeMsg({
+        eventType: 'lifecycle',
+        payload: JSON.stringify({ event: 'session_created' }),
+      }),
+    ]
+    expect(isRunActive(messages)).toBe(true)
   })
 })

--- a/components/ambient-ui/src/components/chat-messages.tsx
+++ b/components/ambient-ui/src/components/chat-messages.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
-import type { DomainSessionMessage, SessionEventType } from '@/domain/types'
+import type { DomainSessionMessage, SessionEventType, SessionPhase } from '@/domain/types'
 import { useSendMessage } from '@/queries/use-send-message'
 import { formatRelativeTime } from '@/lib/format-timestamp'
 import { cn } from '@/lib/utils'
@@ -353,7 +353,7 @@ function SimpleChatMessage({ message }: { message: DomainSessionMessage }) {
 
 // ---- Phase Status Indicator ----
 
-const PHASE_STYLES: Record<string, string> = {
+const PHASE_STYLES: Record<SessionPhase, string> = {
   Running: 'bg-status-success text-status-success-foreground border-status-success-border',
   Pending: 'bg-status-warning text-status-warning-foreground border-status-warning-border',
   Creating: 'bg-status-info text-status-info-foreground border-status-info-border',
@@ -363,8 +363,8 @@ const PHASE_STYLES: Record<string, string> = {
   Stopped: 'bg-event-system text-event-system-foreground border-event-system-border',
 }
 
-export function PhaseIndicator({ phase }: { phase: string }) {
-  const style = PHASE_STYLES[phase] ?? PHASE_STYLES.Stopped
+export function PhaseIndicator({ phase }: { phase: SessionPhase }) {
+  const style = PHASE_STYLES[phase]
   return (
     <Badge
       variant="outline"
@@ -379,7 +379,7 @@ export function PhaseIndicator({ phase }: { phase: string }) {
 
 type ChatInputProps = {
   sessionId: string
-  phase: string
+  phase: SessionPhase
   disabled: boolean
 }
 
@@ -505,8 +505,8 @@ export function ChatInput({ sessionId, phase, disabled }: ChatInputProps) {
 
 // ---- Chat Items List (shared between tab and sidebar) ----
 
-const STARTING_PHASES = new Set(['Pending', 'Creating'])
-const TERMINAL_PHASES = new Set(['Completed', 'Failed', 'Stopped'])
+const STARTING_PHASES: ReadonlySet<SessionPhase> = new Set(['Pending', 'Creating'])
+const TERMINAL_PHASES: ReadonlySet<SessionPhase> = new Set(['Completed', 'Failed', 'Stopped'])
 
 export function ChatItemsList({
   items,
@@ -516,7 +516,7 @@ export function ChatItemsList({
 }: {
   items: ChatItem[]
   isLoading: boolean
-  phase?: string
+  phase?: SessionPhase
   isThinking?: boolean
 }) {
   if (isLoading) {
@@ -616,7 +616,6 @@ export function isRunActive(messages: DomainSessionMessage[]): boolean {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.eventType === 'assistant') return false
-    if (msg.eventType === 'user') return true
     if (msg.eventType !== 'lifecycle') continue
     const event = parseLifecycleEvent(msg.payload)
     if (event === 'run_started') return true

--- a/components/ambient-ui/src/components/chat-messages.tsx
+++ b/components/ambient-ui/src/components/chat-messages.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { User, Bot, Wrench, Send, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react'
+import { User, Bot, Wrench, Send, ChevronDown, ChevronRight, AlertTriangle, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -505,12 +505,19 @@ export function ChatInput({ sessionId, phase, disabled }: ChatInputProps) {
 
 // ---- Chat Items List (shared between tab and sidebar) ----
 
+const STARTING_PHASES = new Set(['Pending', 'Creating'])
+const TERMINAL_PHASES = new Set(['Completed', 'Failed', 'Stopped'])
+
 export function ChatItemsList({
   items,
   isLoading,
+  phase,
+  isThinking,
 }: {
   items: ChatItem[]
   isLoading: boolean
+  phase?: string
+  isThinking?: boolean
 }) {
   if (isLoading) {
     return (
@@ -534,6 +541,33 @@ export function ChatItemsList({
   }
 
   if (items.length === 0) {
+    if (phase && STARTING_PHASES.has(phase)) {
+      return (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Loader2 className="h-8 w-8 mb-3 animate-spin opacity-60" aria-hidden="true" />
+          <p className="text-sm">Runner is starting...</p>
+        </div>
+      )
+    }
+
+    if (phase === 'Running') {
+      return (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Loader2 className="h-8 w-8 mb-3 animate-spin opacity-60" aria-hidden="true" />
+          <p className="text-sm">Runner started. Waiting for messages...</p>
+        </div>
+      )
+    }
+
+    if (phase && TERMINAL_PHASES.has(phase)) {
+      return (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Bot className="h-10 w-10 mb-3 opacity-40" aria-hidden="true" />
+          <p className="text-sm">No conversation messages were recorded.</p>
+        </div>
+      )
+    }
+
     return (
       <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
         <Bot className="h-10 w-10 mb-3 opacity-40" aria-hidden="true" />
@@ -553,6 +587,7 @@ export function ChatItemsList({
         }
         return <SimpleChatMessage key={item.message.id} message={item.message} />
       })}
+      {isThinking && <ThinkingIndicator />}
     </div>
   )
 }
@@ -562,4 +597,51 @@ export function buildChatItems(messages: DomainSessionMessage[]): ChatItem[] {
   const filtered = filterEmptyMessages(messages)
   const chatOnly = filtered.filter(m => CHAT_EVENT_TYPES.has(m.eventType))
   return groupChatItems(chatOnly)
+}
+
+// ---- Run-Active Detection ----
+
+function parseLifecycleEvent(payload: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(payload)
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const obj = parsed as Record<string, unknown>
+      if (typeof obj.event === 'string') return obj.event
+    }
+  } catch { /* plain string */ }
+  return null
+}
+
+export function isRunActive(messages: DomainSessionMessage[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.eventType === 'assistant') return false
+    if (msg.eventType === 'user') return true
+    if (msg.eventType !== 'lifecycle') continue
+    const event = parseLifecycleEvent(msg.payload)
+    if (event === 'run_started') return true
+    if (event === 'run_finished') return false
+  }
+  return false
+}
+
+// ---- Thinking Indicator ----
+
+export function ThinkingIndicator() {
+  return (
+    <div
+      className="flex gap-3 px-4 py-3"
+      role="status"
+      aria-label="Agent is thinking"
+    >
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-secondary">
+        <Bot className="h-4 w-4 text-secondary-foreground" aria-hidden="true" />
+      </div>
+      <div className="flex items-center gap-1 pt-1.5">
+        <span className="h-2 w-2 rounded-full bg-muted-foreground/60 animate-[thinking-dot_1.4s_ease-in-out_infinite]" />
+        <span className="h-2 w-2 rounded-full bg-muted-foreground/60 animate-[thinking-dot_1.4s_ease-in-out_0.2s_infinite]" />
+        <span className="h-2 w-2 rounded-full bg-muted-foreground/60 animate-[thinking-dot_1.4s_ease-in-out_0.4s_infinite]" />
+      </div>
+    </div>
+  )
 }

--- a/components/ambient-ui/src/components/chat-sidebar.tsx
+++ b/components/ambient-ui/src/components/chat-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   ChatInput,
   buildChatItems,
   PhaseIndicator,
+  isRunActive,
 } from '@/components/chat-messages'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useSession, useStopSession, useDeleteSession, useCreateSession } from '@/queries/use-sessions'
@@ -381,6 +382,7 @@ export function ChatSidebar() {
 
   const sessionName = session?.name ?? 'Loading...'
   const sessionPhase = session?.phase ?? 'Pending'
+  const isThinking = sessionPhase === 'Running' && isRunActive(messagesData?.items ?? [])
 
   if (collapsed) {
     return (
@@ -490,7 +492,7 @@ export function ChatSidebar() {
           <div className="absolute top-2 right-3 z-10"><LiveIndicator /></div>
         )}
         <div ref={scrollRef} className="h-full overflow-y-auto" role="log" aria-label="Chat messages" onScroll={handleScroll}>
-          <ChatItemsList items={chatItems} isLoading={messagesLoading} />
+          <ChatItemsList items={chatItems} isLoading={messagesLoading} phase={sessionPhase} isThinking={isThinking} />
           <div ref={sentinelRef} className="h-1" aria-hidden="true" />
         </div>
 

--- a/components/ambient-ui/src/components/chat-sidebar.tsx
+++ b/components/ambient-ui/src/components/chat-sidebar.tsx
@@ -381,7 +381,7 @@ export function ChatSidebar() {
   if (!isOpen || !activeSessionId) return null
 
   const sessionName = session?.name ?? 'Loading...'
-  const sessionPhase = session?.phase ?? 'Pending'
+  const sessionPhase: SessionPhase = session?.phase ?? 'Pending'
   const isThinking = sessionPhase === 'Running' && isRunActive(messagesData?.items ?? [])
 
   if (collapsed) {

--- a/specs/ui/views.spec.md
+++ b/specs/ui/views.spec.md
@@ -167,7 +167,88 @@ Condition colors SHALL reflect semantic health, not literal True/False values. "
 
 Note: the runner currently persists one `assistant` message per turn (final text only). Intermediate assistant text and individual tool call arguments are not yet persisted as separate messages — they arrive via the operational event writer with tool name and result only. Full streaming with intermediate text requires the SSE-Driven Updates requirement.
 
-## Requirement: Draft Message Persistence
+## Requirement: Phase-Aware Chat Empty State
+
+When the Chat tab or chat sidebar has no messages to display, the empty state SHALL reflect the session's current phase rather than showing a generic placeholder. This gives the user immediate feedback that the system is working to start their session.
+
+### Scenario: Pending or Creating session shows waiting spinner
+
+- GIVEN a session in Pending or Creating phase
+- AND the chat message list is empty
+- WHEN the Chat tab or chat sidebar renders
+- THEN it displays an animated spinner with the text "Runner is starting..."
+- AND the spinner is vertically centered in the message area
+
+### Scenario: Running session with no messages yet
+
+- GIVEN a session in Running phase
+- AND the chat message list is empty
+- WHEN the Chat tab or chat sidebar renders
+- THEN it displays an animated spinner with the text "Runner started. Waiting for messages..."
+- AND the spinner is vertically centered in the message area
+
+### Scenario: Terminal session with no messages
+
+- GIVEN a session in Completed, Failed, or Stopped phase
+- AND the chat message list is empty
+- WHEN the Chat tab or chat sidebar renders
+- THEN it displays: "No conversation messages were recorded."
+
+### Scenario: Spinner transitions to messages
+
+- GIVEN a session is showing a spinner ("Runner is starting..." or "Runner started. Waiting for messages...")
+- WHEN the first message arrives
+- THEN the spinner is replaced by the message content
+- AND the transition is seamless (no layout shift)
+
+## Requirement: Agent Thinking Indicator
+
+When the agent is actively processing a user message, the chat SHALL display a pulsing three-dot ellipsis below the message list to indicate the agent is working. The indicator uses the `run_started` and `run_finished` lifecycle events persisted by the runner to determine activity state.
+
+The indicator SHALL appear only when the session is in Running phase AND the most recent lifecycle event in the message stream is `run_started` (i.e., `run_finished` has not yet been received). It SHALL render as three animated dots with a staggered bounce animation, aligned with the assistant message layout (bot avatar + dots).
+
+### Scenario: Thinking indicator appears after user sends a message
+
+- GIVEN a session in Running phase
+- AND the user sends a message via the chat input
+- WHEN the runner emits a `run_started` lifecycle event
+- THEN a pulsing three-dot indicator appears below the last message
+- AND the indicator is left-aligned with assistant messages (bot icon + dots)
+
+### Scenario: Thinking indicator disappears when assistant message arrives
+
+- GIVEN the thinking indicator is displayed
+- WHEN an `assistant` message appears in the message stream
+- THEN the indicator is removed immediately
+- AND the agent's response renders in its place
+- AND the indicator does NOT briefly reappear while waiting for `run_finished`
+
+### Scenario: Thinking indicator persists through tool calls
+
+- GIVEN the thinking indicator is displayed
+- WHEN `tool_use` or `tool_result` messages appear (but no `assistant` message yet)
+- THEN the indicator remains visible
+
+### Scenario: Thinking indicator disappears on run_finished
+
+- GIVEN the thinking indicator is displayed
+- WHEN the runner emits a `run_finished` lifecycle event (even without an assistant message)
+- THEN the indicator is removed
+
+### Scenario: Thinking indicator not shown for terminal sessions
+
+- GIVEN a session in Completed, Failed, or Stopped phase
+- WHEN the chat renders
+- THEN no thinking indicator is displayed regardless of lifecycle event history
+
+### Scenario: Thinking indicator in sidebar
+
+- GIVEN the chat sidebar is open for a Running session
+- AND a run is active
+- WHEN the sidebar renders
+- THEN the same thinking indicator appears below the message list
+
+
 
 The chat input SHALL persist unsent text to `localStorage` as the user types, scoped per session ID. If the user navigates away, refreshes, or is redirected by an auth flow, the draft SHALL be restored when they return to the same session.
 


### PR DESCRIPTION
## Summary
- Add phase-aware empty states to the chat tab and sidebar — spinner for Pending/Creating/Running sessions, static message for terminal sessions
- Add a pulsing three-dot thinking indicator when the agent is actively processing, driven by `run_started`/`run_finished` lifecycle events
- Add spec coverage in `specs/ui/views.spec.md` for both features

## Test plan
- [ ] Verify spinner shows "Runner is starting..." for Pending/Creating sessions
- [ ] Verify spinner shows "Runner started. Waiting for messages..." for Running sessions with no messages
- [ ] Verify terminal sessions show "No conversation messages were recorded."
- [ ] Verify thinking dots appear after user sends a message and disappear when assistant responds
- [ ] Verify thinking indicator works in both chat tab and sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)