### PR TITLE
feat(skills): add jira-log skill for ENGPROD issue creation

### DIFF
--- a/skills/tooling/jira-log/SKILL.md
+++ b/skills/tooling/jira-log/SKILL.md
@@ -1,27 +1,21 @@
 ---
 name: jira-log
 description: >
-  Log a new Jira issue to the ENGPROD project with the ACP component pre-filled.
-  Gathers context to make issues agent-actionable from cold start. Use this
-  whenever work needs tracking in Jira -- creating stories, filing bugs, logging
-  tasks, opening spikes, or any time the user says "create a jira", "log this",
-  "file a bug", "new ticket", "open a story", "track this". Triggers on: "log
-  jira", "create jira", "file a bug", "new ticket", "open a story", "jira
-  issue", "track this work", "open a jira", "create a ticket".
+  Log one or more Jira issues to the ENGPROD project with the acp component
+  pre-filled. Gathers context to make issues agent-actionable from cold start.
+  Use this whenever work needs tracking in Jira -- creating stories, filing
+  bugs, logging tasks, opening spikes, creating epics, or any time the user says
+  "create a jira", "log this", "file a bug", "new ticket", "open a story",
+  "track this", "create tickets", "batch create", or provides a bullet list of
+  work items. Supports single tickets and batch creation from bullet lists.
+  Triggers on: "log jira", "create jira", "file a bug", "new ticket",
+  "open a story", "jira issue", "track this work", "open a jira",
+  "create a ticket", "create tickets", "batch tickets", "log these items".
 ---
 
 # Jira Issue Logger
 
-Create well-structured Jira issues in the ENGPROD project with the ACP (Agent Control Plane) component pre-filled.
-
-## Usage
-
-```text
-/jira-log Add dark mode toggle to session viewer
-/jira-log [Bug] Session list doesn't refresh after deletion
-/jira-log [Task] Migrate session queries to React Query v5
-/jira-log [Spike] Investigate MCP server connection pooling
-```
+Create well-structured Jira issues in the ENGPROD project with the `acp` (Agent Control Plane) component pre-filled. Every issue is built to be agent-actionable from a cold start — meaning another agent (or human) can pick it up and start working immediately without asking clarifying questions.
 
 ## User Input
 
