### PR TITLE
chore(gitignore): ignore local Codex state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ ehthumbs.db
 Thumbs.db
 
 # IDE / AI assistant configuration
+.codex/
 .cursor/
 .tessl/
 


### PR DESCRIPTION
## Summary
- Ignore local `.codex/` assistant state and plan artifacts.

## Verification
- `git diff --check upstream/main...HEAD`
- `git check-ignore -v .codex/plans/deploy-acp-jeder-dev-35.md .codex/config.toml`
- `coderabbit review --agent --base upstream/main` (findings: 0)

## Self-review
- Diff is limited to `.gitignore`.
- No product code, API surface, frontend TypeScript, production Go, or Kubernetes child resources changed.