### PR TITLE
fix(runner): add DNS pre-check to prevent MLflow blocking startup on unresolvable hosts

### DIFF
--- a/components/runners/ambient-runner/ambient_runner/mlflow_autolog.py
+++ b/components/runners/ambient-runner/ambient_runner/mlflow_autolog.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 _DEFAULT_EXPERIMENT_NAME = "ambient-code-sessions"
 _DEFAULT_GENAI_INTEGRATIONS = ("anthropic", "openai")
 _EXPLICIT_FALSE_VALUES = ("0", "false", "no", "off")
-_OPENSHELL_RESOLVE_PREFIX = "openshell:resolve:env:"
 _BASE_AUTOLOG_TAGS = {
     "acp.runner": "ambient-runner",
 }
@@ -85,18 +84,7 @@ def _autolog_tags(extra_tags: Mapping[str, str] | None) -> dict[str, str]:
     return tags
 
 
-def _is_openshell_token(value: str) -> bool:
-    return value.startswith(_OPENSHELL_RESOLVE_PREFIX)
-
-
 def _configure_tracking(mlflow_module: MLflowModule, tracking_uri: str) -> bool:
-    if _is_openshell_token(tracking_uri):
-        logger.info(
-            "MLflow autologging: openshell resolve tokens detected; "
-            "deferring tracking config to runtime env resolution"
-        )
-        return True
-
     from ambient_runner.observability_config import check_mlflow_tracking_reachable
 
     if not check_mlflow_tracking_reachable(tracking_uri):

--- a/components/runners/ambient-runner/ambient_runner/mlflow_autolog.py
+++ b/components/runners/ambient-runner/ambient_runner/mlflow_autolog.py
@@ -89,13 +89,18 @@ def _is_openshell_token(value: str) -> bool:
     return value.startswith(_OPENSHELL_RESOLVE_PREFIX)
 
 
-def _configure_tracking(mlflow_module: MLflowModule, tracking_uri: str) -> None:
+def _configure_tracking(mlflow_module: MLflowModule, tracking_uri: str) -> bool:
     if _is_openshell_token(tracking_uri):
         logger.info(
             "MLflow autologging: openshell resolve tokens detected; "
             "deferring tracking config to runtime env resolution"
         )
-        return
+        return True
+
+    from ambient_runner.observability_config import check_mlflow_tracking_reachable
+
+    if not check_mlflow_tracking_reachable(tracking_uri):
+        return False
 
     experiment_name = (
         os.getenv("MLFLOW_EXPERIMENT_NAME", _DEFAULT_EXPERIMENT_NAME).strip()
@@ -104,11 +109,13 @@ def _configure_tracking(mlflow_module: MLflowModule, tracking_uri: str) -> None:
     try:
         mlflow_module.set_tracking_uri(tracking_uri)
         mlflow_module.set_experiment(experiment_name)
+        return True
     except Exception:
         logger.warning(
             "MLflow autologging: tracking URI or experiment setup failed; "
             "continuing with autologging enabled"
         )
+        return True
 
 
 def _configure_async_logging(mlflow_module: MLflowModule) -> None:
@@ -214,7 +221,8 @@ def activate_mlflow_autologging(extra_tags: Mapping[str, str] | None = None) -> 
         logger.warning("MLflow autologging requested but mlflow is not installed")
         return False
 
-    _configure_tracking(mlflow, tracking_uri)
+    if not _configure_tracking(mlflow, tracking_uri):
+        return False
     _configure_async_logging(mlflow)
     if not _configure_trace_masking(mlflow):
         return False

--- a/components/runners/ambient-runner/ambient_runner/mlflow_observability.py
+++ b/components/runners/ambient-runner/ambient_runner/mlflow_observability.py
@@ -88,6 +88,13 @@ class MLflowSessionTracer:
                 "tracking URI and experiment config to runtime env resolution"
             )
         else:
+            from ambient_runner.observability_config import (
+                check_mlflow_tracking_reachable,
+            )
+
+            if not check_mlflow_tracking_reachable(tracking_uri):
+                return False
+
             try:
                 mlflow.set_tracking_uri(tracking_uri)
                 mlflow.set_experiment(exp_name)

--- a/components/runners/ambient-runner/ambient_runner/mlflow_observability.py
+++ b/components/runners/ambient-runner/ambient_runner/mlflow_observability.py
@@ -71,38 +71,26 @@ class MLflowSessionTracer:
             )
             return False
 
-        # openshell sandbox env vars use lazy-resolve tokens that the
-        # supervisor resolves at the C library level. Skip explicit
-        # mlflow.set_tracking_uri / set_experiment so MLflow reads from
-        # the environment through its own native (Rust/C) bindings where
-        # the supervisor intercepts getenv() and returns real values.
-        openshell_env = self._is_openshell_token(tracking_uri)
         exp_name = (
             os.getenv("MLFLOW_EXPERIMENT_NAME", "ambient-code-sessions").strip()
             or "ambient-code-sessions"
         )
 