@@ -29,53 +23,54 @@ Create well-structured Jira issues in the ENGPROD project with the ACP (Agent Co
 $ARGUMENTS
 ```
 
-You **MUST** consider the user input before proceeding (if not empty).
+Consider the user input before proceeding (if not empty).
 
-## Execution Steps
+## Recognizing Single vs Batch Mode
 
-### 1. Parse User Input
+**Single ticket** (default): The input is a sentence, paragraph, or block of text describing one piece of work.
 
-Extract from `$ARGUMENTS`:
+**Batch mode**: The input contains a markdown bullet list (lines starting with `- ` or `* `). Each top-level bullet becomes a separate ticket. Sub-bullets provide context for that ticket's description. The reason batch mode skips interactive prompting is that asking questions for each of 10+ tickets would be exhausting — instead, use sub-bullet context and reasonable defaults, then confirm the full batch before creating.
 
-- **Summary** (required): The title/summary of the issue
-- **Description** (optional): Detailed description
-- **Issue Type** (optional): Defaults to `Story`. Valid: `Bug`, `Task`, `Spike`. Normalize case (e.g. "bug" -> "Bug") and reject unrecognized values.
-- **Priority** (optional): Defaults to `Normal`
+## Execution
 
-If the user provides a simple sentence, use it as the summary. Multiple lines: first line is summary, rest is description.
+### Step 1 — Parse
 
-### 2. Gather Cold-Start Context
+Extract from user input, per ticket:
 
-To make the Jira actionable by an agent, gather context. Ask the user for missing critical info:
+| Field | Default | Notes |
+|-------|---------|-------|
+| Summary | (required) | Title of the issue |
+| Issue Type | Story | Also: Bug, Task, Spike, Epic. Normalize case. |
+| Priority | Normal | |
+| Description | (from context) | Sub-bullets, multi-line text, or gathered interactively |
+| Epic link | — | If a ticket should belong to an epic |
+| Blocking | — | "X blocks Y" relationships |
 
-**Required for Stories:**
-- User-facing goal (As a [user], I want [X], so that [Y])
-- Acceptance criteria (How do we know it's done)
-- Which component (e.g., `ambient-api-server`, `ambient-control-plane`, `ambient-ui`, `ambient-runner`)
+Type prefix syntax: `[Bug] Session crashes` → type=Bug, summary="Session crashes".
 
-**Required for Bugs:**
-- Steps to reproduce
-- Expected vs actual behaviour
-- Environment info if relevant
+### Step 2 — Gather Context (single ticket only)
 
-**Required for Spikes:**
-- Question to answer, expected deliverables, time-box
+To make a Jira actionable by an agent picking it up cold, gather the information they'd need. The specific info depends on the issue type:
 
-**Helpful for all types:**
-- Relevant file paths (e.g., `components/ambient-ui/src/...`)
-- Related issues/PRs/specs
-- Constraints or out-of-scope items
-- Testing requirements
+**Stories** need: a user story (As a [user], I want [X], so that [Y]), acceptance criteria, and the target component (e.g., `ambient-api-server`, `ambient-control-plane`, `ambient-ui`, `ambient-runner`).
 
-### 3. Build Structured Description
+**Bugs** need: steps to reproduce, expected vs actual behavior, and environment info if relevant.
 
-Use this agent-friendly template, omitting sections that don't apply:
+**Spikes** need: the question to answer, expected deliverables, and a time-box.
+
+**All types** benefit from: relevant file paths, related issues/PRs/specs, constraints, and testing requirements.
+
+In batch mode, skip this interactive step — use whatever context the sub-bullets provide and fill in reasonable defaults for the rest.
+
+### Step 3 — Build Description
+
+Use this template, dropping sections that don't apply:
 
 ```markdown
 ## Overview
-[One paragraph summary of what needs to be done and why]
+[One paragraph: what needs to be done and why]
 
-## User Story (for Stories)
+## User Story
 As a [type of user], I want [goal], so that [benefit].
 
 ## Acceptance Criteria
@@ -98,26 +93,26 @@ As a [type of user], I want [goal], so that [benefit].
 ## Testing Requirements
 - [ ] Unit tests for [X]
 
-## Bug Details (for Bugs only)
+## Bug Details
 **Steps to Reproduce**: ...
 **Expected**: ...
 **Actual**: ...
 
-## Spike Deliverables (for Spikes only)
+## Spike Deliverables
 - [ ] [Output: e.g. design doc, prototype, findings]
 **Time-box**: [e.g. 2 days]
 ```
 
-### 4. Confirm Details
+### Step 4 — Confirm
 
-Before creating, confirm with the user:
+**Single ticket:**
 
 ```
 About to create ENGPROD Jira:
 
 **Summary**: [extracted summary]
-**Type**: [Story/Bug/Task/Spike]
-**Component**: ACP
+**Type**: [Story/Bug/Task/Spike/Epic]
+**Component**: acp
 
 **Description Preview**:
 [First 500 chars of formatted description]
@@ -125,45 +120,81 @@ About to create ENGPROD Jira:
 Shall I create this issue? (yes/no/edit)
 ```
 
-### 5. Create the Jira Issue
+**Batch mode** — show a summary table:
+
+```
+About to create N ENGPROD tickets:
+
+| # | Type  | Summary                        | Epic          |
+|---|-------|--------------------------------|---------------|
+| 1 | Epic  | Feature X                      | —             |
+| 2 | Story | Implement Y                    | Feature X     |
+| 3 | Bug   | Fix Z                          | —             |
+
+Blocking: #2 blocks #3
+
+Create all? (yes/no/edit)
+```
+
+### Step 5 — Create
 
 Use `mcp__jira__jira_create_issue` with:
 
 ```json
 {
   "project_key": "ENGPROD",
-  "summary": "[user provided summary]",
-  "issue_type": "[Story|Bug|Task|Spike]",
-  "description": "[structured description]",
-  "components": "ACP",
+  "summary": "[summary]",
+  "issue_type": "[Story|Bug|Task|Spike|Epic]",
+  "description": "[structured description from step 3]",
+  "components": "acp",
   "additional_fields": "{\"labels\": [\"team:acp\"]}"
 }
 ```
 
-### 6. Report Success
+**Batch execution order** (the order matters because later steps depend on earlier ones):
+1. Create Epics first — their keys are needed for linking
+2. Create remaining tickets (Stories, Bugs, Tasks, Spikes)
+3. Link child tickets to their epics via `mcp__jira__jira_link_to_epic`
+4. Create blocking relationships via `mcp__jira__jira_create_issue_link` with `link_type: "Blocks"`
+5. Create related links via `mcp__jira__jira_create_issue_link` with `link_type: "Related"`
 
+### Step 6 — Report
+
+**Single ticket:**
 ```
 Created: [ISSUE_KEY]
 Link: https://redhat.atlassian.net/browse/[ISSUE_KEY]
 
 Summary: [summary]
-Component: ACP
+Component: acp
 Type: [issue type]
 Agent Cold-Start Ready: Yes
+```
+
+**Batch:**
+```
+Created N tickets:
+
+| Key            | Type  | Summary                        | Epic          |
+|----------------|-------|--------------------------------|---------------|
+| ENGPROD-XXXXX  | Epic  | Feature X                      | —             |
+| ENGPROD-XXXXX  | Story | Implement Y                    | Feature X     |
+| ENGPROD-XXXXX  | Bug   | Fix Z                          | —             |
+
+Links created:
+- ENGPROD-XXXXX blocks ENGPROD-XXXXX
+- ENGPROD-XXXXX → Epic ENGPROD-XXXXX
 ```
 
 ## Examples
 
 ### Quick Story
-
 ```
 /jira-log Add session filtering by project scope
 ```
-
-Will prompt for acceptance criteria, relevant files, etc.
+Prompts for acceptance criteria, relevant files, etc.
 
 ### Bug Report
-
 ```
 /jira-log [Bug] Session list doesn't refresh after deletion
 
@@ -180,7 +211,6 @@ Files: components/ambient-ui/src/components/session-list/
 ```
 
 ### Tech Debt Task
-
 ```
 /jira-log [Task] Add OwnerReferences to reconciler-created Secrets
 
@@ -190,8 +220,7 @@ Component: ambient-control-plane
 Files: components/ambient-control-plane/internal/reconciler/kube_reconciler.go
 ```
 
-### Research Spike
-
+### Spike
 ```
 /jira-log [Spike] Investigate MCP server connection pooling strategies
 
@@ -201,16 +230,30 @@ Deliverables: Findings doc with benchmarks
 Time-box: 3 days
 ```
 
+### Batch
+```
+/jira-log
+- [Epic] User Onboarding Flow
+- Implement SSO login page
+  - Component: ambient-ui
+  - Acceptance: user can log in via Keycloak
+- [Task] Add onboarding docs
+  - Component: docs
+- [Bug] Login redirect fails on Safari
+  - Steps: open Safari, click login, observe redirect loop
+```
+Creates 1 epic + 2 stories + 1 bug, links stories to the epic.
+
 ## Field Reference
 
 | Field | Value | Notes |
 |-------|-------|-------|
 | Project | ENGPROD | Engineering Productivity |
-| Component | ACP | Agent Control Plane |
+| Component | acp | Agent Control Plane |
 | Label | `team:acp` | Set on create |
-| Issue Type | Story | Default; also Bug, Task, Spike |
+| Issue Type | Story | Default; also Bug, Task, Spike, Epic |
 | Browse URL | `https://redhat.atlassian.net/browse/` | |
 
-## Agent Cold-Start Checklist
+## What Makes a Jira Agent-Actionable
 
-A Jira is agent-actionable when it has: a user story (who/why), acceptance criteria (definition of done), repo + file paths (where to edit), constraints (what not to do), and testing requirements (expected coverage). Bug reports additionally need repro steps. Spikes need deliverables and a time-box.
+A Jira is ready for cold-start work when it has: a user story (who/why), acceptance criteria (definition of done), repo + file paths (where to edit), constraints (what not to do), and testing requirements (expected coverage). Bug reports additionally need repro steps. Spikes need deliverables and a time-box.

--- a/skills/tooling/jira-log/SKILL.md
+++ b/skills/tooling/jira-log/SKILL.md
@@ -214,7 +214,3 @@ Time-box: 3 days
 ## Agent Cold-Start Checklist
 
 A Jira is agent-actionable when it has: a user story (who/why), acceptance criteria (definition of done), repo + file paths (where to edit), constraints (what not to do), and testing requirements (expected coverage). Bug reports additionally need repro steps. Spikes need deliverables and a time-box.
-
-## Context
-
-$ARGUMENTS

--- a/skills/tooling/jira-log/SKILL.md
+++ b/skills/tooling/jira-log/SKILL.md
@@ -45,6 +45,7 @@ Extract from user input, per ticket:
 | Description | (from context) | Sub-bullets, multi-line text, or gathered interactively |
 | Epic link | — | If a ticket should belong to an epic |
 | Blocking | — | "X blocks Y" relationships |
+| Related | — | "X related to Y" relationships |
 
 Type prefix syntax: `[Bug] Session crashes` → type=Bug, summary="Session crashes".
 
@@ -56,11 +57,13 @@ To make a Jira actionable by an agent picking it up cold, gather the information
 
 **Bugs** need: steps to reproduce, expected vs actual behavior, and environment info if relevant.
 
-**Spikes** need: the question to answer, expected deliverables, and a time-box.
+**Spikes** need: the question to answer, expected deliverables, and a time-box. Always include a time-box — spikes without one tend to expand indefinitely.
+
+**Epics** need: a high-level overview of the initiative and the child stories/tasks that make it up. Epics are containers, so they don't need Testing Requirements or Acceptance Criteria of their own — their children carry those.
 
 **All types** benefit from: relevant file paths, related issues/PRs/specs, constraints, and testing requirements.
 
-In batch mode, skip this interactive step — use whatever context the sub-bullets provide and fill in reasonable defaults for the rest.
+In batch mode, skip this interactive step — use whatever context the sub-bullets provide and fill in reasonable defaults for the rest. But don't skip content just because it's batch: every non-Epic ticket still needs Testing Requirements and Relevant Paths in its description, even if you have to infer them from the component. Going back to add these later is painful.
 
 ### Step 3 — Build Description
 
@@ -103,6 +106,13 @@ As a [type of user], I want [goal], so that [benefit].
 **Time-box**: [e.g. 2 days]
 ```
 
+**Section guidance by type:**
+- **Epics**: Overview only. No Acceptance Criteria, Testing Requirements, or User Story — those belong on the children.
+- **Stories**: Overview, User Story, Acceptance Criteria, Technical Context (with Relevant Paths), Testing Requirements.
+- **Bugs**: Overview, Bug Details (Steps/Expected/Actual), Technical Context (with Relevant Paths), Testing Requirements.
+- **Tasks**: Overview, Acceptance Criteria, Technical Context (with Relevant Paths), Testing Requirements.
+- **Spikes**: Overview, Spike Deliverables (must include Time-box), Technical Context (with Relevant Paths).
+
 ### Step 4 — Confirm
 
 **Single ticket:**
@@ -132,6 +142,7 @@ About to create N ENGPROD tickets:
 | 3 | Bug   | Fix Z                          | —             |
 
 Blocking: #2 blocks #3
+Related: #4 related to #5
 
 Create all? (yes/no/edit)
 ```
@@ -157,6 +168,10 @@ Use `mcp__jira__jira_create_issue` with:
 3. Link child tickets to their epics via `mcp__jira__jira_link_to_epic`
 4. Create blocking relationships via `mcp__jira__jira_create_issue_link` with `link_type: "Blocks"`
 5. Create related links via `mcp__jira__jira_create_issue_link` with `link_type: "Related"`
+
+**Important**: the Jira link type for related issues is `"Related"` (not "Relates"). Using the wrong name silently fails.
+
+Parallelize where possible: all epics can be created in parallel, then all non-epics in parallel, then all links in parallel. But each phase must complete before the next begins.
 
 ### Step 6 — Report
 
@@ -244,16 +259,41 @@ Time-box: 3 days
 ```
 Creates 1 epic + 2 stories + 1 bug, links stories to the epic.
 
+### Batch with Blocking
+```
+/jira-log
+- [Epic] RBAC Hardening
+- [Task] Audit existing ClusterRole permissions
+  - Component: manifests
+  - Files: components/manifests/base/rbac/
+  - blocks: Implement namespace-scoped RBAC
+- [Story] Implement namespace-scoped RBAC for sessions
+  - Component: ambient-api-server
+  - Acceptance: users can only see sessions in their namespace
+- [Spike] Investigate OPA integration for policy enforcement
+  - Deliverables: findings doc with recommendation
+  - Time-box: 3 days
+```
+Creates 1 epic + 1 story + 1 task + 1 spike, links all to the epic, creates blocking relationship from audit → RBAC story.
+
 ## Field Reference
 
 | Field | Value | Notes |
 |-------|-------|-------|
 | Project | ENGPROD | Engineering Productivity |
-| Component | acp | Agent Control Plane |
+| Component | acp | Agent Control Plane (lowercase) |
 | Label | `team:acp` | Set on create |
 | Issue Type | Story | Default; also Bug, Task, Spike, Epic |
 | Browse URL | `https://redhat.atlassian.net/browse/` | |
+| Board | 348 | ENGPROD kanban board (no sprints) |
+
+## Jira Link Types
+
+| Relationship | `link_type` value | Notes |
+|-------------|-------------------|-------|
+| Blocking | `"Blocks"` | inward issue blocks outward issue |
+| Related | `"Related"` | Not "Relates" — wrong name silently fails |
 
 ## What Makes a Jira Agent-Actionable
 
-A Jira is ready for cold-start work when it has: a user story (who/why), acceptance criteria (definition of done), repo + file paths (where to edit), constraints (what not to do), and testing requirements (expected coverage). Bug reports additionally need repro steps. Spikes need deliverables and a time-box.
+A Jira is ready for cold-start work when it has: a user story (who/why), acceptance criteria (definition of done), repo + file paths (where to edit), constraints (what not to do), and testing requirements (expected coverage). Bug reports additionally need repro steps. Spikes need deliverables and a time-box. Epics need an overview and linked children — their actionability comes from the children being well-structured, not from the epic itself.

--- a/skills/tooling/jira-log/SKILL.md
+++ b/skills/tooling/jira-log/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: jira-log
+description: >
+  Log a new Jira issue to the ENGPROD project with the ACP component pre-filled.
+  Gathers context to make issues agent-actionable from cold start. Use this
+  whenever work needs tracking in Jira -- creating stories, filing bugs, logging
+  tasks, opening spikes, or any time the user says "create a jira", "log this",
+  "file a bug", "new ticket", "open a story", "track this". Triggers on: "log
+  jira", "create jira", "file a bug", "new ticket", "open a story", "jira
+  issue", "track this work", "open a jira", "create a ticket".
+---
+
+# Jira Issue Logger
+
+Create well-structured Jira issues in the ENGPROD project with the ACP (Agent Control Plane) component pre-filled.
+
+## Usage
+
+```text
+/jira-log Add dark mode toggle to session viewer
+/jira-log [Bug] Session list doesn't refresh after deletion
+/jira-log [Task] Migrate session queries to React Query v5
+/jira-log [Spike] Investigate MCP server connection pooling
+```
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Execution Steps
+
+### 1. Parse User Input
+
+Extract from `$ARGUMENTS`:
+
+- **Summary** (required): The title/summary of the issue
+- **Description** (optional): Detailed description
+- **Issue Type** (optional): Defaults to `Story`. Valid: `Bug`, `Task`, `Spike`. Normalize case (e.g. "bug" -> "Bug") and reject unrecognized values.
+- **Priority** (optional): Defaults to `Normal`
+
+If the user provides a simple sentence, use it as the summary. Multiple lines: first line is summary, rest is description.
+
+### 2. Gather Cold-Start Context
+
+To make the Jira actionable by an agent, gather context. Ask the user for missing critical info:
+
+**Required for Stories:**
+- User-facing goal (As a [user], I want [X], so that [Y])
+- Acceptance criteria (How do we know it's done)
+- Which component (e.g., `ambient-api-server`, `ambient-control-plane`, `ambient-ui`, `ambient-runner`)
+
+**Required for Bugs:**
+- Steps to reproduce
+- Expected vs actual behaviour
+- Environment info if relevant
+
+**Required for Spikes:**
+- Question to answer, expected deliverables, time-box
+
+**Helpful for all types:**
+- Relevant file paths (e.g., `components/ambient-ui/src/...`)
+- Related issues/PRs/specs
+- Constraints or out-of-scope items
+- Testing requirements
+
+### 3. Build Structured Description
+
+Use this agent-friendly template, omitting sections that don't apply:
+
+```markdown
+## Overview
+[One paragraph summary of what needs to be done and why]
+
+## User Story (for Stories)
+As a [type of user], I want [goal], so that [benefit].
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+## Technical Context
+**Repo**: openshift-online/agent-control-plane
+**Component**: [e.g. ambient-api-server, ambient-control-plane, ambient-ui, ambient-runner]
+**Relevant Paths**:
+- `components/[component]/path/to/relevant/file`
+
+## Related Links
+- Spec: [link to relevant spec in specs/]
+- Related Issues: [ENGPROD-XXXX]
+
+## Constraints
+- [What NOT to do]
+
+## Testing Requirements
+- [ ] Unit tests for [X]
+
+## Bug Details (for Bugs only)
+**Steps to Reproduce**: ...
+**Expected**: ...
+**Actual**: ...
+
+## Spike Deliverables (for Spikes only)
+- [ ] [Output: e.g. design doc, prototype, findings]
+**Time-box**: [e.g. 2 days]
+```
+
+### 4. Confirm Details
+
+Before creating, confirm with the user:
+
+```
+About to create ENGPROD Jira:
+
+**Summary**: [extracted summary]
+**Type**: [Story/Bug/Task/Spike]
+**Component**: ACP
+
+**Description Preview**:
+[First 500 chars of formatted description]
+
+Shall I create this issue? (yes/no/edit)
+```
+
+### 5. Create the Jira Issue
+
+Use `mcp__jira__jira_create_issue` with:
+
+```json
+{
+  "project_key": "ENGPROD",
+  "summary": "[user provided summary]",
+  "issue_type": "[Story|Bug|Task|Spike]",
+  "description": "[structured description]",
+  "components": "ACP",
+  "additional_fields": "{\"labels\": [\"team:acp\"]}"
+}
+```
+
+### 6. Report Success
+
+```
+Created: [ISSUE_KEY]
+Link: https://redhat.atlassian.net/browse/[ISSUE_KEY]
+
+Summary: [summary]
+Component: ACP
+Type: [issue type]
+Agent Cold-Start Ready: Yes
+```
+
+## Examples
+
+### Quick Story
+
+```
+/jira-log Add session filtering by project scope
+```
+
+Will prompt for acceptance criteria, relevant files, etc.
+
+### Bug Report
+
+```
+/jira-log [Bug] Session list doesn't refresh after deletion
+
+Steps:
+1. Create a session
+2. Delete the session via UI
+3. Observe the list
+
+Expected: Session disappears from list
+Actual: Session remains until page refresh
+
+Component: ambient-ui
+Files: components/ambient-ui/src/components/session-list/
+```
+
+### Tech Debt Task
+
+```
+/jira-log [Task] Add OwnerReferences to reconciler-created Secrets
+
+Control plane creates Secrets without OwnerReferences, leaving orphans.
+
+Component: ambient-control-plane
+Files: components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+```
+
+### Research Spike
+
+```
+/jira-log [Spike] Investigate MCP server connection pooling strategies
+
+Questions: Can we pool connections? What's the memory overhead?
+Component: ambient-mcp
+Deliverables: Findings doc with benchmarks
+Time-box: 3 days
+```
+
+## Field Reference
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| Project | ENGPROD | Engineering Productivity |
+| Component | ACP | Agent Control Plane |
+| Label | `team:acp` | Set on create |
+| Issue Type | Story | Default; also Bug, Task, Spike |
+| Browse URL | `https://redhat.atlassian.net/browse/` | |
+
+## Agent Cold-Start Checklist
+
+A Jira is agent-actionable when it has: a user story (who/why), acceptance criteria (definition of done), repo + file paths (where to edit), constraints (what not to do), and testing requirements (expected coverage). Bug reports additionally need repro steps. Spikes need deliverables and a time-box.
+
+## Context
+
+$ARGUMENTS

--- a/skills/tooling/jira-log/evals/evals.json
+++ b/skills/tooling/jira-log/evals/evals.json
@@ -28,5 +28,23 @@
     "expected_tool_call": "Skill",
     "expected_args": { "skill": "jira-log", "args": "[Spike] Evaluate gRPC streaming alternatives" },
     "description": "Spike issue type creation"
+  },
+  {
+    "input": "/jira-log\n- [Epic] Observability Overhaul\n- Add structured logging to control plane\n  - Component: ambient-control-plane\n  - Files: components/ambient-control-plane/internal/reconciler/\n- Add Prometheus metrics endpoint\n  - Component: ambient-api-server\n  - Acceptance: /metrics endpoint returns request latency and error rate\n- [Task] Configure Grafana dashboards for SLOs\n  - Component: manifests",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "[Epic] Observability Overhaul\n- Add structured logging to control plane\n  - Component: ambient-control-plane\n  - Files: components/ambient-control-plane/internal/reconciler/\n- Add Prometheus metrics endpoint\n  - Component: ambient-api-server\n  - Acceptance: /metrics endpoint returns request latency and error rate\n- [Task] Configure Grafana dashboards for SLOs\n  - Component: manifests" },
+    "description": "Batch creation with epic, stories, and task — verifies epic-first ordering and child linking"
+  },
+  {
+    "input": "/jira-log\n- [Bug] Runner crashes on empty prompt\n  - Steps: create session with empty prompt, observe crash\n  - Component: ambient-runner\n- [Bug] UI shows stale session status after deletion\n  - Steps: delete session, observe list still shows it\n  - Component: ambient-ui\n- [Task] Add retry logic to gRPC watch stream\n  - Component: ambient-control-plane\n  - Files: components/ambient-control-plane/internal/reconciler/kube_reconciler.go",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "[Bug] Runner crashes on empty prompt\n  - Steps: create session with empty prompt, observe crash\n  - Component: ambient-runner\n- [Bug] UI shows stale session status after deletion\n  - Steps: delete session, observe list still shows it\n  - Component: ambient-ui\n- [Task] Add retry logic to gRPC watch stream\n  - Component: ambient-control-plane\n  - Files: components/ambient-control-plane/internal/reconciler/kube_reconciler.go" },
+    "description": "Batch with multiple bugs and a task — no epic, verifies flat batch without linking"
+  },
+  {
+    "input": "/jira-log\n- [Epic] RBAC Hardening\n- [Story] Implement namespace-scoped RBAC for sessions\n  - Component: ambient-api-server\n  - Acceptance: users can only see sessions in their namespace\n- [Spike] Investigate OPA integration for policy enforcement\n  - Deliverables: findings doc with recommendation\n  - Time-box: 3 days\n- [Task] Audit existing ClusterRole permissions\n  - Component: manifests\n  - Files: components/manifests/base/rbac/\n  - blocks: Implement namespace-scoped RBAC",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "[Epic] RBAC Hardening\n- [Story] Implement namespace-scoped RBAC for sessions\n  - Component: ambient-api-server\n  - Acceptance: users can only see sessions in their namespace\n- [Spike] Investigate OPA integration for policy enforcement\n  - Deliverables: findings doc with recommendation\n  - Time-box: 3 days\n- [Task] Audit existing ClusterRole permissions\n  - Component: manifests\n  - Files: components/manifests/base/rbac/\n  - blocks: Implement namespace-scoped RBAC" },
+    "description": "Batch with epic, story, spike, task, and blocking relationship — verifies mixed types, spike time-box, and cross-ticket blocking"
   }
 ]

