### PR TITLE
chore(deps): upgrade agent-sandbox controller v0.4.6 → v0.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ VERTEX_CRED ?= $(GOOGLE_APPLICATION_CREDENTIALS)
 # Override with OPENSHELL_TENANTS="ns1 ns2" to change the set of tenant namespaces.
 OPENSHELL_USE_GATEWAY ?= true
 OPENSHELL_TENANTS ?= tenant-a tenant-b vteam-product-swarm codebase-maintainers
-AGENT_SANDBOX_VERSION ?= v0.4.6
+AGENT_SANDBOX_VERSION ?= v0.5.1
 
 # Colors for output (using tput for better compatibility, with fallback to printf-compatible codes)
 # Use shell assignment to evaluate tput at runtime if available

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#local-development-setup) for full local de
 
 ### OpenShell Gateway (Kind)
 
-The control plane delegates sandbox creation to an OpenShell gateway by default. `make kind-up` automatically installs all prerequisites: the tenant namespace, and the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD (v0.4.6). ACP will automatically install configuration similar to the [OpenShell gateway Helm chart](https://github.com/NVIDIA/OpenShell/tree/main/deploy/helm/openshell) when it is configured to manage a namespace.
+The control plane delegates sandbox creation to an OpenShell gateway by default. `make kind-up` automatically installs all prerequisites: the tenant namespace, and the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) CRD (v0.5.1). ACP will automatically install configuration similar to the [OpenShell gateway Helm chart](https://github.com/NVIDIA/OpenShell/tree/main/deploy/helm/openshell) when it is configured to manage a namespace.
 
 Override defaults with:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENSHELL_TENANT_NAMESPACE` | `tenant` | Namespace for the gateway and sandboxes |
-| `AGENT_SANDBOX_VERSION` | `v0.4.6` | Agent Sandbox CRD release (must match gateway API version) |
+| `AGENT_SANDBOX_VERSION` | `v0.5.1` | Agent Sandbox CRD release (must match gateway API version) |
 
 After the sandbox reaches Ready, the control plane executes commands inside it via the `ExecSandbox` gRPC RPC — the runner starts through exec, not the container entrypoint.
 

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -463,7 +463,7 @@ func (r *SimpleKubeReconciler) injectACPInternalPolicy(ctx context.Context, name
 func (r *SimpleKubeReconciler) patchSandboxDNSConfig(ctx context.Context, namespace, sandboxName string) error {
 	sandboxGVR := schema.GroupVersionResource{
 		Group:    "agents.x-k8s.io",
-		Version:  "v1alpha1",
+		Version:  "v1beta1",
 		Resource: "sandboxes",
 	}
 

--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-ambient-code}"
-AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v0.4.6}"
+AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v0.5.1}"
 # Space-separated list of tenant namespaces to provision
 IFS=' ' read -ra TENANTS <<< "${OPENSHELL_TENANTS:-tenant-a tenant-b vteam-product-swarm codebase-maintainers}"
 

--- a/specs/platform/openshell-sandbox-provisioning.spec.md
+++ b/specs/platform/openshell-sandbox-provisioning.spec.md
@@ -39,16 +39,13 @@ The ACP control plane reads the `openshell-client-tls` Secret from the project n
 
 The [Agent Sandbox CRD](https://github.com/kubernetes-sigs/agent-sandbox) (`sandboxes.agents.x-k8s.io`) and its controller must be installed cluster-wide before deploying the gateway. The CRD version must match the API version that the OpenShell gateway expects.
 
-**Version compatibility:** The OpenShell gateway 0.0.70 uses the `agents.x-k8s.io/v1alpha1` API. The agent-sandbox project graduated its API to `v1beta1` in release v0.5.0. Installing the `latest` release (v0.5.0+) will cause sandbox-to-gateway authentication failures because the gateway's K8s ServiceAccount authenticator checks for `v1alpha1` in pod ownerReferences, but the v0.5.0 controller stamps `v1beta1`.
+**Version compatibility:** The agent-sandbox project graduated its API from `v1alpha1` to `v1beta1` in release v0.5.0. The v0.5.0+ CRD includes a conversion webhook that serves both `v1alpha1` and `v1beta1`, so existing `v1alpha1` API calls continue to work. The controller stamps `v1beta1` in ownerReferences. OpenShell gateway 0.0.74+ is compatible with `v1beta1` ownerReferences.
 
-Install the CRD at the version compatible with your gateway:
+Install the CRD:
 
 ```bash
-# For OpenShell gateway ≤ 0.0.70 — use agent-sandbox v0.4.6 (v1alpha1)
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.4.6/manifest.yaml
-
-# For OpenShell gateway with v1beta1 support (future) — use agent-sandbox v0.5.0+
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/manifest.yaml
+# Current recommended version (v1beta1 API with v1alpha1 conversion webhook)
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.1/manifest.yaml
 ```
 
 This installs the `agent-sandbox-system` namespace, the CRD, and the sandbox controller. The controller watches for Sandbox CRs and creates pods with ownerReferences — the API version in those ownerReferences must match what the gateway authenticator expects.
@@ -566,7 +563,7 @@ The control plane SHALL configure DNS resolution for sandboxes by patching the S
 
 - GIVEN a sandbox has been created via `CreateSandbox`
 - WHEN the control plane prepares the sandbox for runner execution
-- THEN it SHALL patch the `agents.x-k8s.io/v1alpha1` Sandbox CR using a Kubernetes merge-patch on `spec.podTemplate.spec.dnsConfig` with `options: [{name: ndots, value: "1"}]`
+- THEN it SHALL patch the `agents.x-k8s.io/v1beta1` Sandbox CR using a Kubernetes merge-patch on `spec.podTemplate.spec.dnsConfig` with `options: [{name: ndots, value: "1"}]`
 - AND it SHALL delete the sandbox pod to trigger recreation by the sandbox controller with the updated DNS config
 - AND if the pod deletion fails with NotFound, the error SHALL be ignored (pod may not exist yet)
 - AND DNS patching failures SHALL be logged as warnings but SHALL NOT block sandbox provisioning
@@ -847,7 +844,7 @@ The control plane SHALL expose configuration for OpenShell gateway mode alongsid
 | [kube_reconciler.go] `configureInference()` | New method — called after `ensureGatewayProviders`; sets gateway inference routing via `SetClusterInference` when an inference-capable credential is present |
 | `GatewayClient.UploadPayloads()` | New method — opens an SSH session via `CreateSshSession` / `ForwardTcp` gRPC RPCs and writes payload files into the sandbox via `mkdir -p && cat >` SSH commands. Called in the exec-after-Ready goroutine before `ExecSandbox` when the agent has inline content payloads |
 | `GatewayClient.ExecSandboxStreaming()` | New method — fire-and-forget variant of `ExecSandbox` that discards output and uses a caller-provided context, replacing the blocking `ExecSandbox` for long-running processes |
-| [kube_reconciler.go] `patchSandboxDNSConfig()` | New method — patches `agents.x-k8s.io/v1alpha1` Sandbox CR's `podTemplate.spec.dnsConfig` with `ndots:1` and deletes the sandbox pod to force recreation. Workaround for [OpenShell#2053](https://github.com/NVIDIA/OpenShell/issues/2053) |
+| [kube_reconciler.go] `patchSandboxDNSConfig()` | New method — patches `agents.x-k8s.io/v1beta1` Sandbox CR's `podTemplate.spec.dnsConfig` with `ndots:1` and deletes the sandbox pod to force recreation. Workaround for [OpenShell#2053](https://github.com/NVIDIA/OpenShell/issues/2053) |
 | [kube_reconciler.go] `resolveEntrypoint()` | Default entrypoint changed from `/sandbox/runner/entrypoint.sh` to `/runner/entrypoint.sh` to match the gateway runner image's directory layout |
 | `provider_mapping.go` | Updated `vertex` mapping from `vertex-prod` to `google-vertex-ai` to match the OpenShell CLI's provider type |
 | Vendored proto (`openshell.proto`, `sandbox.proto`) | Extended with `UpdateConfig` RPC, `UpdateConfigRequest`/`UpdateConfigResponse` messages, `SettingValue` message, `CreateSshSession` RPC, `ForwardTcp` RPC (bidirectional streaming), `TcpForwardFrame`, `TcpForwardInit`, `SshRelayTarget`, `CreateSshSessionRequest`, and `CreateSshSessionResponse` messages |


### PR DESCRIPTION
## Summary

- Upgrade agent-sandbox controller from v0.4.6 to v0.5.1 (latest release, 2026-07-09)
- Update Sandbox GVR from `v1alpha1` to `v1beta1` to match the new storage version
- Update version compatibility docs in the provisioning spec

## What changed

| File | Change |
|------|--------|
| `scripts/setup-kind-openshell.sh` | Default `AGENT_SANDBOX_VERSION` bumped to `v0.5.1` |
| `README.md` | Version references updated |
| `kube_reconciler.go` | Sandbox GVR updated from `v1alpha1` to `v1beta1` |
| `openshell-sandbox-provisioning.spec.md` | Version compat docs and API version refs updated |

## Why v0.5.1

Key improvements over v0.4.6:
- **API graduation**: `v1alpha1` → `v1beta1` (conversion webhook preserves backward compat)
- **Performance**: pod cache label indexing, namespace queue partitioning for multi-tenant scale
- **K8s 1.36 support**: controller-runtime v0.24.0
- **Security**: SSRF protections, ReDoS fix, warm pool poisoning prevention

[Full release notes](https://github.com/kubernetes-sigs/agent-sandbox/releases/tag/v0.5.1)

## Test plan

- [ ] `make kind-up OPENSHELL_USE_GATEWAY=true` installs v0.5.1 CRD and controller starts
- [ ] `kubectl get crd sandboxes.agents.x-k8s.io` shows the CRD with v1beta1 served
- [ ] Sandbox DNS config patch (`patchSandboxDNSConfig`) works with v1beta1 GVR
- [ ] Gateway-mode session provisioning creates and reaches sandbox Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)