-        if openshell_env:
-            logger.info(
-                "MLflow: openshell resolve tokens detected — deferring "
-                "tracking URI and experiment config to runtime env resolution"
-            )
-        else:
-            from ambient_runner.observability_config import (
-                check_mlflow_tracking_reachable,
-            )
+        from ambient_runner.observability_config import (
+            check_mlflow_tracking_reachable,
+        )
 
-            if not check_mlflow_tracking_reachable(tracking_uri):
-                return False
+        if not check_mlflow_tracking_reachable(tracking_uri):
+            return False
 
-            try:
-                mlflow.set_tracking_uri(tracking_uri)
-                mlflow.set_experiment(exp_name)
-            except Exception as e:
-                logger.warning(
-                    "MLflow: failed to set tracking URI or experiment: %s", e
-                )
-                return False
+        try:
+            mlflow.set_tracking_uri(tracking_uri)
+            mlflow.set_experiment(exp_name)
+        except Exception as e:
+            logger.warning(
+                "MLflow: failed to set tracking URI or experiment: %s", e
+            )
+            return False
 
         auth_mode = os.getenv("MLFLOW_TRACKING_AUTH", "").strip()
         if auth_mode and not self._is_openshell_token(auth_mode):

--- a/components/runners/ambient-runner/ambient_runner/observability_config.py
+++ b/components/runners/ambient-runner/ambient_runner/observability_config.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 logger = logging.getLogger(__name__)
 
 _DNS_CHECK_TIMEOUT = 5.0
-_OPENSHELL_RESOLVE_PREFIX = "openshell:resolve:env:"
 _NON_NETWORK_SCHEMES = frozenset({"file", "sqlite"})
 
 _mlflow_dns_cache: dict[str, bool] = {}
@@ -31,13 +30,10 @@ def check_mlflow_tracking_reachable(
 ) -> bool:
     """Fast DNS pre-check for the MLflow tracking URI hostname.
 
-    Returns True if the hostname resolves or if the URI is not subject to
-    DNS checks (openshell resolve tokens, non-network schemes like file://).
-    Returns cached result on subsequent calls for the same URI.
+    Returns True if the hostname resolves or if the URI uses a non-network
+    scheme (file://, sqlite://). Returns cached result on subsequent calls
+    for the same URI.
     """
-    if tracking_uri.startswith(_OPENSHELL_RESOLVE_PREFIX):
-        return True
-
     parsed = urlparse(tracking_uri)
 
     if parsed.scheme in _NON_NETWORK_SCHEMES or not parsed.hostname:

--- a/components/runners/ambient-runner/ambient_runner/observability_config.py
+++ b/components/runners/ambient-runner/ambient_runner/observability_config.py
@@ -2,7 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import socket
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_DNS_CHECK_TIMEOUT = 5.0
+_OPENSHELL_RESOLVE_PREFIX = "openshell:resolve:env:"
+_NON_NETWORK_SCHEMES = frozenset({"file", "sqlite"})
+
+_mlflow_dns_cache: dict[str, bool] = {}
 
 
 def _truthy_env(name: str) -> bool:
@@ -12,6 +24,58 @@ def _truthy_env(name: str) -> bool:
 
 def _explicitly_false_env(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in ("0", "false", "no", "off")
+
+
+def check_mlflow_tracking_reachable(
+    tracking_uri: str, timeout: float = _DNS_CHECK_TIMEOUT
+) -> bool:
+    """Fast DNS pre-check for the MLflow tracking URI hostname.
+
+    Returns True if the hostname resolves or if the URI is not subject to
+    DNS checks (openshell resolve tokens, non-network schemes like file://).
+    Returns cached result on subsequent calls for the same URI.
+    """
+    if tracking_uri.startswith(_OPENSHELL_RESOLVE_PREFIX):
+        return True
+
+    parsed = urlparse(tracking_uri)
+
+    if parsed.scheme in _NON_NETWORK_SCHEMES or not parsed.hostname:
+        return True
+
+    if tracking_uri in _mlflow_dns_cache:
+        return _mlflow_dns_cache[tracking_uri]
+
+    host = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(socket.getaddrinfo, host, port)
+            future.result(timeout=timeout)
+        _mlflow_dns_cache[tracking_uri] = True
+        return True
+    except FuturesTimeoutError:
+        logger.warning(
+            "MLflow: DNS resolution for %s timed out after %.0fs — skipping MLflow initialization",
+            host,
+            timeout,
+        )
+    except socket.gaierror as e:
+        logger.warning(
+            "MLflow: DNS resolution failed for %s (%s) — skipping MLflow initialization",
+            host,
+            e,
+        )
+    except Exception as e:
+        logger.warning(
+            "MLflow: DNS pre-check failed for %s (%s) — skipping MLflow initialization",
+            host,
+            e,
+        )
+
+    _mlflow_dns_cache[tracking_uri] = False
+    return False
 
 
 def observability_backend_names() -> frozenset[str]:

--- a/components/runners/ambient-runner/ambient_runner/observability_config.py
+++ b/components/runners/ambient-runner/ambient_runner/observability_config.py
@@ -45,10 +45,10 @@ def check_mlflow_tracking_reachable(
     host = parsed.hostname
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
 
+    executor = ThreadPoolExecutor(max_workers=1)
     try:
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(socket.getaddrinfo, host, port)
-            future.result(timeout=timeout)
+        future = executor.submit(socket.getaddrinfo, host, port)
+        future.result(timeout=timeout)
         _mlflow_dns_cache[tracking_uri] = True
         return True
     except FuturesTimeoutError:
@@ -69,6 +69,8 @@ def check_mlflow_tracking_reachable(
             host,
             e,
         )
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
 
     _mlflow_dns_cache[tracking_uri] = False
     return False

--- a/components/runners/ambient-runner/tests/test_mlflow_autolog.py
+++ b/components/runners/ambient-runner/tests/test_mlflow_autolog.py
@@ -261,21 +261,6 @@ def test_genai_integration_is_imported_before_autologging():
     imported_anthropic.autolog.assert_called_once()
 
 
-def test_openshell_resolve_token_skips_explicit_tracking_setup():
-    mock_mlflow = MagicMock()
-    env = {"MLFLOW_TRACKING_URI": "openshell:resolve:env:MLFLOW_TRACKING_URI"}
-
-    with (
-        patch.dict(os.environ, env, clear=True),
-        patch.dict("sys.modules", {"mlflow": mock_mlflow}),
-    ):
-        assert activate_mlflow_autologging() is True
-
-    mock_mlflow.set_tracking_uri.assert_not_called()
-    mock_mlflow.set_experiment.assert_not_called()
-    mock_mlflow.autolog.assert_called_once()
-
-
 def test_idempotent_second_call_does_not_repatch():
     mock_mlflow = MagicMock()
     env = {"MLFLOW_TRACKING_URI": "https://mlflow.example.com"}

--- a/components/runners/ambient-runner/tests/test_mlflow_autolog.py
+++ b/components/runners/ambient-runner/tests/test_mlflow_autolog.py
@@ -14,6 +14,15 @@ def _reset_activated():
     autolog_mod._activated = False
 
 
+@pytest.fixture(autouse=True)
+def _bypass_dns_check():
+    with patch(
+        "ambient_runner.observability_config.check_mlflow_tracking_reachable",
+        return_value=True,
+    ):
+        yield
+
+
 def test_tracking_uri_default_activates_generic_and_genai_autologging():
     mock_mlflow = MagicMock()
     mock_mlflow.anthropic = MagicMock()

--- a/components/runners/ambient-runner/tests/test_mlflow_dns_precheck.py
+++ b/components/runners/ambient-runner/tests/test_mlflow_dns_precheck.py
@@ -1,7 +1,7 @@
 """Tests for MLflow tracking URI DNS pre-check."""
 
 import socket
-from concurrent.futures import TimeoutError as FuturesTimeoutError
+import time
 from unittest.mock import patch
 
 import pytest
@@ -33,14 +33,11 @@ class TestDnsPrecheck:
             assert check_mlflow_tracking_reachable("https://mlflow.example.com") is True
 
     def test_timeout_returns_false(self):
-        def slow_resolve(*args, **kwargs):
-            raise FuturesTimeoutError()
-
         with patch(
             "ambient_runner.observability_config.socket.getaddrinfo",
-            side_effect=slow_resolve,
+            side_effect=lambda *a, **kw: time.sleep(10),
         ):
-            assert check_mlflow_tracking_reachable("https://slow.example.com", timeout=0.1) is False
+            assert check_mlflow_tracking_reachable("https://slow.example.com", timeout=0.01) is False
 
     def test_cached_result_returned_without_repeat_lookup(self):
         with patch(

--- a/components/runners/ambient-runner/tests/test_mlflow_dns_precheck.py
+++ b/components/runners/ambient-runner/tests/test_mlflow_dns_precheck.py
@@ -1,0 +1,132 @@
+"""Tests for MLflow tracking URI DNS pre-check."""
+
+import socket
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from unittest.mock import patch
+
+import pytest
+
+import ambient_runner.observability_config as config_mod
+from ambient_runner.observability_config import check_mlflow_tracking_reachable
+
+
+@pytest.fixture(autouse=True)
+def _clear_dns_cache():
+    config_mod._mlflow_dns_cache.clear()
+    yield
+    config_mod._mlflow_dns_cache.clear()
+
+
+class TestDnsPrecheck:
+    def test_unresolvable_hostname_returns_false(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ):
+            assert check_mlflow_tracking_reachable("https://nonexistent.example.invalid:443") is False
+
+    def test_resolvable_hostname_returns_true(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443))],
+        ):
+            assert check_mlflow_tracking_reachable("https://mlflow.example.com") is True
+
+    def test_timeout_returns_false(self):
+        def slow_resolve(*args, **kwargs):
+            raise FuturesTimeoutError()
+
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            side_effect=slow_resolve,
+        ):
+            assert check_mlflow_tracking_reachable("https://slow.example.com", timeout=0.1) is False
+
+    def test_cached_result_returned_without_repeat_lookup(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443))],
+        ) as mock_resolve:
+            uri = "https://mlflow.example.com"
+            assert check_mlflow_tracking_reachable(uri) is True
+            assert check_mlflow_tracking_reachable(uri) is True
+            mock_resolve.assert_called_once()
+
+    def test_cached_failure_returned_without_repeat_lookup(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ) as mock_resolve:
+            uri = "https://bad.example.invalid"
+            assert check_mlflow_tracking_reachable(uri) is False
+            assert check_mlflow_tracking_reachable(uri) is False
+            mock_resolve.assert_called_once()
+
+    def test_openshell_resolve_token_bypasses_check(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+        ) as mock_resolve:
+            assert check_mlflow_tracking_reachable("openshell:resolve:env:MLFLOW_TRACKING_URI") is True
+            mock_resolve.assert_not_called()
+
+    def test_file_uri_bypasses_check(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+        ) as mock_resolve:
+            assert check_mlflow_tracking_reachable("file:///tmp/mlruns") is True
+            mock_resolve.assert_not_called()
+
+    def test_sqlite_uri_bypasses_check(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+        ) as mock_resolve:
+            assert check_mlflow_tracking_reachable("sqlite:///mlflow.db") is True
+            mock_resolve.assert_not_called()
+
+    def test_default_https_port_used_when_not_specified(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443))],
+        ) as mock_resolve:
+            check_mlflow_tracking_reachable("https://mlflow.example.com")
+            mock_resolve.assert_called_once_with("mlflow.example.com", 443)
+
+    def test_explicit_port_used(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 5000))],
+        ) as mock_resolve:
+            check_mlflow_tracking_reachable("http://mlflow.local:5000")
+            mock_resolve.assert_called_once_with("mlflow.local", 5000)
+
+    def test_http_default_port_80(self):
+        with patch(
+            "ambient_runner.observability_config.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 80))],
+        ) as mock_resolve:
+            check_mlflow_tracking_reachable("http://mlflow.local")
+            mock_resolve.assert_called_once_with("mlflow.local", 80)
+
+
+class TestDnsCheckIntegrationWithAutolog:
+    def test_unreachable_host_prevents_autolog_activation(self):
+        import ambient_runner.mlflow_autolog as autolog_mod
+
+        autolog_mod._activated = False
+        try:
+            with patch(
+                "ambient_runner.observability_config.socket.getaddrinfo",
+                side_effect=socket.gaierror("Name or service not known"),
+            ):
+                import os
+
+                with patch.dict(
+                    os.environ,
+                    {"MLFLOW_TRACKING_URI": "https://unreachable.example.invalid"},
+                    clear=True,
+                ):
+                    result = autolog_mod.activate_mlflow_autologging()
+
+            assert result is False
+        finally:
+            autolog_mod._activated = False

