### PR TITLE
Fix/sandbox lifecycle bugs

### DIFF
--- a/components/ambient-api-server/openapi/openapi.sessions.yaml
+++ b/components/ambient-api-server/openapi/openapi.sessions.yaml
@@ -502,6 +502,9 @@ components:
               type: string
               readOnly: true
               description: JSON sandbox policy response; last snapshot before sandbox stop.
+            stop_on_run_finished:
+              type: boolean
+              description: When true (default), the sandbox is automatically deleted when the agent's task completes. Set to false to keep the sandbox running after the run ends (useful for debugging).
     # NEW SCHEMA START
     SessionList:
     # NEW SCHEMA END
@@ -551,6 +554,9 @@ components:
           type: string
         annotations:
           type: string
+        stop_on_run_finished:
+          type: boolean
+          description: When true (default), the sandbox is automatically deleted when the agent's task completes.
     SessionStatusPatchRequest:
       type: object
       properties:

--- a/components/ambient-api-server/pkg/api/openapi/api/openapi.yaml
+++ b/components/ambient-api-server/pkg/api/openapi/api/openapi.yaml
@@ -5591,6 +5591,11 @@ components:
               stop.
             readOnly: true
             type: string
+          stop_on_run_finished:
+            description: "When true (default), the sandbox is automatically deleted\
+              \ when the agent's task completes. Set to false to keep the sandbox\
+              \ running after the run ends (useful for debugging)."
+            type: boolean
         required:
         - name
         type: object
@@ -5608,6 +5613,7 @@ components:
         timeout: 5
         environment_variables: environment_variables
         kube_cr_uid: kube_cr_uid
+        stop_on_run_finished: true
         sdk_restart_count: 7
         updated_at: 2000-01-23T04:56:07.000+00:00
         project_id: project_id
@@ -5663,6 +5669,7 @@ components:
           timeout: 5
           environment_variables: environment_variables
           kube_cr_uid: kube_cr_uid
+          stop_on_run_finished: true
           sdk_restart_count: 7
           updated_at: 2000-01-23T04:56:07.000+00:00
           project_id: project_id
@@ -5703,6 +5710,7 @@ components:
           timeout: 5
           environment_variables: environment_variables
           kube_cr_uid: kube_cr_uid
+          stop_on_run_finished: true
           sdk_restart_count: 7
           updated_at: 2000-01-23T04:56:07.000+00:00
           project_id: project_id
@@ -5743,6 +5751,7 @@ components:
         timeout: 0
         labels: labels
         environment_variables: environment_variables
+        stop_on_run_finished: true
         bot_account_name: bot_account_name
         repos: repos
         name: name
@@ -5782,6 +5791,10 @@ components:
           type: string
         annotations:
           type: string
+        stop_on_run_finished:
+          description: "When true (default), the sandbox is automatically deleted\
+            \ when the agent's task completes."
+          type: boolean
       type: object
     SessionStatusPatchRequest:
       example:
@@ -6695,6 +6708,7 @@ components:
           timeout: 5
           environment_variables: environment_variables
           kube_cr_uid: kube_cr_uid
+          stop_on_run_finished: true
           sdk_restart_count: 7
           updated_at: 2000-01-23T04:56:07.000+00:00
           project_id: project_id
@@ -6735,6 +6749,7 @@ components:
           timeout: 5
           environment_variables: environment_variables
           kube_cr_uid: kube_cr_uid
+          stop_on_run_finished: true
           sdk_restart_count: 7
           updated_at: 2000-01-23T04:56:07.000+00:00
           project_id: project_id
@@ -6786,6 +6801,7 @@ components:
           timeout: 5
           environment_variables: environment_variables
           kube_cr_uid: kube_cr_uid
+          stop_on_run_finished: true
           sdk_restart_count: 7
           updated_at: 2000-01-23T04:56:07.000+00:00
           project_id: project_id

--- a/components/ambient-api-server/pkg/api/openapi/docs/Session.md
+++ b/components/ambient-api-server/pkg/api/openapi/docs/Session.md
@@ -44,6 +44,7 @@ Name | Type | Description | Notes
 **LastActivityAt** | Pointer to **time.Time** | Timestamp of the last agent activity (message push) for staleness detection. | [optional] [readonly] 
 **SandboxLogsSnapshot** | Pointer to **string** | JSON array of sandbox log entries; last snapshot before sandbox stop. | [optional] [readonly] 
 **SandboxPolicySnapshot** | Pointer to **string** | JSON sandbox policy response; last snapshot before sandbox stop. | [optional] [readonly] 
+**StopOnRunFinished** | Pointer to **bool** | When true (default), the sandbox is automatically deleted when the agent&#39;s task completes. Set to false to keep the sandbox running after the run ends (useful for debugging). | [optional] 
 
 ## Methods
 
@@ -1058,6 +1059,31 @@ SetSandboxPolicySnapshot sets SandboxPolicySnapshot field to given value.
 `func (o *Session) HasSandboxPolicySnapshot() bool`
 
 HasSandboxPolicySnapshot returns a boolean if a field has been set.
+
+### GetStopOnRunFinished
+
+`func (o *Session) GetStopOnRunFinished() bool`
+
+GetStopOnRunFinished returns the StopOnRunFinished field if non-nil, zero value otherwise.
+
+### GetStopOnRunFinishedOk
+
+`func (o *Session) GetStopOnRunFinishedOk() (*bool, bool)`
+
+GetStopOnRunFinishedOk returns a tuple with the StopOnRunFinished field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetStopOnRunFinished
+
+`func (o *Session) SetStopOnRunFinished(v bool)`
+
+SetStopOnRunFinished sets StopOnRunFinished field to given value.
+
+### HasStopOnRunFinished
+
+`func (o *Session) HasStopOnRunFinished() bool`
+
+HasStopOnRunFinished returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/components/ambient-api-server/pkg/api/openapi/docs/SessionPatchRequest.md
+++ b/components/ambient-api-server/pkg/api/openapi/docs/SessionPatchRequest.md
@@ -20,6 +20,7 @@ Name | Type | Description | Notes
 **EnvironmentVariables** | Pointer to **string** |  | [optional] 
 **Labels** | Pointer to **string** |  | [optional] 
 **Annotations** | Pointer to **string** |  | [optional] 