--- a/skills/tooling/jira-log/evals/evals.json
+++ b/skills/tooling/jira-log/evals/evals.json
@@ -1,0 +1,32 @@
+[
+  {
+    "input": "/jira-log Add dark mode toggle to session viewer",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "Add dark mode toggle to session viewer" },
+    "description": "Quick story creation with summary only"
+  },
+  {
+    "input": "/jira-log [Bug] Session list doesn't refresh after deletion",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "[Bug] Session list doesn't refresh after deletion" },
+    "description": "Bug report with type prefix"
+  },
+  {
+    "input": "create a jira for adding OwnerReferences to reconciler secrets",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "adding OwnerReferences to reconciler secrets" },
+    "description": "Natural language Jira creation request"
+  },
+  {
+    "input": "log a ticket for the MCP connection pooling investigation",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "MCP connection pooling investigation" },
+    "description": "Natural language ticket logging request"
+  },
+  {
+    "input": "/jira-log [Spike] Evaluate gRPC streaming alternatives",
+    "expected_tool_call": "Skill",
+    "expected_args": { "skill": "jira-log", "args": "[Spike] Evaluate gRPC streaming alternatives" },
+    "description": "Spike issue type creation"
+  }
+]


### PR DESCRIPTION
## Summary

Adds the `jira-log` skill for creating well-structured Jira issues in the **ENGPROD** project with the **acp** component pre-filled. Issues are templated for agent cold-start readability — another agent or human can pick up any created ticket and start working immediately.

Features:
- **Single ticket mode**: Interactive context gathering (user story, acceptance criteria, repro steps, etc.) tailored to issue type
- **Batch mode**: Bulk creation from markdown bullet lists with automatic epic linking and blocking relationships
- **Issue types**: Story, Bug, Task, Spike, Epic
- **Execution ordering**: Epics created first, then children linked, then blocking/related relationships established
- **Agent-actionable templates**: Structured descriptions with Overview, Acceptance Criteria, Technical Context, Testing Requirements, and type-specific sections

Component is lowercase `acp` to match the Jira component name. Label `team:acp` applied on create.

## Test plan

- [ ] Verify `/jira-log` skill triggers correctly for single ticket
- [ ] Test batch mode with bullet list input containing epics, stories, and blocking relationships
- [ ] Confirm each issue type (Story, Bug, Task, Spike, Epic) creates with correct template
- [ ] Verify `acp` component and `team:acp` label applied on all created issues