### PR TITLE
fix(control-plane): policy merge confirmation and sandbox restart resilience

### DIFF
--- a/components/ambient-control-plane/internal/openshell/gateway_client.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client.go
@@ -301,38 +301,37 @@ func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace stri
 		return err
 	}
 
-	go func() {
-		for {
-			event, err := stream.Recv()
-			if err == io.EOF {
-				g.logger.Debug().Str("sandbox_id", req.SandboxId).Msg("exec stream ended")
-				return
-			}
-			if err != nil {
-				g.logger.Warn().Err(err).Str("sandbox_id", req.SandboxId).Msg("exec stream error")
-				return
-			}
-			switch p := event.Payload.(type) {
-			case *pb.ExecSandboxEvent_Stdout:
-				chunk := p.Stdout.Data
-				if len(chunk) > maxLogChunkSize {
-					chunk = chunk[:maxLogChunkSize]
-				}
-				g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stdout", string(chunk)).Msg("exec stdout")
-			case *pb.ExecSandboxEvent_Stderr:
-				chunk := p.Stderr.Data
-				if len(chunk) > maxLogChunkSize {
-					chunk = chunk[:maxLogChunkSize]
-				}
-				g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stderr", string(chunk)).Msg("exec stderr")
-			case *pb.ExecSandboxEvent_Exit:
-				g.logger.Info().Str("sandbox_id", req.SandboxId).Int32("exit_code", p.Exit.ExitCode).Msg("exec process exited")
-				return
-			}
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			g.logger.Debug().Str("sandbox_id", req.SandboxId).Msg("exec stream ended")
+			return nil
 		}
-	}()
-
-	return nil
+		if err != nil {
+			g.logger.Warn().Err(err).Str("sandbox_id", req.SandboxId).Msg("exec stream error")
+			return err
+		}
+		switch p := event.Payload.(type) {
+		case *pb.ExecSandboxEvent_Stdout:
+			chunk := p.Stdout.Data
+			if len(chunk) > maxLogChunkSize {
+				chunk = chunk[:maxLogChunkSize]
+			}
+			g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stdout", string(chunk)).Msg("exec stdout")
+		case *pb.ExecSandboxEvent_Stderr:
+			chunk := p.Stderr.Data
+			if len(chunk) > maxLogChunkSize {
+				chunk = chunk[:maxLogChunkSize]
+			}
+			g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stderr", string(chunk)).Msg("exec stderr")
+		case *pb.ExecSandboxEvent_Exit:
+			g.logger.Info().Str("sandbox_id", req.SandboxId).Int32("exit_code", p.Exit.ExitCode).Msg("exec process exited")
+			if p.Exit.ExitCode != 0 {
+				return fmt.Errorf("exec process exited with code %d", p.Exit.ExitCode)
+			}
+			return nil
+		}
+	}
 }
 
 func (g *GatewayClient) UpdateConfig(ctx context.Context, namespace string, req *pb.UpdateConfigRequest) (*pb.UpdateConfigResponse, error) {

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -526,9 +526,7 @@ func (r *SimpleKubeReconciler) verifyAndFixDNSConfig(ctx context.Context, namesp
 	}
 
 	r.logger.Warn().Str("sandbox", sbxName).Msg("sandbox pod has ndots:5, deleting for recreation from patched CR")
-	gracePeriod := int64(0)
-	immediateDelete := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
-	if err := r.nsKube().DeletePod(ctx, namespace, sbxName, immediateDelete); err != nil && !k8serrors.IsNotFound(err) {
+	if err := r.nsKube().DeletePod(ctx, namespace, sbxName, &metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		return false, fmt.Errorf("deleting pod %s for ndots fix: %w", sbxName, err)
 	}
 	return false, nil
@@ -665,6 +663,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 	ndotsRetries := 0
 	const maxNdotsRetries = 5
 	awaitingPodRestart := false
+	sawNonReady := false
 
 	for {
 		select {
@@ -704,7 +703,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 			}
 			if phase != openshellpb.SandboxPhase_SANDBOX_PHASE_READY {
 				if awaitingPodRestart {
-					awaitingPodRestart = false
+					sawNonReady = true
 					r.logger.Info().Str("sandbox", sbxName).Str("phase", phase.String()).Msg("sandbox left READY after pod deletion, waiting for new pod")
 				}
 				r.logger.Debug().
@@ -714,9 +713,13 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				continue
 			}
 			if awaitingPodRestart {
-				// Sandbox may return to READY before we poll; re-verify rather than waiting for a phase transition we missed.
-				r.logger.Info().Str("sandbox", sbxName).Msg("sandbox READY after pod deletion, re-verifying DNS")
+				if !sawNonReady {
+					r.logger.Debug().Str("sandbox", sbxName).Msg("sandbox still READY during graceful pod termination, waiting")
+					continue
+				}
+				r.logger.Info().Str("sandbox", sbxName).Msg("sandbox READY after pod recreation, re-verifying DNS")
 				awaitingPodRestart = false
+				sawNonReady = false
 			}
 
 			sandboxID := sbxName
@@ -810,16 +813,42 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				}
 			}
 
-			err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
-				SandboxId:   sandboxID,
-				Command:     entrypoint,
-				Environment: execEnv,
-			})
-			if err != nil {
+			const maxExecRetries = 3
+			const execRetryDelay = 3 * time.Second
+
+			for attempt := 0; attempt <= maxExecRetries; attempt++ {
+				if attempt > 0 {
+					r.logger.Info().
+						Str("sandbox", sbxName).
+						Str("session_id", sessionID).
+						Int("attempt", attempt+1).
+						Msg("retrying entrypoint exec after relay error")
+					time.Sleep(execRetryDelay)
+				}
+
+				err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
+					SandboxId:   sandboxID,
+					Command:     entrypoint,
+					Environment: execEnv,
+				})
+				if err == nil {
+					break
+				}
+
+				if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable && attempt < maxExecRetries {
+					r.logger.Warn().Err(err).
+						Str("sandbox", sbxName).
+						Str("session_id", sessionID).
+						Int("attempt", attempt+1).
+						Msg("exec relay died (likely supervisor reconnect), will retry")
+					continue
+				}
+
 				r.logger.Error().Err(err).Str("sandbox", sbxName).Str("session_id", sessionID).Msg("failed to start runner exec")
 				failSession(fmt.Sprintf("failed to start runner exec: %v", err))
 				return
 			}