--- a/components/runners/ambient-runner/tests/test_mlflow_dns_precheck.py
+++ b/components/runners/ambient-runner/tests/test_mlflow_dns_precheck.py
@@ -62,13 +62,6 @@ class TestDnsPrecheck:
             assert check_mlflow_tracking_reachable(uri) is False
             mock_resolve.assert_called_once()
 
-    def test_openshell_resolve_token_bypasses_check(self):
-        with patch(
-            "ambient_runner.observability_config.socket.getaddrinfo",
-        ) as mock_resolve:
-            assert check_mlflow_tracking_reachable("openshell:resolve:env:MLFLOW_TRACKING_URI") is True
-            mock_resolve.assert_not_called()
-
     def test_file_uri_bypasses_check(self):
         with patch(
             "ambient_runner.observability_config.socket.getaddrinfo",

--- a/components/runners/ambient-runner/tests/test_mlflow_observability.py
+++ b/components/runners/ambient-runner/tests/test_mlflow_observability.py
@@ -36,12 +36,18 @@ def _mock_mlflow_modules():
     _mock_mlflow.set_experiment.reset_mock()
     _mock_mlflow.set_tracking_uri.side_effect = None
     _mock_mlflow.set_experiment.side_effect = None
-    with patch.dict(
-        sys.modules,
-        {
-            "mlflow": _mock_mlflow,
-            "mlflow.entities": _mock_entities,
-        },
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "mlflow": _mock_mlflow,
+                "mlflow.entities": _mock_entities,
+            },
+        ),
+        patch(
+            "ambient_runner.observability_config.check_mlflow_tracking_reachable",
+            return_value=True,
+        ),
     ):
         yield
 

--- a/components/runners/ambient-runner/tests/test_mlflow_observability.py
+++ b/components/runners/ambient-runner/tests/test_mlflow_observability.py
@@ -74,21 +74,7 @@ class TestIsOpenshellToken:
         assert MLflowSessionTracer._is_openshell_token("openshell:resolve:") is False
 
 