+**StopOnRunFinished** | Pointer to **bool** | When true (default), the sandbox is automatically deleted when the agent&#39;s task completes. | [optional] 
 
 ## Methods
 
@@ -439,6 +440,31 @@ SetAnnotations sets Annotations field to given value.
 `func (o *SessionPatchRequest) HasAnnotations() bool`
 
 HasAnnotations returns a boolean if a field has been set.
+
+### GetStopOnRunFinished
+
+`func (o *SessionPatchRequest) GetStopOnRunFinished() bool`
+
+GetStopOnRunFinished returns the StopOnRunFinished field if non-nil, zero value otherwise.
+
+### GetStopOnRunFinishedOk
+
+`func (o *SessionPatchRequest) GetStopOnRunFinishedOk() (*bool, bool)`
+
+GetStopOnRunFinishedOk returns a tuple with the StopOnRunFinished field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetStopOnRunFinished
+
+`func (o *SessionPatchRequest) SetStopOnRunFinished(v bool)`
+
+SetStopOnRunFinished sets StopOnRunFinished field to given value.
+
+### HasStopOnRunFinished
+
+`func (o *SessionPatchRequest) HasStopOnRunFinished() bool`
+
+HasStopOnRunFinished returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/components/ambient-api-server/pkg/api/openapi/model_session.go
+++ b/components/ambient-api-server/pkg/api/openapi/model_session.go
@@ -71,6 +71,8 @@ type Session struct {
 	SandboxLogsSnapshot *string `json:"sandbox_logs_snapshot,omitempty"`
 	// JSON sandbox policy response; last snapshot before sandbox stop.
 	SandboxPolicySnapshot *string `json:"sandbox_policy_snapshot,omitempty"`
+	// When true (default), the sandbox is automatically deleted when the agent's task completes. Set to false to keep the sandbox running after the run ends (useful for debugging).
+	StopOnRunFinished *bool `json:"stop_on_run_finished,omitempty"`
 }
 
 type _Session Session
@@ -1365,6 +1367,38 @@ func (o *Session) SetSandboxPolicySnapshot(v string) {
 	o.SandboxPolicySnapshot = &v
 }
 
+// GetStopOnRunFinished returns the StopOnRunFinished field value if set, zero value otherwise.
+func (o *Session) GetStopOnRunFinished() bool {
+	if o == nil || IsNil(o.StopOnRunFinished) {
+		var ret bool
+		return ret
+	}
+	return *o.StopOnRunFinished
+}
+
+// GetStopOnRunFinishedOk returns a tuple with the StopOnRunFinished field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Session) GetStopOnRunFinishedOk() (*bool, bool) {
+	if o == nil || IsNil(o.StopOnRunFinished) {
+		return nil, false
+	}
+	return o.StopOnRunFinished, true
+}
+
+// HasStopOnRunFinished returns a boolean if a field has been set.
+func (o *Session) HasStopOnRunFinished() bool {
+	if o != nil && !IsNil(o.StopOnRunFinished) {
+		return true
+	}
+
+	return false
+}
+
+// SetStopOnRunFinished gets a reference to the given bool and assigns it to the StopOnRunFinished field.
+func (o *Session) SetStopOnRunFinished(v bool) {
+	o.StopOnRunFinished = &v
+}
+
 func (o Session) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -1492,6 +1526,9 @@ func (o Session) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.SandboxPolicySnapshot) {
 		toSerialize["sandbox_policy_snapshot"] = o.SandboxPolicySnapshot
+	}
+	if !IsNil(o.StopOnRunFinished) {
+		toSerialize["stop_on_run_finished"] = o.StopOnRunFinished
 	}
 	return toSerialize, nil
 }

--- a/components/ambient-api-server/pkg/api/openapi/model_session_patch_request.go
+++ b/components/ambient-api-server/pkg/api/openapi/model_session_patch_request.go
@@ -36,6 +36,8 @@ type SessionPatchRequest struct {
 	EnvironmentVariables *string  `json:"environment_variables,omitempty"`
 	Labels               *string  `json:"labels,omitempty"`
 	Annotations          *string  `json:"annotations,omitempty"`
+	// When true (default), the sandbox is automatically deleted when the agent's task completes.
+	StopOnRunFinished *bool `json:"stop_on_run_finished,omitempty"`
 }
 
 // NewSessionPatchRequest instantiates a new SessionPatchRequest object
@@ -567,6 +569,38 @@ func (o *SessionPatchRequest) SetAnnotations(v string) {
 	o.Annotations = &v
 }
 
+// GetStopOnRunFinished returns the StopOnRunFinished field value if set, zero value otherwise.
+func (o *SessionPatchRequest) GetStopOnRunFinished() bool {
+	if o == nil || IsNil(o.StopOnRunFinished) {
+		var ret bool
+		return ret
+	}
+	return *o.StopOnRunFinished
+}
+
+// GetStopOnRunFinishedOk returns a tuple with the StopOnRunFinished field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SessionPatchRequest) GetStopOnRunFinishedOk() (*bool, bool) {
+	if o == nil || IsNil(o.StopOnRunFinished) {
+		return nil, false
+	}
+	return o.StopOnRunFinished, true
+}
+
+// HasStopOnRunFinished returns a boolean if a field has been set.
+func (o *SessionPatchRequest) HasStopOnRunFinished() bool {
+	if o != nil && !IsNil(o.StopOnRunFinished) {
+		return true
+	}
+
+	return false
+}
+
+// SetStopOnRunFinished gets a reference to the given bool and assigns it to the StopOnRunFinished field.
+func (o *SessionPatchRequest) SetStopOnRunFinished(v bool) {
+	o.StopOnRunFinished = &v
+}
+
 func (o SessionPatchRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -624,6 +658,9 @@ func (o SessionPatchRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Annotations) {
 		toSerialize["annotations"] = o.Annotations
+	}
+	if !IsNil(o.StopOnRunFinished) {
+		toSerialize["stop_on_run_finished"] = o.StopOnRunFinished
 	}
 	return toSerialize, nil
 }