+
 			// FIXME(#223): Mark session PhaseCompleted and set completion_time here once
 			// session lifecycle is ironed out. Currently left Running so the sandbox
 			// isn't orphaned (Completed triggers deprovision).

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -444,7 +444,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 }
 
 func (r *SimpleKubeReconciler) injectACPInternalPolicy(ctx context.Context, namespace, sandboxName string) error {
-	_, err := r.gateway.UpdateConfig(ctx, namespace, &openshellpb.UpdateConfigRequest{
+	resp, err := r.gateway.UpdateConfig(ctx, namespace, &openshellpb.UpdateConfigRequest{
 		Name:            sandboxName,
 		MergeOperations: []*openshellpb.PolicyMergeOperation{acpInternalMergeOperation(r.cfg.CPRuntimeNamespace)},
 	})
@@ -455,7 +455,9 @@ func (r *SimpleKubeReconciler) injectACPInternalPolicy(ctx context.Context, name
 		Str("sandbox", sandboxName).
 		Str("namespace", namespace).
 		Str("cp_namespace", r.cfg.CPRuntimeNamespace).
-		Msg("injected _acp_internal policy via merge operation")
+		Uint32("policy_version", resp.GetVersion()).
+		Str("policy_hash", resp.GetPolicyHash()).
+		Msg("_acp_internal policy merge confirmed by gateway")
 	return nil
 }
 

--- a/specs/platform/openshell-sandbox-provisioning.spec.md
+++ b/specs/platform/openshell-sandbox-provisioning.spec.md
@@ -550,6 +550,16 @@ The `_acp_internal` rule SHALL NOT be included in the `CreateSandboxRequest.Spec
 - THEN the existing default policy rules SHALL remain intact and unmodified
 - AND the `_acp_internal` rule SHALL be added alongside them
 
+#### Scenario: Policy merge confirmation via UpdateConfig response
+
+- GIVEN the control plane has called `UpdateConfig` with the `_acp_internal` merge operation
+- WHEN the gateway processes the merge
+- THEN the `UpdateConfigResponse` SHALL include the new `version` (uint32) and `policy_hash` (string)
+- AND a successful response SHALL serve as the definitive confirmation that the merge has been applied
+- AND the control plane SHALL NOT poll sandbox logs to verify the merge — the synchronous `UpdateConfig` RPC is authoritative
+- AND the control plane SHALL log the returned `policy_version` and `policy_hash` for observability
+- AND the entrypoint execution SHALL proceed immediately after a successful `UpdateConfig` response
+
 #### Scenario: Missing ACP internal policy causes runner failure
 
 - GIVEN the `_acp_internal` network policy rule has not been injected (e.g., `UpdateConfig` merge failed)


### PR DESCRIPTION
## Summary

- Capture the `UpdateConfigResponse` from the gateway after injecting the `_acp_internal` policy merge operation and log the returned `policy_version` and `policy_hash`. Provides definitive confirmation that the gateway applied the merge, replacing the previous fire-and-forget pattern.
- Fix sandbox restart crash caused by supervisor session supersession race condition during ndots pod deletion. Make `ExecSandboxStreaming` blocking so stream errors propagate, switch from force-kill to graceful pod deletion, and add exec retry logic for transient `Unavailable` errors.

## Context

PR #318 introduces scoped sandbox policies with `mergePlatformRules()` at `CreateSandbox` time and a post-READY `UpdateConfig` merge, but neither path confirms the gateway actually applied the policy. This PR adds that confirmation signal.

The ndots DNS fix (`verifyAndFixDNSConfig`) was force-deleting pods with `GracePeriodSeconds: 0`, triggering a supervisor reconnection storm that superseded the active session ~100ms after exec started. The runner appeared to crash immediately on startup, but the root cause was the exec relay being killed by session supersession.

## Changes

**Policy merge confirmation:**
- Log `policy_version` and `policy_hash` from `UpdateConfig` response
- Add spec scenario documenting the confirmation contract

**Sandbox restart resilience:**
- `ExecSandboxStreaming`: remove goroutine wrapper, make blocking with error/exit code propagation
- `verifyAndFixDNSConfig`: graceful pod deletion (default grace period) instead of force-kill
- `execAfterReady`: `sawNonReady` flag to wait for sandbox to leave READY before accepting it as READY again after graceful pod termination
- Exec retry loop (3 attempts, 3s delay) for `codes.Unavailable` errors from transient supervisor reconnects

## Test plan

- [ ] Verify control plane logs include `policy_version` and `policy_hash` after `_acp_internal` merge
- [ ] Verify sandbox with ndots:5 is gracefully deleted and recreated without runner crash
- [ ] Verify exec retries on transient `Unavailable` errors during supervisor reconnect
- [ ] Verify no change in sandbox provisioning behavior for pods that already have ndots:1

🤖 Generated with [Claude Code](https://claude.com/claude-code)