-class TestInitializeOpenshellTokens:
-    def test_openshell_token_skips_set_tracking_uri_and_set_experiment(self):
-        env = {
-            "MLFLOW_TRACKING_URI": "openshell:resolve:env:MLFLOW_TRACKING_URI",
-            "MLFLOW_EXPERIMENT_NAME": "openshell:resolve:env:MLFLOW_EXPERIMENT_NAME",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            tracer = MLflowSessionTracer("s1", "u1", "user1")
-            result = tracer.initialize(**INIT_KWARGS)
-
-        assert result is True
-        assert tracer.enabled is True
-        _mock_mlflow.set_tracking_uri.assert_not_called()
-        _mock_mlflow.set_experiment.assert_not_called()
-
+class TestInitializeTracking:
     def test_standard_uri_calls_set_tracking_uri_and_set_experiment(self):
         env = {
             "MLFLOW_TRACKING_URI": "https://mlflow.example.com",

--- a/specs/platform/mlflow-tracing.spec.md
+++ b/specs/platform/mlflow-tracing.spec.md
@@ -1,7 +1,7 @@
 # MLflow Tracing
 
 **Date:** 2026-07-01
-**Last Updated:** 2026-07-08
+**Last Updated:** 2026-07-10
 **Status:** Implemented
 **Related:** `runner.spec.md` — runner lifecycle and observability; `credential-binding.spec.md` — credential resolution hierarchy; `openshell-sandbox-provisioning.spec.md` — gateway credential providers and provider type mapping; `agent-sandbox-config.spec.md` — agent sandbox provider declarations
 
@@ -184,6 +184,52 @@ The runner MUST attempt provider-native GenAI autologging for `MLFLOW_GENAI_AUTO
 - THEN the runner MUST log a warning
 - AND the session MUST NOT fail due to a tracing initialization error
 - AND no MLflow liveness probe or server health check may block pod or session startup
+
+### Requirement: Fast-Fail DNS Pre-Check for Tracking Server
+
+Before calling any MLflow SDK initialization function (`set_tracking_uri`, `set_experiment`), the runner MUST perform a DNS resolution pre-check on the hostname extracted from `MLFLOW_TRACKING_URI`. The pre-check MUST complete within 5 seconds. If DNS resolution fails or times out, the runner MUST skip all MLflow initialization immediately rather than waiting for MLflow's internal HTTP timeout (default: 120 seconds with 7 retries and exponential backoff).
+
+The pre-check result MUST be cached for the lifetime of the process so that subsequent initialization paths (e.g., `MLflowSessionTracer.initialize` after `activate_mlflow_autologging`) return instantly without repeating the DNS lookup.
+
+This requirement does not apply to `openshell:resolve:env:` prefixed URIs, which defer hostname resolution to the OpenShell supervisor, nor to non-network URIs (file paths, SQLite).
+
+#### Scenario: Unresolvable hostname — fast skip
+
+- GIVEN `MLFLOW_TRACKING_URI` is set to `https://nonexistent.example.invalid:443`
+- AND the hostname does not resolve in DNS
+- WHEN the runner initializes the Claude SDK bridge
+- THEN the DNS pre-check MUST fail within 5 seconds
+- AND the runner MUST log a warning indicating DNS resolution failed for the tracking URI hostname
+- AND the runner MUST NOT call `mlflow.set_tracking_uri()` or `mlflow.set_experiment()`
+- AND the session MUST proceed without MLflow tracing
+
+#### Scenario: Resolvable hostname — normal initialization
+
+- GIVEN `MLFLOW_TRACKING_URI` is set to a valid tracking server URL
+- AND the hostname resolves in DNS
+- WHEN the runner initializes the Claude SDK bridge
+- THEN the DNS pre-check MUST succeed
+- AND normal MLflow initialization MUST proceed
+
+#### Scenario: Cached pre-check result
+
+- GIVEN the DNS pre-check has already been performed for a given tracking URI
+- WHEN a second initialization path invokes the pre-check for the same URI
+- THEN the cached result MUST be returned immediately without repeating the DNS lookup
+
+#### Scenario: OpenShell resolve tokens bypass pre-check
+
+- GIVEN `MLFLOW_TRACKING_URI` is set to a value prefixed with `openshell:resolve:env:`
+- WHEN the runner initializes
+- THEN the DNS pre-check MUST NOT be performed
+- AND initialization MUST defer to the supervisor's runtime env resolution
+
+#### Scenario: Non-network URIs bypass pre-check
+
+- GIVEN `MLFLOW_TRACKING_URI` is set to a local path (e.g., `file:///tmp/mlruns` or `sqlite:///mlflow.db`)
+- WHEN the runner initializes
+- THEN the DNS pre-check MUST NOT be performed
+- AND normal MLflow initialization MUST proceed
 
 #### Scenario: Autolog called before agent client creation
 

--- a/specs/platform/mlflow-tracing.spec.md
+++ b/specs/platform/mlflow-tracing.spec.md
@@ -170,7 +170,7 @@ The runner MUST attempt provider-native GenAI autologging for `MLFLOW_GENAI_AUTO
 
 #### Scenario: Tracing activation is best-effort (standard env)
 
-- GIVEN `MLFLOW_TRACKING_URI` is set to a valid tracking server URL
+- GIVEN `MLFLOW_TRACKING_URI` is set
 - WHEN `mlflow.set_tracking_uri()`, `mlflow.set_experiment()`, generic `mlflow.autolog()`, or provider-specific autologging raises an exception
 - THEN the runner MUST log a warning
 - AND the session MUST NOT fail due to a tracing initialization error
@@ -196,7 +196,7 @@ The pre-check result MUST be cached for the lifetime of the process so that subs
 
 #### Scenario: Resolvable hostname — normal initialization
 
-- GIVEN `MLFLOW_TRACKING_URI` is set to a valid tracking server URL
+- GIVEN `MLFLOW_TRACKING_URI` is set
 - AND the hostname resolves in DNS
 - WHEN the runner initializes the Claude SDK bridge
 - THEN the DNS pre-check MUST succeed

--- a/specs/platform/mlflow-tracing.spec.md
+++ b/specs/platform/mlflow-tracing.spec.md
@@ -75,7 +75,7 @@ The platform SHALL support an `mlflow` credential provider. The credential secre
 
 The credential provider follows the existing credential binding hierarchy defined in `credential-binding.spec.md` — it can be bound at agent or project scope. The MLflow bearer token source may be materialized by Vault into the ACP deployment namespace, but it MUST NOT be injected into tenant sandboxes unless an `mlflow` credential binding authorizes that project or agent to use it.
 
-The control-plane reads MLflow runtime env from its own process environment (set on the deployment). When `MLFLOW_TRACKING_URI` is set, the control-plane injects the MLflow runtime env into every standard runner pod and OpenShell sandbox. Agent-level environment configuration (`agent.environment`) MAY override non-platform MLflow defaults such as `MLFLOW_EXPERIMENT_NAME`, `MLFLOW_TRACING_ENABLED`, `MLFLOW_AUTOLOG_EXCLUDE_FLAVORS`, and `MLFLOW_GENAI_AUTOLOG_INTEGRATIONS`. Agent configuration MUST NOT override platform MLflow routing or authentication keys: `MLFLOW_TRACKING_URI`, `MLFLOW_TRACKING_AUTH`, `MLFLOW_WORKSPACE`, or `MLFLOW_TRACKING_TOKEN`.
+The control-plane reads MLflow runtime env from its own process environment (set on the deployment). When `MLFLOW_TRACKING_URI` is set, the control-plane injects the MLflow runtime env into every standard runner pod and OpenShell sandbox. `MLFLOW_TRACKING_URI` MUST NOT be injected as a provider credential (i.e., it MUST NOT arrive in the sandbox as an `openshell:resolve:env:` token); it is a platform environment variable resolved at deployment time, not a lazy-resolve credential. Agent-level environment configuration (`agent.environment`) MAY override non-platform MLflow defaults such as `MLFLOW_EXPERIMENT_NAME`, `MLFLOW_TRACING_ENABLED`, `MLFLOW_AUTOLOG_EXCLUDE_FLAVORS`, and `MLFLOW_GENAI_AUTOLOG_INTEGRATIONS`. Agent configuration MUST NOT override platform MLflow routing or authentication keys: `MLFLOW_TRACKING_URI`, `MLFLOW_TRACKING_AUTH`, `MLFLOW_WORKSPACE`, or `MLFLOW_TRACKING_TOKEN`.
 
 #### Scenario: MLflow credential bound to project
 
@@ -145,22 +145,13 @@ The runner MUST attempt provider-native GenAI autologging for `MLFLOW_GENAI_AUTO
 
 #### Scenario: Tracking URI present — tracing enabled
 
-- GIVEN `MLFLOW_TRACKING_URI` is set to `https://mlflow.example.com` (a real URL, not an openshell resolve token)
+- GIVEN `MLFLOW_TRACKING_URI` is set to `https://mlflow.example.com`
 - WHEN the runner initializes the Claude SDK bridge
 - THEN the runner MUST call `mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)`
 - AND it MUST call `mlflow.set_experiment(MLFLOW_EXPERIMENT_NAME or "ambient-code-sessions")`
 - AND it MUST call generic `mlflow.autolog(log_models=False, log_datasets=True, log_traces=True, silent=False, ...)`
 - AND it MUST attempt `mlflow.anthropic.autolog()` and `mlflow.openai.autolog()` before creating the `ClaudeSDKClient`
 - AND ACP session, turn, and tool spans MUST remain the universal trace envelope for Claude, Codex, OpenCode, and CLI-based agents
-
-#### Scenario: OpenShell resolve tokens — deferred configuration
-
-- GIVEN `MLFLOW_TRACKING_URI` is set to a value prefixed with `openshell:resolve:env:` (an openshell lazy-resolve token)
-- WHEN the runner initializes the Claude SDK bridge
-- THEN the runner MUST NOT call `mlflow.set_tracking_uri()` or `mlflow.set_experiment()` explicitly
-- AND the runner MUST defer tracking URI and experiment configuration to runtime environment resolution by the openshell supervisor (which intercepts `getenv()` at the C library level and returns real values)
-- AND the runner MUST still call generic and configured provider autologging before creating the `ClaudeSDKClient`
-- AND tracing MUST be enabled, relying on MLflow's native environment variable reading through supervisor-intercepted `getenv()`
 
 #### Scenario: Missing MLFLOW_TRACKING_URI — tracing disabled
 
@@ -179,7 +170,7 @@ The runner MUST attempt provider-native GenAI autologging for `MLFLOW_GENAI_AUTO
 
 #### Scenario: Tracing activation is best-effort (standard env)
 
-- GIVEN `MLFLOW_TRACKING_URI` is set to a real value (not an openshell resolve token)
+- GIVEN `MLFLOW_TRACKING_URI` is set to a valid tracking server URL
 - WHEN `mlflow.set_tracking_uri()`, `mlflow.set_experiment()`, generic `mlflow.autolog()`, or provider-specific autologging raises an exception
 - THEN the runner MUST log a warning
 - AND the session MUST NOT fail due to a tracing initialization error
@@ -191,7 +182,7 @@ Before calling any MLflow SDK initialization function (`set_tracking_uri`, `set_
 
 The pre-check result MUST be cached for the lifetime of the process so that subsequent initialization paths (e.g., `MLflowSessionTracer.initialize` after `activate_mlflow_autologging`) return instantly without repeating the DNS lookup.
 
-This requirement does not apply to `openshell:resolve:env:` prefixed URIs, which defer hostname resolution to the OpenShell supervisor, nor to non-network URIs (file paths, SQLite).
+`MLFLOW_TRACKING_URI` SHALL always contain a valid URI; the runner MUST NOT inspect or handle `openshell:resolve:env:` prefixed values for this variable. This requirement does not apply to non-network URIs (file paths, SQLite).
 
 #### Scenario: Unresolvable hostname — fast skip
 
@@ -216,13 +207,6 @@ This requirement does not apply to `openshell:resolve:env:` prefixed URIs, which
 - GIVEN the DNS pre-check has already been performed for a given tracking URI
 - WHEN a second initialization path invokes the pre-check for the same URI
 - THEN the cached result MUST be returned immediately without repeating the DNS lookup
-
-#### Scenario: OpenShell resolve tokens bypass pre-check
-
-- GIVEN `MLFLOW_TRACKING_URI` is set to a value prefixed with `openshell:resolve:env:`
-- WHEN the runner initializes
-- THEN the DNS pre-check MUST NOT be performed
-- AND initialization MUST defer to the supervisor's runtime env resolution
 
 #### Scenario: Non-network URIs bypass pre-check
 

--- a/specs/platform/mlflow-tracing.spec.md
+++ b/specs/platform/mlflow-tracing.spec.md
@@ -75,7 +75,7 @@ The platform SHALL support an `mlflow` credential provider. The credential secre
 
 The credential provider follows the existing credential binding hierarchy defined in `credential-binding.spec.md` — it can be bound at agent or project scope. The MLflow bearer token source may be materialized by Vault into the ACP deployment namespace, but it MUST NOT be injected into tenant sandboxes unless an `mlflow` credential binding authorizes that project or agent to use it.
 
-The control-plane reads MLflow runtime env from its own process environment (set on the deployment). When `MLFLOW_TRACKING_URI` is set, the control-plane injects the MLflow runtime env into every standard runner pod and OpenShell sandbox. `MLFLOW_TRACKING_URI` MUST NOT be injected as a provider credential (i.e., it MUST NOT arrive in the sandbox as an `openshell:resolve:env:` token); it is a platform environment variable resolved at deployment time, not a lazy-resolve credential. Agent-level environment configuration (`agent.environment`) MAY override non-platform MLflow defaults such as `MLFLOW_EXPERIMENT_NAME`, `MLFLOW_TRACING_ENABLED`, `MLFLOW_AUTOLOG_EXCLUDE_FLAVORS`, and `MLFLOW_GENAI_AUTOLOG_INTEGRATIONS`. Agent configuration MUST NOT override platform MLflow routing or authentication keys: `MLFLOW_TRACKING_URI`, `MLFLOW_TRACKING_AUTH`, `MLFLOW_WORKSPACE`, or `MLFLOW_TRACKING_TOKEN`.
+The control-plane reads MLflow runtime env from its own process environment (set on the deployment). When `MLFLOW_TRACKING_URI` is set, the control-plane injects the MLflow runtime env into every standard runner pod and OpenShell sandbox. `MLFLOW_TRACKING_URI` is a platform environment variable set at deployment time. Agent-level environment configuration (`agent.environment`) MAY override non-platform MLflow defaults such as `MLFLOW_EXPERIMENT_NAME`, `MLFLOW_TRACING_ENABLED`, `MLFLOW_AUTOLOG_EXCLUDE_FLAVORS`, and `MLFLOW_GENAI_AUTOLOG_INTEGRATIONS`. Agent configuration MUST NOT override platform MLflow routing or authentication keys: `MLFLOW_TRACKING_URI`, `MLFLOW_TRACKING_AUTH`, `MLFLOW_WORKSPACE`, or `MLFLOW_TRACKING_TOKEN`.
 
 #### Scenario: MLflow credential bound to project
 
@@ -182,7 +182,7 @@ Before calling any MLflow SDK initialization function (`set_tracking_uri`, `set_
 
 The pre-check result MUST be cached for the lifetime of the process so that subsequent initialization paths (e.g., `MLflowSessionTracer.initialize` after `activate_mlflow_autologging`) return instantly without repeating the DNS lookup.
 
-`MLFLOW_TRACKING_URI` SHALL always contain a valid URI; the runner MUST NOT inspect or handle `openshell:resolve:env:` prefixed values for this variable. This requirement does not apply to non-network URIs (file paths, SQLite).
+`MLFLOW_TRACKING_URI` is a platform environment variable that SHALL always contain a valid URI. This requirement does not apply to non-network URIs (file paths, SQLite).
 
 #### Scenario: Unresolvable hostname — fast skip
 
@@ -275,7 +275,7 @@ When operating in gateway mode with MLflow tracing enabled, the sandbox OPA netw
 | `agent-sandbox-config.spec.md` § Provider type mapping | Maps credential types to OpenShell provider types | Add `mlflow` → `generic` to the mapping table |
 | Control plane `provider_mapping.go` | Maps ambient credential providers to OpenShell provider types; contained `MLflowNetworkPolicy()` for dynamic OPA policy generation | Add `mlflow` → `generic` entry (follows existing pattern for `jira`, `google`, `kubeconfig`); remove `MLflowNetworkPolicy()` function (superseded by static `policy.yaml` entry); remove `MLflowSandboxEnvVars()` and `MLflowProviderCredentials()` — URI and experiment name now come from CP config, not the secret |
 | OPA policy (`policy.yaml`) | Network policy sections for known endpoints | Add `_mlflow_rh` static entry with the MLflow tracking server endpoint; uses `_` prefix convention for platform-managed policies (matching `_acp_internal`) |
-| `mlflow_observability.py` | Manual span tracking using `mlflow.start_span()` | Add openshell resolve token detection — when `MLFLOW_TRACKING_URI` starts with `openshell:resolve:env:`, skip explicit `mlflow.set_tracking_uri()` / `mlflow.set_experiment()` and defer to runtime env resolution by the openshell supervisor |
+| `mlflow_observability.py` | Manual span tracking using `mlflow.start_span()` | Add DNS pre-check before `mlflow.set_tracking_uri()` / `mlflow.set_experiment()` to avoid blocking on unresolvable hosts |
 | Control plane `config.go` | No MLflow config fields | Add `MLflowTrackingURI` and `MLflowExperimentName` config fields read from `MLFLOW_TRACKING_URI` and `MLFLOW_EXPERIMENT_NAME` env vars; these are the global defaults forwarded to sandboxes that have an MLflow provider |
 
 ### Specs requiring amendment


### PR DESCRIPTION
## Summary

- Add a 5-second DNS resolution pre-check before calling `mlflow.set_tracking_uri()` / `mlflow.set_experiment()`. If the hostname from `MLFLOW_TRACKING_URI` doesn't resolve, MLflow initialization is skipped immediately instead of waiting for MLflow's internal HTTP timeout (120s × 7 retries = 4+ minutes blocking startup).
- Cache the DNS result so the second init path (`MLflowSessionTracer.initialize` after `activate_mlflow_autologging`) returns instantly.
- Use `executor.shutdown(wait=False, cancel_futures=True)` so the caller unblocks immediately after timeout — the `ThreadPoolExecutor` context manager's `shutdown(wait=True)` would have defeated the 5s goal.
- Remove `openshell:resolve:env:` token handling from `MLFLOW_TRACKING_URI` — it's a platform env var set at deployment time, not a credential. The runner should not inspect its format.
- Update the mlflow-tracing spec with the DNS pre-check requirement and simplify credential provider language.

## Test plan

- [x] 10 unit tests for DNS pre-check (resolvable, unresolvable, timeout with real sleep, caching, file/sqlite bypass, port defaults)
- [x] 1 integration test verifying unreachable host prevents autolog activation end-to-end
- [x] All 33 MLflow-related tests pass
- [x] Timeout test uses `time.sleep` side effect (not direct `FuturesTimeoutError` raise) to exercise the real timeout path

🤖 Generated with [Claude Code](https://claude.com/claude-code)