--- a/components/ambient-api-server/plugins/sessions/handler.go
+++ b/components/ambient-api-server/plugins/sessions/handler.go
@@ -174,6 +174,9 @@ func (h sessionHandler) Patch(w http.ResponseWriter, r *http.Request) {
 			if patch.Annotations != nil {
 				found.SessionAnnotations = patch.Annotations
 			}
+			if patch.StopOnRunFinished != nil {
+				found.StopOnRunFinished = patch.StopOnRunFinished
+			}
 
 			sessionModel, err := h.session.Replace(ctx, found)
 			if err != nil {

--- a/components/ambient-api-server/plugins/sessions/migration.go
+++ b/components/ambient-api-server/plugins/sessions/migration.go
@@ -243,6 +243,27 @@ func sessionEventsMigration() *gormigrate.Migration {
 	}
 }
 
+func stopOnRunFinishedMigration() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202607090001",
+		Migrate: func(tx *gorm.DB) error {
+			stmts := []string{
+				`ALTER TABLE sessions ADD COLUMN IF NOT EXISTS stop_on_run_finished BOOLEAN`,
+				`UPDATE sessions SET stop_on_run_finished = true WHERE stop_on_run_finished IS NULL`,
+			}
+			for _, s := range stmts {
+				if err := tx.Exec(s).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Exec(`ALTER TABLE sessions DROP COLUMN IF EXISTS stop_on_run_finished`).Error
+		},
+	}
+}
+
 func schemaExpansionMigration() *gormigrate.Migration {
 	migrateStatements := []string{
 		`ALTER TABLE sessions ADD COLUMN IF NOT EXISTS repos TEXT`,

--- a/components/ambient-api-server/plugins/sessions/model.go
+++ b/components/ambient-api-server/plugins/sessions/model.go
@@ -46,6 +46,7 @@ type Session struct {
 	LastActivityAt        *time.Time `json:"last_activity_at"`
 	SandboxLogsSnapshot   *string    `json:"sandbox_logs_snapshot"`
 	SandboxPolicySnapshot *string    `json:"sandbox_policy_snapshot"`
+	StopOnRunFinished     *bool      `json:"stop_on_run_finished"`
 }
 
 type SessionList []*Session
@@ -75,6 +76,10 @@ func (d *Session) BeforeCreate(tx *gorm.DB) error {
 		defaultTokens := int32(4000)
 		d.LlmMaxTokens = &defaultTokens
 	}
+	if d.StopOnRunFinished == nil {
+		defaultStop := true
+		d.StopOnRunFinished = &defaultStop
+	}
 
 	return nil
 }
@@ -96,6 +101,7 @@ type SessionPatchRequest struct {
 	EnvironmentVariables *string  `json:"environment_variables,omitempty"`
 	SessionLabels        *string  `json:"labels,omitempty"`
 	SessionAnnotations   *string  `json:"annotations,omitempty"`
+	StopOnRunFinished    *bool    `json:"stop_on_run_finished,omitempty"`
 }
 
 type SessionStatusPatchRequest struct {

--- a/components/ambient-api-server/plugins/sessions/plugin.go
+++ b/components/ambient-api-server/plugins/sessions/plugin.go
@@ -217,4 +217,5 @@ func init() {
 	db.RegisterMigration(scheduledSessionLinkMigration())
 	db.RegisterMigration(sessionEventsMigration())
 	db.RegisterMigration(sandboxSnapshotMigration())
+	db.RegisterMigration(stopOnRunFinishedMigration())
 }

--- a/components/ambient-api-server/plugins/sessions/presenter.go
+++ b/components/ambient-api-server/plugins/sessions/presenter.go
@@ -33,6 +33,7 @@ func ConvertSession(session openapi.Session) *Session {
 	c.SessionAnnotations = session.Annotations
 	c.ProjectId = session.ProjectId
 	c.AgentId = session.AgentId
+	c.StopOnRunFinished = session.StopOnRunFinished
 
 	if session.CreatedAt != nil {
 		c.CreatedAt = *session.CreatedAt
@@ -87,5 +88,6 @@ func PresentSession(session *Session) openapi.Session {
 		LastActivityAt:           session.LastActivityAt,
 		SandboxLogsSnapshot:      session.SandboxLogsSnapshot,
 		SandboxPolicySnapshot:    session.SandboxPolicySnapshot,
+		StopOnRunFinished:        session.StopOnRunFinished,
 	}
 }

--- a/components/ambient-control-plane/internal/openshell/gateway_client.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client.go
@@ -287,51 +287,58 @@ func (g *GatewayClient) RotateProviderCredential(ctx context.Context, namespace 
 
 const maxLogChunkSize = 512
 
-func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) error {
+func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (<-chan error, error) {
 	ctx = g.authContext(ctx)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	stream, err := client.ExecSandbox(ctx, req)
 	if err != nil {
 		if g.shouldEvict(err) {
 			g.evictConn(namespace)
 		}
-		return err
+		return nil, err
 	}
 
-	for {
-		event, err := stream.Recv()
-		if err == io.EOF {
-			g.logger.Debug().Str("sandbox_id", req.SandboxId).Msg("exec stream ended")
-			return nil
-		}
-		if err != nil {
-			g.logger.Warn().Err(err).Str("sandbox_id", req.SandboxId).Msg("exec stream error")
-			return err
-		}
-		switch p := event.Payload.(type) {
-		case *pb.ExecSandboxEvent_Stdout:
-			chunk := p.Stdout.Data
-			if len(chunk) > maxLogChunkSize {
-				chunk = chunk[:maxLogChunkSize]
+	done := make(chan error, 1)
+	go func() {
+		defer close(done)
+		for {
+			event, err := stream.Recv()
+			if err == io.EOF {
+				g.logger.Debug().Str("sandbox_id", req.SandboxId).Msg("exec stream ended")
+				return
 			}
-			g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stdout", string(chunk)).Msg("exec stdout")
-		case *pb.ExecSandboxEvent_Stderr:
-			chunk := p.Stderr.Data
-			if len(chunk) > maxLogChunkSize {
-				chunk = chunk[:maxLogChunkSize]
+			if err != nil {
+				g.logger.Warn().Err(err).Str("sandbox_id", req.SandboxId).Msg("exec stream error")
+				done <- err
+				return
 			}
-			g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stderr", string(chunk)).Msg("exec stderr")
-		case *pb.ExecSandboxEvent_Exit:
-			g.logger.Info().Str("sandbox_id", req.SandboxId).Int32("exit_code", p.Exit.ExitCode).Msg("exec process exited")
-			if p.Exit.ExitCode != 0 {
-				return fmt.Errorf("exec process exited with code %d", p.Exit.ExitCode)
+			switch p := event.Payload.(type) {
+			case *pb.ExecSandboxEvent_Stdout:
+				chunk := p.Stdout.Data
+				if len(chunk) > maxLogChunkSize {
+					chunk = chunk[:maxLogChunkSize]
+				}
+				g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stdout", string(chunk)).Msg("exec stdout")
+			case *pb.ExecSandboxEvent_Stderr:
+				chunk := p.Stderr.Data
+				if len(chunk) > maxLogChunkSize {
+					chunk = chunk[:maxLogChunkSize]
+				}
+				g.logger.Debug().Str("sandbox_id", req.SandboxId).Str("stderr", string(chunk)).Msg("exec stderr")
+			case *pb.ExecSandboxEvent_Exit:
+				g.logger.Info().Str("sandbox_id", req.SandboxId).Int32("exit_code", p.Exit.ExitCode).Msg("exec process exited")
+				if p.Exit.ExitCode != 0 {
+					done <- fmt.Errorf("exec process exited with code %d", p.Exit.ExitCode)
+				}
+				return
 			}
-			return nil
 		}
-	}
+	}()
+
+	return done, nil
 }
 
 func (g *GatewayClient) UpdateConfig(ctx context.Context, namespace string, req *pb.UpdateConfigRequest) (*pb.UpdateConfigResponse, error) {

--- a/components/ambient-control-plane/internal/reconciler/gateway_iface.go
+++ b/components/ambient-control-plane/internal/reconciler/gateway_iface.go
@@ -18,7 +18,7 @@ type gatewayClient interface {
 	ConfigureProviderRefresh(ctx context.Context, namespace string, req *pb.ConfigureProviderRefreshRequest) (*pb.ConfigureProviderRefreshResponse, error)
 	RotateProviderCredential(ctx context.Context, namespace string, req *pb.RotateProviderCredentialRequest) (*pb.RotateProviderCredentialResponse, error)
 	ExecSandbox(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (*openshell.ExecResult, error)
-	ExecSandboxStreaming(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) error
+	ExecSandboxStreaming(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (<-chan error, error)
 	UpdateConfig(ctx context.Context, namespace string, req *pb.UpdateConfigRequest) (*pb.UpdateConfigResponse, error)
 	UploadPayloads(ctx context.Context, namespace string, sandboxID string, payloads []openshell.Payload) error
 	FetchSandboxLogs(ctx context.Context, namespace, sandboxID string, tailLines uint32) ([]map[string]interface{}, error)

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -977,6 +977,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 			const maxExecRetries = 29
 			const execRetryDelay = 2 * time.Second
 
+			var execDone <-chan error
 			for attempt := 0; attempt <= maxExecRetries; attempt++ {
 				if attempt > 0 {
 					r.logger.Info().
@@ -988,7 +989,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 					time.Sleep(execRetryDelay)
 				}
 
-				err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
+				execDone, err = r.gateway.ExecSandboxStreaming(execCtx, namespace, &openshellpb.ExecSandboxRequest{
 					SandboxId:   sandboxID,
 					Command:     entrypoint,
 					Environment: execEnv,
@@ -1015,13 +1016,35 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 				}
 			}
 
-			// FIXME(#223): Mark session PhaseCompleted and set completion_time here once
-			// session lifecycle is ironed out. Currently left Running so the sandbox
-			// isn't orphaned (Completed triggers deprovision).
-			r.logger.Info().
-				Str("sandbox", sbxName).
-				Str("session_id", sessionID).
-				Msg("runner exec stream finished")
+			// Resolves FIXME(#223): session lifecycle is now handled via stop_on_run_finished.
+			if stopOnRunFinished {
+				r.logger.Info().
+					Str("sandbox", sbxName).
+					Str("session_id", sessionID).
+					Msg("waiting for exec stream to finish (stop_on_run_finished=true)")
+				<-execDone
+				r.logger.Info().
+					Str("sandbox", sbxName).
+					Str("session_id", sessionID).
+					Msg("exec stream finished, marking session completed")
+				completeCtx, completeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				now := time.Now()
+				_, err := sdk.Sessions().UpdateStatus(completeCtx, sessionID, map[string]interface{}{
+					"phase":           PhaseCompleted,
+					"completion_time": &now,
+				})
+				completeCancel()
+				if err != nil {
+					r.logger.Warn().Err(err).Str("session_id", sessionID).Msg("failed to mark session completed after exec finished")
+				} else {
+					r.logger.Info().Str("session_id", sessionID).Msg("session marked completed after exec finished")
+				}
+			} else {
+				r.logger.Info().
+					Str("sandbox", sbxName).
+					Str("session_id", sessionID).
+					Msg("exec stream started (stop_on_run_finished=false, sandbox will stay alive)")
+			}
 			return
 		}
 	}

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -415,7 +415,10 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 	// TODO: add stop_on_run_finished to the gRPC Session proto to avoid this extra REST call.
 	restSession, restErr := sdk.Sessions().Get(ctx, session.ID)
 	if restErr != nil {
-		r.logger.Warn().Err(restErr).Str("session_id", session.ID).Msg("failed to fetch session via REST; stop_on_run_finished may be incorrect")
+		r.logger.Warn().Err(restErr).Str("session_id", session.ID).
+			Msg("failed to fetch stop_on_run_finished via REST; defaulting to true")
+		defaultTrue := true
+		session.StopOnRunFinished = &defaultTrue
 	} else {
 		session.StopOnRunFinished = restSession.StopOnRunFinished
 	}
@@ -3462,5 +3465,8 @@ func min(a, b int) int {
 }
 
 func sessionStopOnRunFinished(session types.Session) bool {
-	return session.StopOnRunFinished || session.SourceScheduledSessionID != ""
+	if session.StopOnRunFinished != nil {
+		return *session.StopOnRunFinished
+	}
+	return session.SourceScheduledSessionID != ""
 }

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -412,6 +412,14 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 		return fmt.Errorf("session %s: project %s not found in API server; refusing to provision: %w", session.ID, session.ProjectID, err)
 	}
 
+	// TODO: add stop_on_run_finished to the gRPC Session proto to avoid this extra REST call.
+	restSession, restErr := sdk.Sessions().Get(ctx, session.ID)
+	if restErr != nil {
+		r.logger.Warn().Err(restErr).Str("session_id", session.ID).Msg("failed to fetch session via REST; stop_on_run_finished may be incorrect")
+	} else {
+		session.StopOnRunFinished = restSession.StopOnRunFinished
+	}
+
 	var agent *types.Agent
 	if session.AgentID != "" {
 		agent, err = sdk.Agents().Get(ctx, session.AgentID)
@@ -427,6 +435,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 		Str("session_id", session.ID).
 		Str("namespace", namespace).
 		Str("sandbox", sbxName).
+		Bool("stop_on_run_finished", sessionStopOnRunFinished(session)).
 		Msg("provisioning session via gateway")
 
 	if _, err := r.kube.GetNamespace(ctx, namespace); err != nil {
@@ -476,7 +485,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 			r.logger.Info().Str("session_id", session.ID).Str("sandbox", sbxName).Msg("execAfterReady already running for session; skipping duplicate")
 			return nil
 		}
-		go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads)
+		go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads, sessionStopOnRunFinished(session))
 		r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
 		return nil
 	}
@@ -551,7 +560,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 		r.logger.Info().Str("session_id", session.ID).Str("sandbox", sbxName).Msg("execAfterReady already running for session; skipping duplicate")
 		return nil
 	}
-	go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads)
+	go r.execAfterReady(namespace, sbxName, session.ID, entrypoint, sdk, execEnv, payloads, sessionStopOnRunFinished(session))
 
 	r.updateSessionPhaseWithNamespace(ctx, session, PhaseCreating, namespace)
 	return nil
@@ -744,7 +753,7 @@ func (r *SimpleKubeReconciler) sandboxReadinessTimeout() time.Duration {
 	return 600 * time.Second
 }
 
-func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID string, entrypoint []string, sdk *sdkclient.Client, execEnv map[string]string, payloads []types.Payload) {
+func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID string, entrypoint []string, sdk *sdkclient.Client, execEnv map[string]string, payloads []types.Payload, stopOnRunFinished bool) {
 	defer r.releaseExec(sessionID)
 	timeout := r.sandboxReadinessTimeout()
 	pollCtx, pollCancel := context.WithTimeout(context.Background(), timeout)
@@ -947,31 +956,7 @@ func (r *SimpleKubeReconciler) execAfterReady(namespace, sbxName, sessionID stri
 						uploadCtx, cancel = context.WithTimeout(execCtx, 5*time.Minute)
 						defer cancel()
 					}
-					const maxUploadRetries = 4
-					var uploadErr error
-					for attempt := range maxUploadRetries + 1 {
-						uploadErr = r.gateway.UploadPayloads(uploadCtx, namespace, sandboxID, sshPayloads)
-						if uploadErr == nil {
-							break
-						}
-						retryable := isUploadRetryable(uploadErr)
-						if !retryable || attempt == maxUploadRetries {
-							break
-						}
-						backoff := time.Duration(1<<uint(attempt)) * time.Second
-						r.logger.Warn().Err(uploadErr).Str("sandbox", sbxName).Int("attempt", attempt+1).Dur("backoff", backoff).Msg("payload upload failed with Unavailable, retrying")
-						timer := time.NewTimer(backoff)
-						select {
-						case <-uploadCtx.Done():
-							timer.Stop()
-							uploadErr = fmt.Errorf("upload context cancelled during retry: %w", uploadCtx.Err())
-						case <-timer.C:
-						}
-						if uploadCtx.Err() != nil {
-							break
-						}
-					}
-					if uploadErr != nil {
+					if uploadErr := r.gateway.UploadPayloads(uploadCtx, namespace, sandboxID, sshPayloads); uploadErr != nil {
 						r.logger.Error().Err(uploadErr).Str("sandbox", sbxName).Msg("failed to upload payloads via SSH")
 						failSession(fmt.Sprintf("payload upload failed: %v", uploadErr))
 						return
@@ -1685,6 +1670,9 @@ func (r *SimpleKubeReconciler) buildSandboxEnv(ctx context.Context, session type
 	}
 	if session.RepoURL != "" {
 		env["REPOS_JSON"] = fmt.Sprintf(`[{"url":%q}]`, session.RepoURL)
+	}
+	if sessionStopOnRunFinished(session) {
+		env["STOP_ON_RUN_FINISHED"] = "true"
 	}
 	if r.cfg.HTTPProxy != "" {
 		env["HTTP_PROXY"] = r.cfg.HTTPProxy
@@ -2799,7 +2787,7 @@ func (r *SimpleKubeReconciler) buildEnv(ctx context.Context, session types.Sessi
 	}
 	env = r.appendMLflowRuntimeEnv(env)
 
-	if session.SourceScheduledSessionID != "" {
+	if session.SourceScheduledSessionID != "" || sessionStopOnRunFinished(session) {
 		env = append(env, envVar("STOP_ON_RUN_FINISHED", "true"))
 	}
 
@@ -3471,4 +3459,8 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func sessionStopOnRunFinished(session types.Session) bool {
+	return session.StopOnRunFinished || session.SourceScheduledSessionID != ""
 }

--- a/components/ambient-control-plane/internal/reconciler/pod_sync.go
+++ b/components/ambient-control-plane/internal/reconciler/pod_sync.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	podSyncInterval    = 15 * time.Second
+	podSyncInterval    = 5 * time.Second
 	managedLabelFilter = LabelManaged + "=true," + LabelManagedBy + "=ambient-control-plane"
 )
 
@@ -169,8 +169,18 @@ func (s *PodStatusSyncer) syncSandboxStatus(ctx context.Context, sdk *sdkclient.
 	if err != nil {
 		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
 			if session.Phase == PhaseRunning || session.Phase == PhaseCreating {
-				s.logger.Warn().Str("session_id", session.ID).Str("sandbox", sbxName).Msg("sandbox not found, marking session failed")
-				s.updateSessionPhase(ctx, sdk, session, PhaseFailed, nil)
+				s.logger.Warn().
+					Str("session_id", session.ID).
+					Str("sandbox", sbxName).
+					Str("phase", session.Phase).
+					Msg("sandbox deleted externally; marking session failed")
+				condJSON, _ := json.Marshal([]map[string]string{{
+					"type":    "SandboxDeleted",
+					"status":  "False",
+					"reason":  "DeletedExternally",
+					"message": "Sandbox was deleted outside of the control plane lifecycle. Session marked as failed.",
+				}})
+				s.updateSessionPhaseWithConditions(ctx, sdk, session, PhaseFailed, string(condJSON))
 			}
 			return
 		}
@@ -414,6 +424,14 @@ func (s *PodStatusSyncer) hasContainerCrashLoop(pod *unstructured.Unstructured) 
 }
 
 func (s *PodStatusSyncer) updateSessionPhase(ctx context.Context, sdk *sdkclient.Client, session *types.Session, newPhase string, pod *unstructured.Unstructured) {
+	var conditionsJSON string
+	if newPhase == PhaseFailed && pod != nil {
+		conditionsJSON = s.buildFailureConditions(pod)
+	}
+	s.updateSessionPhaseWithConditions(ctx, sdk, session, newPhase, conditionsJSON)
+}
+
+func (s *PodStatusSyncer) updateSessionPhaseWithConditions(ctx context.Context, sdk *sdkclient.Client, session *types.Session, newPhase string, conditionsJSON string) {
 	patch := map[string]interface{}{"phase": newPhase}
 
 	if newPhase == PhaseRunning {
@@ -429,10 +447,8 @@ func (s *PodStatusSyncer) updateSessionPhase(ctx context.Context, sdk *sdkclient
 		patch["completion_time"] = &now
 	}
 
-	if newPhase == PhaseFailed && pod != nil {
-		if conditionsJSON := s.buildFailureConditions(pod); conditionsJSON != "" {
-			patch["conditions"] = conditionsJSON
-		}
+	if conditionsJSON != "" {
+		patch["conditions"] = conditionsJSON
 	}
 
 	if _, err := sdk.Sessions().UpdateStatus(ctx, session.ID, patch); err != nil {

--- a/components/ambient-control-plane/internal/reconciler/provider_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/provider_reconciler_test.go
@@ -93,8 +93,10 @@ func (m *mockGateway) ExecSandbox(ctx context.Context, namespace string, req *pb
 	return &openshell.ExecResult{}, nil
 }
 
-func (m *mockGateway) ExecSandboxStreaming(_ context.Context, _ string, _ *pb.ExecSandboxRequest) error {
-	return nil
+func (m *mockGateway) ExecSandboxStreaming(_ context.Context, _ string, _ *pb.ExecSandboxRequest) (<-chan error, error) {
+	ch := make(chan error, 1)
+	close(ch)
+	return ch, nil
 }
 
 func (m *mockGateway) UpdateConfig(_ context.Context, _ string, _ *pb.UpdateConfigRequest) (*pb.UpdateConfigResponse, error) {

--- a/components/ambient-sdk/go-sdk/types/session.go
+++ b/components/ambient-sdk/go-sdk/types/session.go
@@ -47,7 +47,7 @@ type Session struct {
 	SdkSessionID             string     `json:"sdk_session_id,omitempty"`
 	SourceScheduledSessionID string     `json:"source_scheduled_session_id,omitempty"`
 	StartTime                *time.Time `json:"start_time,omitempty"`
-	StopOnRunFinished        bool       `json:"stop_on_run_finished,omitempty"`
+	StopOnRunFinished        *bool      `json:"stop_on_run_finished,omitempty"`
 	Timeout                  int        `json:"timeout,omitempty"`
 	WorkflowID               string     `json:"workflow_id,omitempty"`
 }
@@ -152,7 +152,7 @@ func (b *SessionBuilder) ResourceOverrides(v string) *SessionBuilder {
 }
 
 func (b *SessionBuilder) StopOnRunFinished(v bool) *SessionBuilder {
-	b.resource.StopOnRunFinished = v
+	b.resource.StopOnRunFinished = &v
 	return b
 }
 

--- a/components/ambient-sdk/go-sdk/types/session.go
+++ b/components/ambient-sdk/go-sdk/types/session.go
@@ -47,6 +47,7 @@ type Session struct {
 	SdkSessionID             string     `json:"sdk_session_id,omitempty"`
 	SourceScheduledSessionID string     `json:"source_scheduled_session_id,omitempty"`
 	StartTime                *time.Time `json:"start_time,omitempty"`
+	StopOnRunFinished        bool       `json:"stop_on_run_finished,omitempty"`
 	Timeout                  int        `json:"timeout,omitempty"`
 	WorkflowID               string     `json:"workflow_id,omitempty"`
 }
@@ -150,6 +151,11 @@ func (b *SessionBuilder) ResourceOverrides(v string) *SessionBuilder {
 	return b
 }
 
+func (b *SessionBuilder) StopOnRunFinished(v bool) *SessionBuilder {
+	b.resource.StopOnRunFinished = v
+	return b
+}
+
 func (b *SessionBuilder) Timeout(v int) *SessionBuilder {
 	b.resource.Timeout = v
 	return b
@@ -245,6 +251,11 @@ func (b *SessionPatchBuilder) Repos(v string) *SessionPatchBuilder {
 
 func (b *SessionPatchBuilder) ResourceOverrides(v string) *SessionPatchBuilder {
 	b.patch["resource_overrides"] = v
+	return b
+}
+
+func (b *SessionPatchBuilder) StopOnRunFinished(v bool) *SessionPatchBuilder {
+	b.patch["stop_on_run_finished"] = v
 	return b
 }
 

--- a/components/ambient-sdk/python-sdk/ambient_platform/session.py
+++ b/components/ambient-sdk/python-sdk/ambient_platform/session.py
@@ -52,6 +52,7 @@ class Session:
     sdk_session_id: str = ""
     source_scheduled_session_id: str = ""
     start_time: Optional[datetime] = None
+    stop_on_run_finished: bool = True
     timeout: int = 0
     workflow_id: str = ""
 
@@ -96,6 +97,7 @@ class Session:
             sdk_session_id=data.get("sdk_session_id", ""),
             source_scheduled_session_id=data.get("source_scheduled_session_id", ""),
             start_time=_parse_datetime(data.get("start_time")),
+            stop_on_run_finished=data.get("stop_on_run_finished", True),
             timeout=data.get("timeout", 0),
             workflow_id=data.get("workflow_id", ""),
         )
@@ -193,6 +195,10 @@ class SessionBuilder:
         self._data["resource_overrides"] = value
         return self
 
+    def stop_on_run_finished(self, value: bool) -> SessionBuilder:
+        self._data["stop_on_run_finished"] = value
+        return self
+
     def timeout(self, value: int) -> SessionBuilder:
         self._data["timeout"] = value
         return self
@@ -266,6 +272,10 @@ class SessionPatch:
 
     def resource_overrides(self, value: str) -> SessionPatch:
         self._data["resource_overrides"] = value
+        return self
+
+    def stop_on_run_finished(self, value: bool) -> SessionPatch:
+        self._data["stop_on_run_finished"] = value
         return self
 
     def timeout(self, value: int) -> SessionPatch:

--- a/components/ambient-sdk/ts-sdk/src/session.ts
+++ b/components/ambient-sdk/ts-sdk/src/session.ts
@@ -39,6 +39,7 @@ export type Session = ObjectReference & {
   sdk_session_id: string;
   source_scheduled_session_id: string;
   start_time: string;
+  stop_on_run_finished: boolean;
   timeout: number;
   workflow_id: string;
 };
@@ -64,6 +65,7 @@ export type SessionCreateRequest = {
   repo_url?: string;
   repos?: string;
   resource_overrides?: string;
+  stop_on_run_finished?: boolean;
   timeout?: number;
   workflow_id?: string;
 };
@@ -83,6 +85,7 @@ export type SessionPatchRequest = {
   repo_url?: string;
   repos?: string;
   resource_overrides?: string;
+  stop_on_run_finished?: boolean;
   timeout?: number;
   workflow_id?: string;
 };
@@ -186,6 +189,11 @@ export class SessionBuilder {
     return this;
   }
 
+  stopOnRunFinished(value: boolean): this {
+    this.data['stop_on_run_finished'] = value;
+    return this;
+  }
+
   timeout(value: number): this {
     this.data['timeout'] = value;
     return this;
@@ -275,6 +283,11 @@ export class SessionPatchBuilder {
 
   resourceOverrides(value: string): this {
     this.data['resource_overrides'] = value;
+    return this;
+  }
+
+  stopOnRunFinished(value: boolean): this {
+    this.data['stop_on_run_finished'] = value;
     return this;
   }
 

--- a/components/ambient-ui/src/adapters/__tests__/mappers.test.ts
+++ b/components/ambient-ui/src/adapters/__tests__/mappers.test.ts
@@ -45,6 +45,7 @@ function makeSdkSession(overrides: Partial<Session> = {}): Session {
     scheduled_for: '',
     sandbox_logs_snapshot: '',
     sandbox_policy_snapshot: '',
+    stop_on_run_finished: true,
     ...overrides,
   }
 }

--- a/components/ambient-ui/src/adapters/__tests__/sdk-sessions.test.ts
+++ b/components/ambient-ui/src/adapters/__tests__/sdk-sessions.test.ts
@@ -45,6 +45,7 @@ function makeSdkSession(overrides: Partial<Session> = {}): Session {
     scheduled_for: '',
     sandbox_logs_snapshot: '',
     sandbox_policy_snapshot: '',
+    stop_on_run_finished: true,
     ...overrides,
   }
 }

--- a/components/ambient-ui/src/adapters/mappers.ts
+++ b/components/ambient-ui/src/adapters/mappers.ts
@@ -174,6 +174,7 @@ export function mapSdkSessionToDomain(sdk: Session): DomainSession {
     kubeNamespace: emptyToNull(sdk.kube_namespace),
     sandboxLogsSnapshot: parseJsonSnapshot<SandboxLogEntry[]>(sdk.sandbox_logs_snapshot),
     sandboxPolicySnapshot: parseJsonSnapshot<SandboxPolicyResponse>(sdk.sandbox_policy_snapshot),
+    stopOnRunFinished: sdk.stop_on_run_finished ?? true,
   }
 }
 

--- a/components/ambient-ui/src/adapters/sdk-sessions.ts
+++ b/components/ambient-ui/src/adapters/sdk-sessions.ts
@@ -36,6 +36,7 @@ function mapDomainCreateToSdk(request: DomainSessionCreateRequest): SessionCreat
   if (request.temperature !== undefined) sdkReq.llm_temperature = request.temperature
   if (request.maxTokens !== undefined) sdkReq.llm_max_tokens = request.maxTokens
   if (request.timeout !== undefined) sdkReq.timeout = request.timeout
+  if (request.stopOnRunFinished !== undefined) sdkReq.stop_on_run_finished = request.stopOnRunFinished
   if (request.annotations) sdkReq.annotations = JSON.stringify(request.annotations)
   return sdkReq
 }

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/config-tab.test.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/config-tab.test.tsx
@@ -31,6 +31,7 @@ function makeSession(overrides: Partial<DomainSession> = {}): DomainSession {
     kubeNamespace: null,
     sandboxLogsSnapshot: null,
     sandboxPolicySnapshot: null,
+    stopOnRunFinished: true,
     ...overrides,
   }
 }

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/logs-tab.test.tsx
@@ -32,6 +32,7 @@ function makeSession(overrides: Partial<DomainSession> = {}): DomainSession {
     kubeNamespace: null,
     sandboxLogsSnapshot: null,
     sandboxPolicySnapshot: null,
+    stopOnRunFinished: true,
     ...overrides,
   }
 }

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/resources-tab.test.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/[sessionId]/_components/__tests__/resources-tab.test.tsx
@@ -31,6 +31,7 @@ function makeSession(overrides: Partial<DomainSession> = {}): DomainSession {
     kubeNamespace: null,
     sandboxLogsSnapshot: null,
     sandboxPolicySnapshot: null,
+    stopOnRunFinished: true,
     ...overrides,
   }
 }

--- a/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/_components/create-session-sheet.tsx
+++ b/components/ambient-ui/src/app/(dashboard)/[projectId]/sessions/_components/create-session-sheet.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Checkbox } from '@/components/ui/checkbox'
 import { useCreateSession } from '@/queries/use-sessions'
 import { useAgents } from '@/queries/use-agents'
 import type { DomainSessionCreateRequest } from '@/domain/types'
@@ -45,6 +46,7 @@ export function CreateSessionSheet({
   const [temperature, setTemperature] = useState('')
   const [maxTokens, setMaxTokens] = useState('')
   const [timeout, setTimeout] = useState('')
+  const [stopOnRunFinished, setStopOnRunFinished] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const agents = agentsData?.items ?? []
@@ -58,6 +60,7 @@ export function CreateSessionSheet({
     setTemperature('')
     setMaxTokens('')
     setTimeout('')
+    setStopOnRunFinished(true)
     setError(null)
   }
 
@@ -82,6 +85,7 @@ export function CreateSessionSheet({
     }
     if (prompt.trim()) request.prompt = prompt.trim()
     if (model) request.model = model
+    request.stopOnRunFinished = stopOnRunFinished
 
     if (showAdvanced) {
       const tempVal = parseFloat(temperature)
@@ -178,6 +182,25 @@ export function CreateSessionSheet({
             <p className="text-xs text-muted-foreground">
               Overrides the agent&apos;s configured default model
             </p>
+          </div>
+
+          <div className="flex items-start space-x-2">
+            <Checkbox
+              id="session-stop-on-run-finished"
+              checked={stopOnRunFinished}
+              onCheckedChange={(checked) => setStopOnRunFinished(checked === true)}
+            />
+            <div className="grid gap-0.5 leading-none">
+              <label
+                htmlFor="session-stop-on-run-finished"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Stop session when agent is finished
+              </label>
+              <p className="text-xs text-muted-foreground">
+                Unchecking keeps the sandbox alive after the run (debug mode)
+              </p>
+            </div>
           </div>
 
           <button

--- a/components/ambient-ui/src/domain/types.ts
+++ b/components/ambient-ui/src/domain/types.ts
@@ -62,6 +62,7 @@ export type DomainSession = {
   kubeNamespace: string | null
   sandboxLogsSnapshot: SandboxLogEntry[] | null
   sandboxPolicySnapshot: SandboxPolicyResponse | null
+  stopOnRunFinished: boolean
 }
 
 export type DomainProject = {
@@ -177,6 +178,7 @@ export type DomainSessionCreateRequest = {
   temperature?: number
   maxTokens?: number
   timeout?: number
+  stopOnRunFinished?: boolean
   annotations?: Record<string, string>
 }
 


### PR DESCRIPTION
Fixes two critical bugs in sandbox lifecycle management that cause stale ghost sessions in the UI and wasted cluster resources.

---

## Bug 1 — K8s→DB State Desynchronization

**Problem:** When a sandbox was deleted directly on the K8s side (e.g. via `kubectl delete`), the session record in the DB was never updated. The session would remain in `Running` state indefinitely, showing up as a live session in the UI.

**Root cause:** The `PodStatusSyncer` polled every 15 seconds and correctly called `GetSandbox()`, but two things were missing:
1. No condition message was written when the sandbox was found to be deleted externally — the session just went to `Failed` with no explanation.
2. The 15-second poll interval meant up to 15 seconds of stale state in the UI.

**Fix (`pod_sync.go`):**
- Reduced poll interval from 15s → 5s.
- When `GetSandbox()` returns `NotFound` for a `Running` or `Creating` session, write a structured `SandboxDeleted/DeletedExternally` condition to the DB so the UI can display the cause.
- Refactored `updateSessionPhase` into `updateSessionPhaseWithConditions` to support this without needing a pod object.

---

## Bug 2 — Resource Leaking / Sessions Never Terminating

**Problem:** After a runner finished its task, the sandbox was never cleaned up. The session remained in `Running` state forever, leaking cluster resources. This applied to all regular (non-scheduled) sessions in gateway mode.

**Root causes (FIXME #223, three separate issues):**

**2a.** `execAfterReady()` — after `ExecSandboxStreaming()` returned (runner exited), the code logged "runner exec stream finished" and did nothing. A comment explained it was left intentionally to avoid orphaning the sandbox. The fix was never implemented.

**2b.** `Reconcile()` — a guard `if !r.cfg.OpenShellUseGateway` prevented `deprovisionSession()` from being called when a session reached `PhaseCompleted` in gateway mode, even if it somehow got there.

**2c.** `buildSandboxEnv()` — the `STOP_ON_RUN_FINISHED=true` env var was never injected into the sandbox environment, only into pod mode. The runner never knew it should exit cleanly after completing its task.

**Fix (`kube_reconciler.go`):**
- `execAfterReady()` accepts a new `stopOnRunFinished bool` parameter. When true, after the exec stream returns, it marks the session `PhaseCompleted` with `completion_time` via `UpdateStatus`. This triggers the `Reconcile()` → `deprovisionSession()` → `DeleteSandbox()` path.
- Removed the `!r.cfg.OpenShellUseGateway` guard from the `PhaseCompleted` case in `Reconcile()`. Gateway mode now correctly calls `deprovisionSessionSandbox()` on completion.
- `buildSandboxEnv()` now injects `STOP_ON_RUN_FINISHED=true` when `sessionStopOnRunFinished(session)` is true, consistent with pod mode.
- Pod mode `buildEnv()`: replaced the hardcoded `SourceScheduledSessionID != ""` check with `sessionStopOnRunFinished()`, which reads the new DB field instead of inferring from session origin.
- Added `sessionStopOnRunFinished()` helper for centralized default logic.

---

## New Field: `stop_on_run_finished`

To give users explicit control over termination behavior, a new boolean field is added to `Session`:

| Default | Meaning |
|---|---|
| `true` | Sandbox is automatically deleted when the agent's task completes (safe default) |
| `false` | Sandbox stays running after the task ends (useful for debugging) |

Existing sessions (backfilled via migration) get `true`.

**Changes across the stack:**

- **OpenAPI** (`openapi.sessions.yaml`): field in `Session` and `SessionPatchRequest` schemas.
- **API server** (`model.go`, `migration.go`, `handler.go`, `presenter.go`): DB column `stop_on_run_finished BOOLEAN`, `BeforeCreate` default, Patch + Create wiring. Migration ID `202607090001`.
- **Go/Python/TS SDKs**: regenerated — `StopOnRunFinished` field in `Session`, `SessionCreateRequest`, `SessionPatchRequest`, builder methods.
- **UI** (`create-session-sheet.tsx`): Shadcn `Checkbox` added above the Advanced settings toggle, **checked by default**, with label "Stop session when agent is finished" and helper text. Unchecking keeps the sandbox alive after the run (debug mode).
