### PR TITLE
feat(cli): add acpctl get gateway with connection info and --setup

### DIFF
--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -230,21 +230,6 @@ jobs:
 
         PF_DIR=/tmp/ambient-code ./scripts/setup-gateway-cli.sh tenant-a
 
-        # setup-gateway-cli.sh sets up port-forwards but no longer auto-registers
-        # gateways. Register the mTLS gateway so the e2e test can use it.
-        GW_PORT=$(cat /tmp/ambient-code/kind-pf-openshell-tenant-a.log | grep -oE 'Forwarding from 127\.0\.0\.1:[0-9]+' | grep -oE '[0-9]+$' | head -1)
-        if [ -n "$GW_PORT" ]; then
-          CERT_DIR="$HOME/.config/openshell/gateways/tenant-a/mtls"
-          openshell gateway add --name tenant-a --local "https://localhost:${GW_PORT}"
-          # Re-extract certs after registration (gateway add may overwrite them)
-          kubectl get secret openshell-server-tls -n tenant-a \
-            -o jsonpath='{.data.ca\.crt}' | base64 -d > "$CERT_DIR/ca.crt"
-          kubectl get secret openshell-server-tls -n tenant-a \
-            -o jsonpath='{.data.tls\.crt}' | base64 -d > "$CERT_DIR/tls.crt"
-          kubectl get secret openshell-server-tls -n tenant-a \
-            -o jsonpath='{.data.tls\.key}' | base64 -d > "$CERT_DIR/tls.key"
-        fi
-
         TEST_TOKEN=$(kubectl get secret test-user-token -n ambient-code -o jsonpath='{.data.token}' | base64 -d) \
         API_URL=http://localhost:13592 \
         bash tests/e2e/gateway-e2e-test.sh || {

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 .PHONY: local-dev-token
 .PHONY: local-logs local-logs-api-server local-logs-ui local-logs-control-plane local-shell-api-server local-shell-ui
 .PHONY: local-test local-test-dev local-test-quick test-all local-troubleshoot local-port-forward local-stop-port-forward
-.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-reload-ambient-control-plane kind-reload-ambient-api-server kind-reload-runner-openshell kind-load-runner kind-status kind-login kind-sso-toggle kind-setup-vertex kind-setup-openshell-cli kind-setup-openshell-cli-stop
+.PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-reload-ambient-control-plane kind-reload-ambient-api-server kind-reload-runner-openshell kind-load-runner kind-status kind-login kind-sso-toggle kind-setup-vertex
 .PHONY: preflight-cluster preflight dev-env dev
 .PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift test-gateway-e2e test-vteam-catalog-lab
 .PHONY: unleash-port-forward unleash-status
-.PHONY: kind-port-forward kind-port-forward-stop _kind-start-port-forward kind-acpctl-login kind-apply-examples
+.PHONY: kind-port-forward kind-port-forward-stop _kind-start-port-forward _kind-print-access kind-acpctl-login kind-apply-examples
 .PHONY: setup-minio minio-console minio-logs minio-status
 .PHONY: validate-makefile lint-makefile check-shell makefile-health benchmark benchmark-ci
 .PHONY: _create-operator-config _auto-port-forward _show-access-info _kind-load-images _kind-preload-runner
@@ -1031,25 +1031,7 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for ambient-ui to pick up SSO config..."
 	@kubectl wait --for=condition=ready pod -l app=ambient-ui -n $(NAMESPACE) --timeout=60s >/dev/null 2>&1
 	@$(MAKE) --no-print-directory _kind-start-port-forward
-	@echo ""
-	@echo "$(COLOR_BOLD)Access the platform:$(COLOR_RESET)"
-	@echo "  Cluster:  $(KIND_CLUSTER_NAME)"
-	@echo ""
-	@echo "  Frontend:   http://localhost:$(KIND_FWD_FRONTEND_PORT)"
-	@echo "  Backend:    http://localhost:$(KIND_FWD_BACKEND_PORT)"
-	@echo "  Ambient UI: http://localhost:$(KIND_FWD_AMBIENT_UI_PORT)"
-	@echo "  Keycloak:   http://localhost:$(KIND_FWD_KEYCLOAK_PORT)"
-	@echo ""
-	@echo "$(COLOR_BOLD)Default SSO users:$(COLOR_RESET)"
-	@echo "  Developer: developer / developer (ambient-users group)"
-	@echo "  Admin:     admin / admin (ambient-users, ambient-admins groups)"
-	@echo ""
-	@echo "  Get test token: kubectl get secret test-user-token -n ambient-code -o jsonpath='{.data.token}' | base64 -d"
-	@echo ""
-	@echo "  Configure CLI:      $(COLOR_BOLD)make kind-acpctl-login$(COLOR_RESET)"
-	@echo "  Setup OpenShell:    $(COLOR_BOLD)make kind-setup-openshell-cli$(COLOR_RESET)"
-	@echo "  Stop port-forwards: $(COLOR_BOLD)make kind-port-forward-stop$(COLOR_RESET)"
-	@echo "  Run tests:          $(COLOR_BOLD)make test-e2e$(COLOR_RESET)"
+	@$(MAKE) --no-print-directory _kind-print-access
 
 kind-down: ## Stop and delete kind cluster
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Cleaning up kind cluster '$(KIND_CLUSTER_NAME)'..."
@@ -1068,38 +1050,11 @@ kind-login: check-kubectl check-local-context ## Set kubectl context, port-forwa
 		kubectl config use-context kind-$(KIND_CLUSTER_NAME); \
 	fi
 	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) kubeconfig set to kind-$(KIND_CLUSTER_NAME)"
-	@echo ""
-	@echo "Starting port-forwards..."
-	@pkill -f "port-forward.*ambient-api-server" 2>/dev/null || true
-	@pkill -f "port-forward.*ambient-ui-service" 2>/dev/null || true
-	@kubectl port-forward -n $(NAMESPACE) svc/ambient-api-server $(KIND_FWD_API_SERVER_PORT):8000 >/tmp/pf-api-server.log 2>&1 & \
-		sleep 1; \
-		echo "$(COLOR_GREEN)✓$(COLOR_RESET) ambient-api-server → http://localhost:$(KIND_FWD_API_SERVER_PORT)"
-	@kubectl port-forward -n $(NAMESPACE) svc/ambient-ui-service $(KIND_FWD_FRONTEND_PORT):3000 >/tmp/pf-ui.log 2>&1 & \
-		sleep 1; \
-		echo "$(COLOR_GREEN)✓$(COLOR_RESET) frontend          → http://localhost:$(KIND_FWD_FRONTEND_PORT)"
-	@echo ""
-	@echo "Configuring acpctl..."
-	@TOKEN=$$(kubectl get secret test-user-token -n $(NAMESPACE) -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null); \
-	if [ -z "$$TOKEN" ]; then \
-		echo "$(COLOR_YELLOW)Warning: test-user-token not found — acpctl not configured$(COLOR_RESET)"; \
-	else \
-		components/ambient-cli/acpctl login --url http://localhost:$(KIND_FWD_API_SERVER_PORT) --token "$$TOKEN" 2>/dev/null || \
-			./acpctl login --url http://localhost:$(KIND_FWD_API_SERVER_PORT) --token "$$TOKEN" 2>/dev/null || \
-			echo "$(COLOR_YELLOW)Warning: acpctl not built — run 'make build-cli' first$(COLOR_RESET)"; \
-		echo "$(COLOR_GREEN)✓$(COLOR_RESET) acpctl configured: http://localhost:$(KIND_FWD_API_SERVER_PORT)"; \
-		echo ""; \
-		echo "Test token:"; \
-		echo "$$TOKEN"; \
-	fi
+	@$(MAKE) --no-print-directory kind-port-forward
+	@$(MAKE) --no-print-directory kind-acpctl-login
 
-kind-acpctl-login: check-kubectl ## Configure acpctl CLI against the kind cluster
-	@TOKEN=$$(kubectl get secret test-user-token -n $(NAMESPACE) -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null); \
-	if [ -z "$$TOKEN" ]; then \
-		echo "$(COLOR_RED)\u2717$(COLOR_RESET) test-user-token not found in namespace $(NAMESPACE)"; \
-		exit 1; \
-	fi; \
-	ACPCTL=""; \
+kind-acpctl-login: check-kubectl ## Configure acpctl CLI against the kind cluster (OIDC via Keycloak)
+	@ACPCTL=""; \
 	if command -v acpctl >/dev/null 2>&1; then \
 		ACPCTL=acpctl; \
 	elif [ -x components/ambient-cli/acpctl ]; then \
@@ -1108,12 +1063,17 @@ kind-acpctl-login: check-kubectl ## Configure acpctl CLI against the kind cluste
 		ACPCTL=./acpctl; \
 	fi; \
 	if [ -n "$$ACPCTL" ]; then \
-		$$ACPCTL login --url http://localhost:$(KIND_FWD_BACKEND_PORT) --token "$$TOKEN" && \
-		echo "$(COLOR_GREEN)\u2713$(COLOR_RESET) acpctl configured: http://localhost:$(KIND_FWD_BACKEND_PORT)"; \
+		$$ACPCTL login --password-grant \
+			--username $${KIND_DEV_USERNAME:-developer} \
+			--password $${KIND_DEV_PASSWORD:-developer} \
+			--issuer-url http://localhost:$(KIND_FWD_KEYCLOAK_PORT)/realms/ambient-code \
+			--client-id openshell-cli \
+			--url http://localhost:$(KIND_FWD_BACKEND_PORT) && \
+		echo "$(COLOR_GREEN)\u2713$(COLOR_RESET) acpctl configured (OIDC): http://localhost:$(KIND_FWD_BACKEND_PORT)"; \
 	else \
-		echo "$(COLOR_YELLOW)acpctl not found — build it first: make build-cli$(COLOR_RESET)"; \
+		echo "$(COLOR_YELLOW)acpctl not found \u2014 build it first: make build-cli$(COLOR_RESET)"; \
 		echo "  Then run manually:"; \
-		echo "  acpctl login --url http://localhost:$(KIND_FWD_BACKEND_PORT) --token $$TOKEN"; \
+		echo "  acpctl login --password-grant --username developer --password developer --issuer-url http://localhost:$(KIND_FWD_KEYCLOAK_PORT)/realms/ambient-code --client-id openshell-cli --url http://localhost:$(KIND_FWD_BACKEND_PORT)"; \
 	fi
 
 kind-apply-examples: ## Apply example resources (projects, providers, agents, credentials) to the cluster via acpctl
@@ -1160,19 +1120,36 @@ kind-port-forward: check-kubectl check-local-context ## Port-forward kind servic
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Waiting for ambient-ui to be ready..."
 	@kubectl wait --for=condition=ready pod -l app=ambient-ui -n $(NAMESPACE) --timeout=60s >/dev/null 2>&1
 	@$(MAKE) --no-print-directory _kind-start-port-forward
+	@$(MAKE) --no-print-directory _kind-print-access
+
+_kind-print-access:
 	@echo ""
-	@echo "$(COLOR_GREEN)✓$(COLOR_RESET) Port forwarding started in background"
+	@echo "$(COLOR_BOLD)Access the platform:$(COLOR_RESET)"
+	@echo "  Cluster:  $(KIND_CLUSTER_NAME)"
 	@echo ""
 	@echo "  Frontend:   http://localhost:$(KIND_FWD_FRONTEND_PORT)"
 	@echo "  Backend:    http://localhost:$(KIND_FWD_BACKEND_PORT)"
 	@echo "  Ambient UI: http://localhost:$(KIND_FWD_AMBIENT_UI_PORT)"
 	@echo "  Keycloak:   http://localhost:$(KIND_FWD_KEYCLOAK_PORT)"
+	@for PORT_FILE in $(KIND_PF_DIR)/kind-pf-openshell-*.port; do \
+		[ -f "$$PORT_FILE" ] || continue; \
+		NS=$$(basename "$$PORT_FILE" .port | sed 's/^kind-pf-openshell-//'); \
+		PORT=$$(cat "$$PORT_FILE"); \
+		if [ -n "$$PORT" ]; then \
+			echo "  Gateway ($$NS): https://localhost:$$PORT"; \
+		fi; \
+	done
 	@echo ""
 	@echo "$(COLOR_BOLD)Default SSO users:$(COLOR_RESET)"
-	@echo "  Developer: developer / developer"
-	@echo "  Admin:     admin / admin"
+	@echo "  Developer: developer / developer (ambient-users group)"
+	@echo "  Admin:     admin / admin (ambient-users, ambient-admins groups)"
 	@echo ""
-	@echo "  Stop with: $(COLOR_BOLD)make kind-port-forward-stop$(COLOR_RESET)"
+	@echo "  Get test token: kubectl get secret test-user-token -n ambient-code -o jsonpath='{.data.token}' | base64 -d"
+	@echo ""
+	@echo "  Configure CLI:      $(COLOR_BOLD)make kind-acpctl-login$(COLOR_RESET)"
+	@echo "  Setup openshell:    $(COLOR_BOLD)acpctl gateway setup-cli <name> --gateway-url https://localhost:<port>$(COLOR_RESET)"
+	@echo "  Stop port-forwards: $(COLOR_BOLD)make kind-port-forward-stop$(COLOR_RESET)"
+	@echo "  Run tests:          $(COLOR_BOLD)make test-e2e$(COLOR_RESET)"
 
 _kind-start-port-forward:
 	@$(MAKE) --no-print-directory kind-port-forward-stop 2>/dev/null || true
@@ -1181,6 +1158,17 @@ _kind-start-port-forward:
 	@kubectl port-forward -n $(NAMESPACE) svc/ambient-api-server $(KIND_FWD_BACKEND_PORT):8000 >$(KIND_PF_DIR)/kind-pf-backend.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-backend.pid
 	@kubectl port-forward -n $(NAMESPACE) svc/ambient-ui-service $(KIND_FWD_AMBIENT_UI_PORT):3000 >$(KIND_PF_DIR)/kind-pf-ambient-ui.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-ambient-ui.pid
 	@kubectl port-forward -n $(NAMESPACE) svc/keycloak-service $(KIND_FWD_KEYCLOAK_PORT):11880 >$(KIND_PF_DIR)/kind-pf-keycloak.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-keycloak.pid
+	@# Discover and port-forward openshell gateways on deterministic ports
+	@GW_NAMESPACES=$$(kubectl get pods --all-namespaces -l app.kubernetes.io/instance=openshell-gateway -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null | sort -u); \
+	OFFSET=0; \
+	for NS in $$GW_NAMESPACES; do \
+		PORT=$$(($(KIND_FWD_GATEWAY_BASE_PORT) + $$OFFSET)); \
+		kubectl port-forward -n "$$NS" statefulset/openshell-gateway $$PORT:8080 \
+			>"$(KIND_PF_DIR)/kind-pf-openshell-$$NS.log" 2>&1 & \
+		echo $$! > "$(KIND_PF_DIR)/kind-pf-openshell-$$NS.pid"; \
+		echo "$$PORT" > "$(KIND_PF_DIR)/kind-pf-openshell-$$NS.port"; \
+		OFFSET=$$(($$OFFSET + 1)); \
+	done
 	@sleep 1
 	@FAILED=0; \
 	for svc in frontend backend ambient-ui keycloak; do \
@@ -1190,6 +1178,18 @@ _kind-start-port-forward:
 		else \
 			echo "$(COLOR_RED)✗$(COLOR_RESET) $$svc port-forward failed to start (check $(KIND_PF_DIR)/kind-pf-$$svc.log)"; \
 			FAILED=1; \
+		fi; \
+	done; \
+	for PID_FILE in $(KIND_PF_DIR)/kind-pf-openshell-*.pid; do \
+		[ -f "$$PID_FILE" ] || continue; \
+		NS=$$(basename "$$PID_FILE" .pid | sed 's/^kind-pf-openshell-//'); \
+		if ps -p $$(cat "$$PID_FILE") >/dev/null 2>&1; then \
+			PORT=$$(cat "$(KIND_PF_DIR)/kind-pf-openshell-$$NS.port" 2>/dev/null); \
+			if [ -n "$$PORT" ]; then \
+				echo "$(COLOR_GREEN)✓$(COLOR_RESET) openshell-gateway ($$NS) -> localhost:$$PORT"; \
+			fi; \
+		else \
+			echo "$(COLOR_RED)✗$(COLOR_RESET) openshell-gateway ($$NS) port-forward failed (check $(KIND_PF_DIR)/kind-pf-openshell-$$NS.log)"; \
 		fi; \
 	done; \
 	if [ "$$FAILED" -ne 0 ]; then exit 1; fi
@@ -1208,6 +1208,19 @@ kind-port-forward-stop: ## Stop background kind port-forwarding
 			rm -f "$$PID_FILE"; \
 		fi; \
 		rm -f "$(KIND_PF_DIR)/kind-pf-$$svc.log"; \
+	done; \
+	for PID_FILE in $(KIND_PF_DIR)/kind-pf-openshell-*.pid; do \
+		[ -f "$$PID_FILE" ] || continue; \
+		NS=$$(basename "$$PID_FILE" .pid | sed 's/^kind-pf-openshell-//'); \
+		PID=$$(cat "$$PID_FILE"); \
+		if ps -p "$$PID" >/dev/null 2>&1; then \
+			kill "$$PID" 2>/dev/null || true; \
+			echo "  Stopped openshell-gateway ($$NS) port-forward (PID $$PID)"; \
+			STOPPED=1; \
+		fi; \
+		rm -f "$$PID_FILE"; \
+		rm -f "$(KIND_PF_DIR)/kind-pf-openshell-$$NS.log"; \
+		rm -f "$(KIND_PF_DIR)/kind-pf-openshell-$$NS.port"; \
 	done; \
 	if [ "$$STOPPED" -eq 1 ]; then \
 		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Port forwarding stopped"; \
@@ -1488,35 +1501,6 @@ kind-setup-vertex: check-kubectl _kind-require-cluster ## Configure Vertex AI fo
 			CLOUD_ML_REGION="$(CLOUD_ML_REGION)" \
 			AMBIENT_UI_URL="http://$$(if [ -n "$(KIND_HOST)" ]; then echo "$(KIND_HOST)"; else echo "localhost"; fi):$(KIND_FWD_AMBIENT_UI_PORT)" \
 			./scripts/setup-vertex-kind.sh; \
-	fi
-
-kind-setup-openshell-cli: check-kubectl _kind-require-cluster ## Auto-discover tenant gateways and register openshell CLI access (stop with: make kind-setup-openshell-cli-stop)
-	@NAMESPACES=$$(kubectl get pods --all-namespaces -l app.kubernetes.io/instance=openshell-gateway -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null | sort -u); \
-	if [ -z "$$NAMESPACES" ]; then \
-		echo "$(COLOR_RED)✗$(COLOR_RESET) No openshell-gateway pods found in any namespace"; \
-		exit 1; \
-	fi; \
-	echo "$(COLOR_BLUE)▶$(COLOR_RESET) Found openshell-gateway in: $$NAMESPACES"; \
-	PF_DIR=$(KIND_PF_DIR) GATEWAY_BASE_PORT=$(KIND_FWD_GATEWAY_BASE_PORT) ./scripts/setup-gateway-cli.sh $$NAMESPACES
-
-kind-setup-openshell-cli-stop: ## Stop background openshell gateway port-forwards
-	@STOPPED=0; \
-	for PID_FILE in $(KIND_PF_DIR)/kind-pf-openshell-*.pid; do \
-		[ -f "$$PID_FILE" ] || continue; \
-		SVC=$$(basename "$$PID_FILE" .pid | sed 's/^kind-pf-openshell-//'); \
-		PID=$$(cat "$$PID_FILE"); \
-		if ps -p "$$PID" >/dev/null 2>&1; then \
-			kill "$$PID" 2>/dev/null || true; \
-			echo "  Stopped openshell-gateway port-forward for $$SVC (PID $$PID)"; \
-			STOPPED=1; \
-		fi; \
-		rm -f "$$PID_FILE"; \
-		rm -f "$(KIND_PF_DIR)/kind-pf-openshell-$$SVC.log"; \
-	done; \
-	if [ "$$STOPPED" -eq 1 ]; then \
-		echo "$(COLOR_GREEN)✓$(COLOR_RESET) Openshell gateway port-forwarding stopped"; \
-	else \
-		echo "$(COLOR_YELLOW)No active openshell gateway port-forwards found$(COLOR_RESET)"; \
 	fi
 
 kind-clean: kind-down ## Alias for kind-down

--- a/Makefile
+++ b/Makefile
@@ -1472,6 +1472,14 @@ kind-status: check-kind ## Show all kind clusters and their port assignments
 	@if [ -n "$(KIND_HOST)" ]; then echo "  Host:     $(KIND_HOST) (remote)"; else echo "  Host:     localhost"; fi
 	@echo "  NodePort: $(KIND_HTTP_PORT) (HTTP) / $(KIND_HTTPS_PORT) (HTTPS)"
 	@echo "  Forward:  $(KIND_FWD_FRONTEND_PORT) (frontend) / $(KIND_FWD_BACKEND_PORT) (backend) / $(KIND_FWD_KEYCLOAK_PORT) (keycloak)"
+	@for PORT_FILE in $(KIND_PF_DIR)/kind-pf-openshell-*.port; do \
+		[ -f "$$PORT_FILE" ] || continue; \
+		NS=$$(basename "$$PORT_FILE" .port | sed 's/^kind-pf-openshell-//'); \
+		PORT=$$(cat "$$PORT_FILE"); \
+		if [ -n "$$PORT" ]; then \
+			echo "  Gateway:  $$PORT ($$NS)"; \
+		fi; \
+	done
 	@echo ""
 	@CLUSTERS=$$($(if $(filter podman,$(CONTAINER_ENGINE)),KIND_EXPERIMENTAL_PROVIDER=podman) kind get clusters 2>/dev/null); \
 	if [ -z "$$CLUSTERS" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1471,15 +1471,7 @@ kind-status: check-kind ## Show all kind clusters and their port assignments
 	@echo "  Name:     $(KIND_CLUSTER_NAME)"
 	@if [ -n "$(KIND_HOST)" ]; then echo "  Host:     $(KIND_HOST) (remote)"; else echo "  Host:     localhost"; fi
 	@echo "  NodePort: $(KIND_HTTP_PORT) (HTTP) / $(KIND_HTTPS_PORT) (HTTPS)"
-	@echo "  Forward:  $(KIND_FWD_FRONTEND_PORT) (frontend) / $(KIND_FWD_BACKEND_PORT) (backend) / $(KIND_FWD_KEYCLOAK_PORT) (keycloak)"
-	@for PORT_FILE in $(KIND_PF_DIR)/kind-pf-openshell-*.port; do \
-		[ -f "$$PORT_FILE" ] || continue; \
-		NS=$$(basename "$$PORT_FILE" .port | sed 's/^kind-pf-openshell-//'); \
-		PORT=$$(cat "$$PORT_FILE"); \
-		if [ -n "$$PORT" ]; then \
-			echo "  Gateway:  $$PORT ($$NS)"; \
-		fi; \
-	done
+	@echo "  Forward:  $(KIND_FWD_FRONTEND_PORT) (frontend) / $(KIND_FWD_BACKEND_PORT) (backend) / $(KIND_FWD_KEYCLOAK_PORT) (keycloak) / $(KIND_FWD_GATEWAY_BASE_PORT)+ (gateways)"
 	@echo ""
 	@CLUSTERS=$$($(if $(filter podman,$(CONTAINER_ENGINE)),KIND_EXPERIMENTAL_PROVIDER=podman) kind get clusters 2>/dev/null); \
 	if [ -z "$$CLUSTERS" ]; then \

--- a/README.md
+++ b/README.md
@@ -55,11 +55,24 @@ ACP organizes work around a few core concepts:
 
 ```bash
 make kind-up
-make kind-port-forward           # ports shown in output
-make kind-setup-openshell-cli    # optional: port-forward to OpenShell gateways
+make kind-login                  # port-forward services, configure acpctl, print access info
 ```
 
-Once the cluster is running, see [examples/README.md](examples/README.md) to deploy starter agents and vTeam lab environments.
+Once the cluster is running, configure the openshell CLI for a gateway:
+
+```bash
+acpctl gateway setup-cli --project <namespace> --gateway-url https://localhost:<port>
+```
+
+The gateway URL and port are printed by `make kind-login`. If you've already run `setup-cli` before, it will re-authenticate using your existing acpctl credentials instead of re-registering.
+
+To remove a gateway registration:
+
+```bash
+acpctl gateway remove-cli --project <namespace>
+```
+
+See [examples/README.md](examples/README.md) to deploy starter agents and vTeam lab environments.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md#local-development-setup) for full local development setup.
 

--- a/components/ambient-cli/cmd/acpctl/delete/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/delete/cmd.go
@@ -34,6 +34,7 @@ Valid resource types:
   role-binding      (aliases: rolebinding, rb)
   credential        (aliases: cred)
   application       (aliases: app, apps)
+  gateway           (aliases: gateways, gw)
 
 Use --all / -A to delete all resources of the given type.
 For sessions, active sessions are stopped before deletion.`,
@@ -146,8 +147,15 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "application/%s deleted\n", name)
 		return nil
 
+	case "gateway", "gateways", "gw":
+		if err := client.Gateways().Delete(ctx, name); err != nil {
+			return fmt.Errorf("delete gateway %q: %w", name, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "gateway/%s deleted\n", name)
+		return nil
+
 	default:
-		return fmt.Errorf("unknown or non-deletable resource type: %s\nDeletable types: project, project-settings, session, agent, role, role-binding, credential, application", cmdArgs[0])
+		return fmt.Errorf("unknown or non-deletable resource type: %s\nDeletable types: project, project-settings, session, agent, role, role-binding, credential, application, gateway", cmdArgs[0])
 	}
 }
 

--- a/components/ambient-cli/cmd/acpctl/gateway/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/cmd.go
@@ -11,7 +11,8 @@ var Cmd = &cobra.Command{
 	Long: `Manage openshell gateways.
 
 Examples:
-  acpctl gateway setup-cli <name>    # configure openshell CLI access for a gateway`,
+  acpctl gateway setup-cli     # configure openshell CLI access for a gateway
+  acpctl gateway remove-cli    # remove an openshell CLI gateway registration`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},
@@ -19,4 +20,5 @@ Examples:
 
 func init() {
 	Cmd.AddCommand(setupCmd)
+	Cmd.AddCommand(removeCmd)
 }

--- a/components/ambient-cli/cmd/acpctl/gateway/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/cmd.go
@@ -1,0 +1,22 @@
+// Package gateway implements subcommands for interacting with openshell gateways.
+package gateway
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "gateway",
+	Short: "Manage openshell gateways",
+	Long: `Manage openshell gateways.
+
+Examples:
+  acpctl gateway setup <name>    # configure openshell CLI access for a gateway`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+func init() {
+	Cmd.AddCommand(setupCmd)
+}

--- a/components/ambient-cli/cmd/acpctl/gateway/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/cmd.go
@@ -11,7 +11,7 @@ var Cmd = &cobra.Command{
 	Long: `Manage openshell gateways.
 
 Examples:
-  acpctl gateway setup <name>    # configure openshell CLI access for a gateway`,
+  acpctl gateway setup-cli <name>    # configure openshell CLI access for a gateway`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},

--- a/components/ambient-cli/cmd/acpctl/gateway/remove.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/remove.go
@@ -1,0 +1,69 @@
+package gateway
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var removeArgs struct {
+	project string
+}
+
+var removeCmd = &cobra.Command{
+	Use:   "remove-cli [name]",
+	Short: "Remove an openshell CLI gateway registration",
+	Long: `Remove a local openshell CLI gateway registration.
+
+The gateway name defaults to "<project>-openshell-gateway" if not specified.
+
+This is equivalent to running 'openshell gateway remove <name>'.`,
+	Example: `  acpctl gateway remove-cli --project tenant-a
+  acpctl gateway remove-cli tenant-a-openshell-gateway`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRemove,
+}
+
+func init() {
+	removeCmd.Flags().StringVar(&removeArgs.project, "project", "", "Project/namespace used to derive the gateway name (defaults to configured project)")
+}
+
+func runRemove(cmd *cobra.Command, args []string) error {
+	if _, err := exec.LookPath("openshell"); err != nil {
+		return fmt.Errorf("openshell not found in PATH: required for gateway removal")
+	}
+
+	var localName string
+	if len(args) > 0 {
+		localName = args[0]
+	} else {
+		project := removeArgs.project
+		if project == "" {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			project = cfg.GetProject()
+			if project == "" {
+				return fmt.Errorf("no project set; use --project or provide the gateway name as an argument")
+			}
+		}
+		localName = project + "-openshell-gateway"
+	}
+
+	if !gatewayRegistered(localName) {
+		return fmt.Errorf("gateway %q is not registered in openshell", localName)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Removing gateway %s...\n", localName)
+	removeOut, err := exec.Command("openshell", "gateway", "remove", localName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("openshell gateway remove: %s", strings.TrimSpace(string(removeOut)))
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Gateway %s removed\n", localName)
+	return nil
+}

--- a/components/ambient-cli/cmd/acpctl/gateway/setup.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/setup.go
@@ -199,20 +199,7 @@ func gatewayRegistered(localName string) bool {
 }
 
 func resolveLocalName(project, apiGWName string) string {
-	base := project + "-" + apiGWName
-	existing := listOpenshellGateways()
-	if existing[base] {
-		return base
-	}
-	if !existing[base] {
-		return base
-	}
-	for i := 1; ; i++ {
-		candidate := fmt.Sprintf("%s-%d", base, i)
-		if !existing[candidate] {
-			return candidate
-		}
-	}
+	return project + "-" + apiGWName
 }
 
 func isLocalURL(url string) bool {

--- a/components/ambient-cli/cmd/acpctl/gateway/setup.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/setup.go
@@ -435,7 +435,7 @@ func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway, cfg *config.Config
 			}
 			if err := fetchClientTLS(localName, namespace); err != nil {
 				fmt.Fprintf(w, "Warning: could not fetch mTLS certs: %v\n", err)
-				fmt.Fprintf(w, "You may need to pass --gateway-insecure to openshell commands\n")
+				fmt.Fprintf(w, "Ensure kubectl has access to namespace %q or manually provision certs\n", namespace)
 			}
 			fmt.Fprintf(w, "OIDC credentials configured from acpctl\n")
 		} else {

--- a/components/ambient-cli/cmd/acpctl/gateway/setup.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/setup.go
@@ -4,13 +4,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
 	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
@@ -20,22 +20,67 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var setupArgs struct {
+	gatewayURL string
+	project    string
+	printOnly  bool
+}
+
 var setupCmd = &cobra.Command{
-	Use:   "setup-cli <name>",
+	Use:   "setup-cli [name]",
 	Short: "Configure openshell CLI access for a gateway",
 	Long: `Configure local openshell CLI access for a named gateway.
 
-Extracts mTLS certificates from the cluster, starts a kubectl port-forward,
-and registers the gateway with the openshell CLI.
+Reads the gateway's authentication configuration from the API server
+and registers it with the openshell CLI. For OIDC-enabled gateways,
+the user's existing acpctl credentials are used to configure openshell
+non-interactively. If no acpctl credentials are available, the
+interactive browser-based OIDC flow is used instead.
 
-Requires kubectl and openshell to be installed and a valid kubeconfig context.`,
-	Example: "  acpctl gateway setup-cli my-gateway",
-	Args:    cobra.ExactArgs(1),
-	RunE:    runSetup,
+If the gateway was previously registered, re-authenticates using the
+existing registration instead of creating a new one.
+
+The API-side gateway name defaults to "openshell-gateway" if not specified.
+The local openshell registration is named "<project>-openshell-gateway",
+with a numeric suffix added if a new registration is needed and the name
+is already taken.
+
+Use --print to show the openshell commands instead of running them.
+
+Requires openshell to be installed.`,
+	Example: `  acpctl gateway setup-cli --gateway-url https://localhost:54684 --project tenant-a
+  acpctl gateway setup-cli my-gateway --gateway-url https://gateway.example.com:8080
+  acpctl gateway setup-cli --gateway-url https://localhost:54684 --project tenant-a --print`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runSetup,
+}
+
+func init() {
+	setupCmd.Flags().StringVar(&setupArgs.gatewayURL, "gateway-url", "", "Gateway URL (e.g. https://gateway.example.com:8080)")
+	setupCmd.Flags().StringVar(&setupArgs.project, "project", "", "Project/namespace to look up the gateway in (defaults to configured project)")
+	setupCmd.Flags().BoolVar(&setupArgs.printOnly, "print", false, "Print the openshell commands instead of running them")
+	_ = setupCmd.MarkFlagRequired("gateway-url")
 }
 
 func runSetup(cmd *cobra.Command, args []string) error {
-	client, err := connection.NewClientFromConfig()
+	factory, err := connection.NewClientFactory()
+	if err != nil {
+		return err
+	}
+
+	project := setupArgs.project
+	if project == "" {
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		project = cfg.GetProject()
+		if project == "" {
+			return fmt.Errorf("no project set; use --project or run 'acpctl config set project <name>'")
+		}
+	}
+
+	client, err := factory.ForProject(project)
 	if err != nil {
 		return err
 	}
@@ -48,10 +93,17 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
 	defer cancel()
 
-	gw, err := findGateway(ctx, client, args[0])
+	apiGWName := "openshell-gateway"
+	if len(args) > 0 {
+		apiGWName = args[0]
+	}
+
+	gw, err := findGateway(ctx, client, apiGWName)
 	if err != nil {
 		return err
 	}
+
+	localName := resolveLocalName(project, apiGWName)
 
 	format, err := output.ParseFormat("")
 	if err != nil {
@@ -59,7 +111,7 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	}
 	printer := output.NewPrinter(format, cmd.OutOrStdout())
 
-	return setupOpenshellGateway(printer.Writer(), gw)
+	return setupOpenshellGateway(printer.Writer(), gw, cfg, localName, setupArgs.gatewayURL, project, setupArgs.printOnly)
 }
 
 func findGateway(ctx context.Context, client *sdkclient.Client, nameOrID string) (*sdktypes.Gateway, error) {
@@ -89,148 +141,319 @@ func findGateway(ctx context.Context, client *sdkclient.Client, nameOrID string)
 	return nil, fmt.Errorf("gateway %q not found", nameOrID)
 }
 
-// TODO: once gateway access via Route/Ingress is supported, use that instead of kubectl port-forward
-func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway) error {
-	namespace := strings.ToLower(gw.ProjectID)
-	gwName := gw.Name
-
-	if _, err := exec.LookPath("kubectl"); err != nil {
-		return fmt.Errorf("kubectl not found in PATH: required for gateway setup")
+func stripANSI(s string) string {
+	var out strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && ((s[j] >= '0' && s[j] <= '9') || s[j] == ';') {
+				j++
+			}
+			if j < len(s) {
+				j++
+			}
+			i = j
+			continue
+		}
+		out.WriteByte(s[i])
+		i++
 	}
+	return out.String()
+}
+
+func listOpenshellGateways() map[string]bool {
+	names := make(map[string]bool)
+	out, err := exec.Command("openshell", "gateway", "list").Output()
+	if err != nil {
+		return names
+	}
+	scanner := bufio.NewScanner(strings.NewReader(stripANSI(string(out))))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
+		if name == "*" && len(fields) > 1 {
+			name = fields[1]
+		}
+		if strings.ToUpper(name) == "NAME" {
+			continue
+		}
+		names[name] = true
+	}
+	return names
+}
+
+func openshellConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "openshell")
+}
+
+func gatewayRegistered(localName string) bool {
+	return listOpenshellGateways()[localName]
+}
+
+func resolveLocalName(project, apiGWName string) string {
+	base := project + "-" + apiGWName
+	existing := listOpenshellGateways()
+	if existing[base] {
+		return base
+	}
+	if !existing[base] {
+		return base
+	}
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if !existing[candidate] {
+			return candidate
+		}
+	}
+}
+
+func isLocalURL(url string) bool {
+	return strings.Contains(url, "localhost") || strings.Contains(url, "127.0.0.1")
+}
+
+func buildAddArgs(localName, gwURL string, oidc *sdktypes.GatewayOidc) []string {
+	args := []string{"gateway", "add", "--name", localName}
+	if oidc != nil && oidc.Issuer != "" {
+		args = append(args,
+			"--oidc-issuer", oidc.Issuer,
+			"--oidc-client-id", oidc.Audience,
+			"--oidc-audience", oidc.Audience,
+		)
+	}
+	if isLocalURL(gwURL) {
+		args = append(args, "--gateway-insecure")
+	}
+	args = append(args, gwURL)
+	return args
+}
+
+func buildLoginArgs(localName, gwURL string) []string {
+	args := []string{"gateway", "login", "-g", localName}
+	if isLocalURL(gwURL) {
+		args = append(args, "--gateway-insecure")
+	}
+	return args
+}
+
+type gatewayMetadata struct {
+	Name            string `json:"name"`
+	GatewayEndpoint string `json:"gateway_endpoint"`
+	IsRemote        bool   `json:"is_remote"`
+	GatewayPort     int    `json:"gateway_port"`
+	AuthMode        string `json:"auth_mode"`
+	OIDCIssuer      string `json:"oidc_issuer,omitempty"`
+	OIDCClientID    string `json:"oidc_client_id,omitempty"`
+	OIDCAudience    string `json:"oidc_audience,omitempty"`
+}
+
+type oidcTokenFile struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresAt    int64  `json:"expires_at,omitempty"`
+	Issuer       string `json:"issuer"`
+	ClientID     string `json:"client_id"`
+}
+
+// fetchClientTLS retrieves the openshell-client-tls secret from the
+// gateway's namespace and writes ca.crt, tls.crt, and tls.key to the
+// local openshell config. This lets openshell verify the gateway's TLS
+// cert and perform mTLS client auth without --gateway-insecure.
+func fetchClientTLS(localName, namespace string) error {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		return fmt.Errorf("kubectl not found in PATH")
+	}
+
+	base := openshellConfigDir()
+	if base == "" {
+		return fmt.Errorf("cannot determine home directory")
+	}
+
+	mtlsDir := filepath.Join(base, "gateways", localName, "mtls")
+	if err := os.MkdirAll(mtlsDir, 0700); err != nil {
+		return fmt.Errorf("create mtls dir: %w", err)
+	}
+
+	secretName := "openshell-client-tls"
+	files := []struct {
+		field string
+		name  string
+		perm  os.FileMode
+	}{
+		{"ca\\.crt", "ca.crt", 0644},
+		{"tls\\.crt", "tls.crt", 0644},
+		{"tls\\.key", "tls.key", 0600},
+	}
+
+	for _, f := range files {
+		out, err := exec.Command("kubectl", "get", "secret", secretName,
+			"-n", namespace,
+			"-o", fmt.Sprintf("jsonpath={.data.%s}", f.field),
+		).Output()
+		if err != nil {
+			return fmt.Errorf("fetch %s from %s/%s: %w", f.name, namespace, secretName, err)
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(string(out))
+		if err != nil {
+			return fmt.Errorf("decode %s: %w", f.name, err)
+		}
+
+		if err := os.WriteFile(filepath.Join(mtlsDir, f.name), decoded, f.perm); err != nil {
+			return fmt.Errorf("write %s: %w", f.name, err)
+		}
+	}
+	return nil
+}
+
+func writeGatewayConfig(localName, gwURL string, oidc *sdktypes.GatewayOidc) error {
+	base := openshellConfigDir()
+	if base == "" {
+		return fmt.Errorf("cannot determine home directory")
+	}
+
+	gwDir := filepath.Join(base, "gateways", localName)
+	if err := os.MkdirAll(gwDir, 0700); err != nil {
+		return fmt.Errorf("create gateway dir: %w", err)
+	}
+
+	meta := &gatewayMetadata{
+		Name:            localName,
+		GatewayEndpoint: gwURL,
+		IsRemote:        true,
+		GatewayPort:     0,
+		AuthMode:        "oidc",
+	}
+	if oidc != nil {
+		meta.OIDCIssuer = oidc.Issuer
+		meta.OIDCClientID = oidc.Audience
+		meta.OIDCAudience = oidc.Audience
+	}
+
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(gwDir, "metadata.json"), data, 0600)
+}
+
+func writeOIDCToken(localName string, cfg *config.Config, gwOidc *sdktypes.GatewayOidc) error {
+	accessToken := cfg.GetToken()
+	if accessToken == "" {
+		return fmt.Errorf("no access token in acpctl config; run 'acpctl login' first")
+	}
+
+	token := &oidcTokenFile{
+		AccessToken:  accessToken,
+		RefreshToken: cfg.RefreshToken,
+		Issuer:       gwOidc.Issuer,
+		ClientID:     gwOidc.Audience,
+	}
+
+	base := openshellConfigDir()
+	if base == "" {
+		return fmt.Errorf("cannot determine home directory")
+	}
+
+	tokenPath := filepath.Join(base, "gateways", localName, "oidc_token.json")
+
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0700); err != nil {
+		return fmt.Errorf("create token dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal token: %w", err)
+	}
+
+	return os.WriteFile(tokenPath, data, 0600)
+}
+
+func hasACPCredentials(cfg *config.Config) bool {
+	return cfg.GetToken() != ""
+}
+
+func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway, cfg *config.Config, localName, gwURL, namespace string, printOnly bool) error {
 	if _, err := exec.LookPath("openshell"); err != nil {
 		return fmt.Errorf("openshell not found in PATH: required for gateway setup")
 	}
 
-	if !kubectlNamespaceExists(namespace) {
-		return fmt.Errorf("namespace %q does not exist in the cluster", namespace)
+	gwURL = strings.TrimRight(gwURL, "/")
+	alreadyRegistered := gatewayRegistered(localName)
+	hasOIDC := gw.Oidc != nil && gw.Oidc.Issuer != ""
+	hasCreds := hasACPCredentials(cfg)
+
+	if printOnly {
+		addArgs := buildAddArgs(localName, gwURL, gw.Oidc)
+		loginArgs := buildLoginArgs(localName, gwURL)
+
+		fmt.Fprintf(w, "# Register a new gateway\n")
+		fmt.Fprintf(w, "  openshell %s\n", strings.Join(addArgs, " "))
+		fmt.Fprintf(w, "\n# Re-authenticate an existing gateway\n")
+		fmt.Fprintf(w, "  openshell %s\n", strings.Join(loginArgs, " "))
+		fmt.Fprintf(w, "\n# Verify connectivity\n")
+		fmt.Fprintf(w, "  openshell -g %s provider list\n", localName)
+		return nil
 	}
 
-	if !kubectlSecretExists(namespace, "openshell-server-tls") {
-		return fmt.Errorf("openshell-server-tls secret not found in namespace %q; gateway may not be fully provisioned", namespace)
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("get home directory: %w", err)
-	}
-	certDir := filepath.Join(homeDir, ".config", "openshell", "gateways", gwName, "mtls")
-	if err := os.MkdirAll(certDir, 0700); err != nil {
-		return fmt.Errorf("create cert directory: %w", err)
-	}
-
-	fmt.Fprintf(w, "Extracting mTLS certs from openshell-server-tls...\n")
-	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
-		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
-			return fmt.Errorf("extract %s: %w", key, err)
-		}
-	}
-
-	fmt.Fprintf(w, "Starting port-forward to openshell-gateway in %s...\n", namespace)
-	pfCmd := exec.Command("kubectl", "port-forward", "-n", namespace,
-		"statefulset/openshell-gateway", ":8080")
-	pfCmd.Stderr = os.Stderr
-	pfOut, err := pfCmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("create port-forward pipe: %w", err)
-	}
-	if err := pfCmd.Start(); err != nil {
-		return fmt.Errorf("start port-forward: %w", err)
-	}
-	defer func() {
-		_ = pfCmd.Process.Kill()
-		_ = pfCmd.Wait()
-	}()
-
-	port := ""
-	scanner := bufio.NewScanner(pfOut)
-	portCh := make(chan string, 1)
-	pfCtx, pfCancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer pfCancel()
-	go func() {
-		defer pfCancel()
-		for scanner.Scan() {
-			line := scanner.Text()
-			if idx := strings.Index(line, "Forwarding from 127.0.0.1:"); idx >= 0 {
-				rest := line[idx+len("Forwarding from 127.0.0.1:"):]
-				if end := strings.Index(rest, " "); end > 0 {
-					portCh <- rest[:end]
-					return
-				}
+	if alreadyRegistered {
+		fmt.Fprintf(w, "Gateway %s is already registered, re-authenticating...\n", localName)
+		if hasCreds {
+			if err := writeOIDCToken(localName, cfg, gw.Oidc); err != nil {
+				return fmt.Errorf("OIDC token injection: %w", err)
+			}
+			if err := fetchClientTLS(localName, namespace); err != nil {
+				fmt.Fprintf(w, "Warning: could not refresh mTLS certs: %v\n", err)
+			}
+			fmt.Fprintf(w, "OIDC credentials refreshed from acpctl\n")
+		} else {
+			loginArgs := buildLoginArgs(localName, gwURL)
+			loginCmd := exec.Command("openshell", loginArgs...)
+			loginCmd.Stdin = os.Stdin
+			loginCmd.Stdout = os.Stdout
+			loginCmd.Stderr = os.Stderr
+			if err := loginCmd.Run(); err != nil {
+				return fmt.Errorf("openshell gateway login: %w", err)
 			}
 		}
-	}()
-
-	select {
-	case port = <-portCh:
-	case <-pfCtx.Done():
-		return fmt.Errorf("timeout waiting for port-forward to start")
-	}
-
-	fmt.Fprintf(w, "Port-forward active on localhost:%s\n", port)
-
-	_ = exec.Command("openshell", "gateway", "remove", gwName).Run()
-
-	fmt.Fprintf(w, "Registering gateway %s -> https://localhost:%s...\n", gwName, port)
-	addCmd := exec.Command("openshell", "gateway", "add",
-		"--name", gwName, "--local",
-		fmt.Sprintf("https://localhost:%s", port))
-	addOut, err := addCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("openshell gateway add: %s", string(addOut))
-	}
-
-	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
-		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
-			return fmt.Errorf("re-extract %s: %w", key, err)
+	} else {
+		if hasOIDC && hasCreds {
+			fmt.Fprintf(w, "Registering new gateway %s -> %s...\n", localName, gwURL)
+			if err := writeGatewayConfig(localName, gwURL, gw.Oidc); err != nil {
+				return fmt.Errorf("write gateway config: %w", err)
+			}
+			if err := writeOIDCToken(localName, cfg, gw.Oidc); err != nil {
+				return fmt.Errorf("OIDC token injection: %w", err)
+			}
+			if err := fetchClientTLS(localName, namespace); err != nil {
+				fmt.Fprintf(w, "Warning: could not fetch mTLS certs: %v\n", err)
+				fmt.Fprintf(w, "You may need to pass --gateway-insecure to openshell commands\n")
+			}
+			fmt.Fprintf(w, "OIDC credentials configured from acpctl\n")
+		} else {
+			fmt.Fprintf(w, "Registering new gateway %s -> %s...\n", localName, gwURL)
+			addArgs := buildAddArgs(localName, gwURL, gw.Oidc)
+			addCmd := exec.Command("openshell", addArgs...)
+			addCmd.Stdin = os.Stdin
+			addCmd.Stdout = os.Stdout
+			addCmd.Stderr = os.Stderr
+			if err := addCmd.Run(); err != nil {
+				return fmt.Errorf("openshell gateway add failed: %w", err)
+			}
 		}
 	}
 
-	fmt.Fprintf(w, "Verifying connectivity...\n")
-	statusCmd := exec.Command("openshell", "-g", gwName, "provider", "list")
-	if err := statusCmd.Run(); err != nil {
-		fmt.Fprintf(w, "Warning: connectivity check failed — verify gateway pod is running:\n")
-		fmt.Fprintf(w, "  kubectl logs -l app.kubernetes.io/instance=openshell-gateway -n %s\n", namespace)
-	} else {
-		fmt.Fprintf(w, "Gateway %s connected successfully\n", gwName)
-	}
-
+	fmt.Fprintf(w, "Gateway %s configured successfully\n", localName)
 	fmt.Fprintf(w, "\nUsage:\n")
-	fmt.Fprintf(w, "  openshell sandbox list --gateway %s\n", gwName)
-
-	fmt.Fprintf(w, "\nPort-forward is running in the foreground (PID %d). Press Ctrl+C to stop.\n", pfCmd.Process.Pid)
-
-	_ = pfCmd.Wait()
+	fmt.Fprintf(w, "  openshell sandbox list --gateway %s\n", localName)
 
 	return nil
-}
-
-func kubectlNamespaceExists(namespace string) bool {
-	cmd := exec.Command("kubectl", "get", "namespace", namespace)
-	return cmd.Run() == nil
-}
-
-func kubectlSecretExists(namespace, name string) bool {
-	cmd := exec.Command("kubectl", "get", "secret", name, "-n", namespace)
-	return cmd.Run() == nil
-}
-
-func extractSecretKey(namespace, secretName, key, destPath string) error {
-	cmd := exec.Command("kubectl", "get", "secret", secretName,
-		"-n", namespace,
-		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(key, ".", "\\.")))
-	out, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("kubectl get secret: %w", err)
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(string(out))
-	if err != nil {
-		return fmt.Errorf("base64 decode: %w", err)
-	}
-
-	perm := os.FileMode(0644)
-	if strings.Contains(key, "key") {
-		perm = 0600
-	}
-	return os.WriteFile(destPath, decoded, perm)
 }

--- a/components/ambient-cli/cmd/acpctl/gateway/setup.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/setup.go
@@ -451,9 +451,34 @@ func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway, cfg *config.Config
 		}
 	}
 
-	fmt.Fprintf(w, "Gateway %s configured successfully\n", localName)
+	fmt.Fprintf(w, "Verifying gateway connectivity...\n")
+	if err := verifyGateway(localName); err != nil {
+		if !alreadyRegistered {
+			cleanupGatewayConfig(localName)
+		}
+		return fmt.Errorf("gateway at %s is not reachable: %w\nCheck that the URL is correct and the gateway is running.", gwURL, err)
+	}
+
+	fmt.Fprintf(w, "Gateway %s configured and verified\n", localName)
 	fmt.Fprintf(w, "\nUsage:\n")
 	fmt.Fprintf(w, "  openshell sandbox list --gateway %s\n", localName)
 
 	return nil
+}
+
+func verifyGateway(localName string) error {
+	out, err := exec.Command("openshell", "status", "-g", localName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(stripANSI(string(out))))
+	}
+	return nil
+}
+
+func cleanupGatewayConfig(localName string) {
+	base := openshellConfigDir()
+	if base == "" {
+		return
+	}
+	gwDir := filepath.Join(base, "gateways", localName)
+	_ = os.RemoveAll(gwDir)
 }

--- a/components/ambient-cli/cmd/acpctl/gateway/setup.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/setup.go
@@ -1,0 +1,236 @@
+package gateway
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/config"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/connection"
+	"github.com/ambient-code/platform/components/ambient-cli/pkg/output"
+	sdkclient "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/client"
+	sdktypes "github.com/ambient-code/platform/components/ambient-sdk/go-sdk/types"
+	"github.com/spf13/cobra"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup <name>",
+	Short: "Configure openshell CLI access for a gateway",
+	Long: `Configure local openshell CLI access for a named gateway.
+
+Extracts mTLS certificates from the cluster, starts a kubectl port-forward,
+and registers the gateway with the openshell CLI.
+
+Requires kubectl and openshell to be installed and a valid kubeconfig context.`,
+	Example: "  acpctl gateway setup my-gateway",
+	Args:    cobra.ExactArgs(1),
+	RunE:    runSetup,
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	client, err := connection.NewClientFromConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.GetRequestTimeout())
+	defer cancel()
+
+	gw, err := findGateway(ctx, client, args[0])
+	if err != nil {
+		return err
+	}
+
+	format, err := output.ParseFormat("")
+	if err != nil {
+		return err
+	}
+	printer := output.NewPrinter(format, cmd.OutOrStdout())
+
+	return setupOpenshellGateway(printer.Writer(), gw)
+}
+
+func findGateway(ctx context.Context, client *sdkclient.Client, nameOrID string) (*sdktypes.Gateway, error) {
+	gw, err := client.Gateways().Get(ctx, nameOrID)
+	if err == nil {
+		return gw, nil
+	}
+
+	page := 1
+	pageSize := 100
+	for {
+		opts := sdktypes.NewListOptions().Page(page).Size(pageSize).Build()
+		list, err2 := client.Gateways().List(ctx, opts)
+		if err2 != nil {
+			return nil, fmt.Errorf("list gateways: %w", err2)
+		}
+		for i := range list.Items {
+			if list.Items[i].Name == nameOrID {
+				return &list.Items[i], nil
+			}
+		}
+		if len(list.Items) < pageSize {
+			break
+		}
+		page++
+	}
+	return nil, fmt.Errorf("gateway %q not found", nameOrID)
+}
+
+// TODO: once gateway access via Route/Ingress is supported, use that instead of kubectl port-forward
+func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway) error {
+	namespace := strings.ToLower(gw.ProjectID)
+	gwName := gw.Name
+
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		return fmt.Errorf("kubectl not found in PATH: required for gateway setup")
+	}
+	if _, err := exec.LookPath("openshell"); err != nil {
+		return fmt.Errorf("openshell not found in PATH: required for gateway setup")
+	}
+
+	if !kubectlNamespaceExists(namespace) {
+		return fmt.Errorf("namespace %q does not exist in the cluster", namespace)
+	}
+
+	if !kubectlSecretExists(namespace, "openshell-server-tls") {
+		return fmt.Errorf("openshell-server-tls secret not found in namespace %q; gateway may not be fully provisioned", namespace)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home directory: %w", err)
+	}
+	certDir := filepath.Join(homeDir, ".config", "openshell", "gateways", gwName, "mtls")
+	if err := os.MkdirAll(certDir, 0700); err != nil {
+		return fmt.Errorf("create cert directory: %w", err)
+	}
+
+	fmt.Fprintf(w, "Extracting mTLS certs from openshell-server-tls...\n")
+	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
+		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
+			return fmt.Errorf("extract %s: %w", key, err)
+		}
+	}
+
+	fmt.Fprintf(w, "Starting port-forward to openshell-gateway in %s...\n", namespace)
+	pfCmd := exec.Command("kubectl", "port-forward", "-n", namespace,
+		"statefulset/openshell-gateway", ":8080")
+	pfCmd.Stderr = os.Stderr
+	pfOut, err := pfCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("create port-forward pipe: %w", err)
+	}
+	if err := pfCmd.Start(); err != nil {
+		return fmt.Errorf("start port-forward: %w", err)
+	}
+	defer func() {
+		_ = pfCmd.Process.Kill()
+		_ = pfCmd.Wait()
+	}()
+
+	port := ""
+	scanner := bufio.NewScanner(pfOut)
+	portCh := make(chan string, 1)
+	pfCtx, pfCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer pfCancel()
+	go func() {
+		defer pfCancel()
+		for scanner.Scan() {
+			line := scanner.Text()
+			if idx := strings.Index(line, "Forwarding from 127.0.0.1:"); idx >= 0 {
+				rest := line[idx+len("Forwarding from 127.0.0.1:"):]
+				if end := strings.Index(rest, " "); end > 0 {
+					portCh <- rest[:end]
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case port = <-portCh:
+	case <-pfCtx.Done():
+		return fmt.Errorf("timeout waiting for port-forward to start")
+	}
+
+	fmt.Fprintf(w, "Port-forward active on localhost:%s\n", port)
+
+	_ = exec.Command("openshell", "gateway", "remove", gwName).Run()
+
+	fmt.Fprintf(w, "Registering gateway %s -> https://localhost:%s...\n", gwName, port)
+	addCmd := exec.Command("openshell", "gateway", "add",
+		"--name", gwName, "--local",
+		fmt.Sprintf("https://localhost:%s", port))
+	addOut, err := addCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("openshell gateway add: %s", string(addOut))
+	}
+
+	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
+		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
+			return fmt.Errorf("re-extract %s: %w", key, err)
+		}
+	}
+
+	fmt.Fprintf(w, "Verifying connectivity...\n")
+	statusCmd := exec.Command("openshell", "-g", gwName, "provider", "list")
+	if err := statusCmd.Run(); err != nil {
+		fmt.Fprintf(w, "Warning: connectivity check failed — verify gateway pod is running:\n")
+		fmt.Fprintf(w, "  kubectl logs -l app.kubernetes.io/instance=openshell-gateway -n %s\n", namespace)
+	} else {
+		fmt.Fprintf(w, "Gateway %s connected successfully\n", gwName)
+	}
+
+	fmt.Fprintf(w, "\nUsage:\n")
+	fmt.Fprintf(w, "  openshell sandbox list --gateway %s\n", gwName)
+
+	fmt.Fprintf(w, "\nPort-forward is running in the foreground (PID %d). Press Ctrl+C to stop.\n", pfCmd.Process.Pid)
+
+	_ = pfCmd.Wait()
+
+	return nil
+}
+
+func kubectlNamespaceExists(namespace string) bool {
+	cmd := exec.Command("kubectl", "get", "namespace", namespace)
+	return cmd.Run() == nil
+}
+
+func kubectlSecretExists(namespace, name string) bool {
+	cmd := exec.Command("kubectl", "get", "secret", name, "-n", namespace)
+	return cmd.Run() == nil
+}
+
+func extractSecretKey(namespace, secretName, key, destPath string) error {
+	cmd := exec.Command("kubectl", "get", "secret", secretName,
+		"-n", namespace,
+		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(key, ".", "\\.")))
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("kubectl get secret: %w", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(string(out))
+	if err != nil {
+		return fmt.Errorf("base64 decode: %w", err)
+	}
+
+	perm := os.FileMode(0644)
+	if strings.Contains(key, "key") {
+		perm = 0600
+	}
+	return os.WriteFile(destPath, decoded, perm)
+}

--- a/components/ambient-cli/cmd/acpctl/gateway/setup.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/setup.go
@@ -21,7 +21,7 @@ import (
 )
 
 var setupCmd = &cobra.Command{
-	Use:   "setup <name>",
+	Use:   "setup-cli <name>",
 	Short: "Configure openshell CLI access for a gateway",
 	Long: `Configure local openshell CLI access for a named gateway.
 
@@ -29,7 +29,7 @@ Extracts mTLS certificates from the cluster, starts a kubectl port-forward,
 and registers the gateway with the openshell CLI.
 
 Requires kubectl and openshell to be installed and a valid kubeconfig context.`,
-	Example: "  acpctl gateway setup my-gateway",
+	Example: "  acpctl gateway setup-cli my-gateway",
 	Args:    cobra.ExactArgs(1),
 	RunE:    runSetup,
 }

--- a/components/ambient-cli/cmd/acpctl/gateway/setup.go
+++ b/components/ambient-cli/cmd/acpctl/gateway/setup.go
@@ -443,7 +443,7 @@ func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway, cfg *config.Config
 		if !alreadyRegistered {
 			cleanupGatewayConfig(localName)
 		}
-		return fmt.Errorf("gateway at %s is not reachable: %w\nCheck that the URL is correct and the gateway is running.", gwURL, err)
+		return fmt.Errorf("gateway at %s is not reachable: %w", gwURL, err)
 	}
 
 	fmt.Fprintf(w, "Gateway %s configured and verified\n", localName)

--- a/components/ambient-cli/cmd/acpctl/get/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd.go
@@ -993,9 +993,8 @@ func printGatewayConnectionInfo(w io.Writer, gw *sdktypes.Gateway) {
 	if len(gw.ServerDnsNames) > 0 {
 		fmt.Fprintf(w, "  Server SANs:  %s\n", strings.Join(gw.ServerDnsNames, ", "))
 	}
-	fmt.Fprintf(w, "  TLS Secret:   openshell-server-tls (namespace: %s)\n", namespace)
 	fmt.Fprintf(w, "\nSetup openshell CLI:\n")
-	fmt.Fprintf(w, "  acpctl gateway setup-cli %s\n", gw.Name)
+	fmt.Fprintf(w, "  acpctl gateway setup-cli %s --gateway-url <url>\n", gw.Name)
 }
 
 func sessionChanged(old, current sdktypes.Session) bool {

--- a/components/ambient-cli/cmd/acpctl/get/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd.go
@@ -157,6 +157,9 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 	case "gateways":
 		return getGateways(ctx, client, printer, name)
 	default:
+		if args.setup {
+			return fmt.Errorf("--setup is only supported for the 'gateway' resource type")
+		}
 		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-agents, project-settings, users, agents, providers, policies, roles, role-bindings, credentials, gateways", cmdArgs[0])
 	}
 }
@@ -957,22 +960,28 @@ func getGateways(ctx context.Context, client *sdkclient.Client, printer *output.
 }
 
 func findGateway(ctx context.Context, client *sdkclient.Client, nameOrID string) (*sdktypes.Gateway, error) {
-	// Try by ID first
 	gw, err := client.Gateways().Get(ctx, nameOrID)
 	if err == nil {
 		return gw, nil
 	}
 
-	// Fall back to name search
-	opts := sdktypes.NewListOptions().Size(100).Build()
-	list, err2 := client.Gateways().List(ctx, opts)
-	if err2 != nil {
-		return nil, fmt.Errorf("list gateways: %w", err2)
-	}
-	for i := range list.Items {
-		if list.Items[i].Name == nameOrID {
-			return &list.Items[i], nil
+	page := 1
+	pageSize := 100
+	for {
+		opts := sdktypes.NewListOptions().Page(page).Size(pageSize).Build()
+		list, err2 := client.Gateways().List(ctx, opts)
+		if err2 != nil {
+			return nil, fmt.Errorf("list gateways: %w", err2)
 		}
+		for i := range list.Items {
+			if list.Items[i].Name == nameOrID {
+				return &list.Items[i], nil
+			}
+		}
+		if len(list.Items) < pageSize {
+			break
+		}
+		page++
 	}
 	return nil, fmt.Errorf("gateway %q not found", nameOrID)
 }
@@ -1037,11 +1046,11 @@ func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway) error {
 	fmt.Fprintf(w, "Starting port-forward to openshell-gateway in %s...\n", namespace)
 	pfCmd := exec.Command("kubectl", "port-forward", "-n", namespace,
 		"statefulset/openshell-gateway", ":8080")
+	pfCmd.Stderr = os.Stderr
 	pfOut, err := pfCmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("create port-forward pipe: %w", err)
 	}
-	pfCmd.Stderr = pfCmd.Stdout
 	if err := pfCmd.Start(); err != nil {
 		return fmt.Errorf("start port-forward: %w", err)
 	}
@@ -1053,15 +1062,18 @@ func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway) error {
 	// Wait for port-forward to print the assigned port
 	port := ""
 	scanner := bufio.NewScanner(pfOut)
-	deadline := time.After(15 * time.Second)
 	portCh := make(chan string, 1)
+	pfCtx, pfCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer pfCancel()
 	go func() {
+		defer pfCancel()
 		for scanner.Scan() {
 			line := scanner.Text()
 			if idx := strings.Index(line, "Forwarding from 127.0.0.1:"); idx >= 0 {
 				rest := line[idx+len("Forwarding from 127.0.0.1:"):]
 				if end := strings.Index(rest, " "); end > 0 {
 					portCh <- rest[:end]
+					return
 				}
 			}
 		}
@@ -1069,7 +1081,7 @@ func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway) error {
 
 	select {
 	case port = <-portCh:
-	case <-deadline:
+	case <-pfCtx.Done():
 		return fmt.Errorf("timeout waiting for port-forward to start")
 	}
 

--- a/components/ambient-cli/cmd/acpctl/get/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd.go
@@ -2,15 +2,11 @@
 package get
 
 import (
-	"bufio"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -27,7 +23,6 @@ var args struct {
 	limit        int
 	watch        bool
 	watchTimeout time.Duration
-	setup        bool
 }
 
 var Cmd = &cobra.Command{
@@ -67,7 +62,6 @@ func init() {
 	Cmd.Flags().DurationVar(&args.watchTimeout, "watch-timeout", 30*time.Minute, "Timeout for watch mode (e.g. 1h, 10m)")
 	Cmd.Flags().StringVar(&projectAgentArgs.projectID, "project", "", "Project ID (required for project-agents)")
 	Cmd.Flags().StringVar(&projectAgentArgs.paID, "project-agent", "", "Filter sessions by project-agent ID (requires --project)")
-	Cmd.Flags().BoolVar(&args.setup, "setup", false, "Configure openshell CLI access for a gateway (gateways only)")
 }
 
 func run(cmd *cobra.Command, cmdArgs []string) error {
@@ -157,9 +151,6 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 	case "gateways":
 		return getGateways(ctx, client, printer, name)
 	default:
-		if args.setup {
-			return fmt.Errorf("--setup is only supported for the 'gateway' resource type")
-		}
 		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-agents, project-settings, users, agents, providers, policies, roles, role-bindings, credentials, gateways", cmdArgs[0])
 	}
 }
@@ -920,17 +911,6 @@ func printApplicationTable(printer *output.Printer, applications []sdktypes.Appl
 }
 
 func getGateways(ctx context.Context, client *sdkclient.Client, printer *output.Printer, name string) error {
-	if args.setup {
-		if name == "" {
-			return fmt.Errorf("--setup requires a gateway name: acpctl get gateway <name> --setup")
-		}
-		gw, err := findGateway(ctx, client, name)
-		if err != nil {
-			return err
-		}
-		return setupOpenshellGateway(printer.Writer(), gw)
-	}
-
 	if name != "" {
 		gw, err := findGateway(ctx, client, name)
 		if err != nil {
@@ -1006,160 +986,6 @@ func printGatewayTable(printer *output.Printer, gateways []sdktypes.Gateway) err
 	return nil
 }
 
-func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway) error {
-	namespace := strings.ToLower(gw.ProjectID)
-	gwName := gw.Name
-
-	if _, err := exec.LookPath("kubectl"); err != nil {
-		return fmt.Errorf("kubectl not found in PATH: required for --setup")
-	}
-	if _, err := exec.LookPath("openshell"); err != nil {
-		return fmt.Errorf("openshell not found in PATH: required for --setup")
-	}
-
-	if !kubectlNamespaceExists(namespace) {
-		return fmt.Errorf("namespace %q does not exist in the cluster", namespace)
-	}
-
-	if !kubectlSecretExists(namespace, "openshell-server-tls") {
-		return fmt.Errorf("openshell-server-tls secret not found in namespace %q; gateway may not be fully provisioned", namespace)
-	}
-
-	// Extract mTLS certs before registering
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("get home directory: %w", err)
-	}
-	certDir := filepath.Join(homeDir, ".config", "openshell", "gateways", gwName, "mtls")
-	if err := os.MkdirAll(certDir, 0700); err != nil {
-		return fmt.Errorf("create cert directory: %w", err)
-	}
-
-	fmt.Fprintf(w, "Extracting mTLS certs from openshell-server-tls...\n")
-	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
-		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
-			return fmt.Errorf("extract %s: %w", key, err)
-		}
-	}
-
-	// Start port-forward
-	fmt.Fprintf(w, "Starting port-forward to openshell-gateway in %s...\n", namespace)
-	pfCmd := exec.Command("kubectl", "port-forward", "-n", namespace,
-		"statefulset/openshell-gateway", ":8080")
-	pfCmd.Stderr = os.Stderr
-	pfOut, err := pfCmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("create port-forward pipe: %w", err)
-	}
-	if err := pfCmd.Start(); err != nil {
-		return fmt.Errorf("start port-forward: %w", err)
-	}
-	defer func() {
-		_ = pfCmd.Process.Kill()
-		_ = pfCmd.Wait()
-	}()
-
-	// Wait for port-forward to print the assigned port
-	port := ""
-	scanner := bufio.NewScanner(pfOut)
-	portCh := make(chan string, 1)
-	pfCtx, pfCancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer pfCancel()
-	go func() {
-		defer pfCancel()
-		for scanner.Scan() {
-			line := scanner.Text()
-			if idx := strings.Index(line, "Forwarding from 127.0.0.1:"); idx >= 0 {
-				rest := line[idx+len("Forwarding from 127.0.0.1:"):]
-				if end := strings.Index(rest, " "); end > 0 {
-					portCh <- rest[:end]
-					return
-				}
-			}
-		}
-	}()
-
-	select {
-	case port = <-portCh:
-	case <-pfCtx.Done():
-		return fmt.Errorf("timeout waiting for port-forward to start")
-	}
-
-	fmt.Fprintf(w, "Port-forward active on localhost:%s\n", port)
-
-	// Remove existing gateway registration
-	_ = exec.Command("openshell", "gateway", "remove", gwName).Run()
-
-	// Register gateway
-	fmt.Fprintf(w, "Registering gateway %s -> https://localhost:%s...\n", gwName, port)
-	addCmd := exec.Command("openshell", "gateway", "add",
-		"--name", gwName, "--local",
-		fmt.Sprintf("https://localhost:%s", port))
-	addOut, err := addCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("openshell gateway add: %s", string(addOut))
-	}
-
-	// Re-extract certs after add (add --local generates self-signed ones that overwrite ours)
-	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
-		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
-			return fmt.Errorf("re-extract %s: %w", key, err)
-		}
-	}
-
-	// Verify connectivity
-	fmt.Fprintf(w, "Verifying connectivity...\n")
-	statusCmd := exec.Command("openshell", "-g", gwName, "provider", "list")
-	if err := statusCmd.Run(); err != nil {
-		fmt.Fprintf(w, "Warning: connectivity check failed — verify gateway pod is running:\n")
-		fmt.Fprintf(w, "  kubectl logs -l app.kubernetes.io/instance=openshell-gateway -n %s\n", namespace)
-	} else {
-		fmt.Fprintf(w, "✓ Gateway %s connected successfully\n", gwName)
-	}
-
-	fmt.Fprintf(w, "\nUsage:\n")
-	fmt.Fprintf(w, "  openshell sandbox list --gateway %s\n", gwName)
-
-	// Keep port-forward running — detach it from this process
-	fmt.Fprintf(w, "\nPort-forward is running in the foreground (PID %d). Press Ctrl+C to stop.\n", pfCmd.Process.Pid)
-
-	// Wait for the port-forward to end (user will Ctrl+C)
-	_ = pfCmd.Wait()
-
-	return nil
-}
-
-func kubectlNamespaceExists(namespace string) bool {
-	cmd := exec.Command("kubectl", "get", "namespace", namespace)
-	return cmd.Run() == nil
-}
-
-func kubectlSecretExists(namespace, name string) bool {
-	cmd := exec.Command("kubectl", "get", "secret", name, "-n", namespace)
-	return cmd.Run() == nil
-}
-
-func extractSecretKey(namespace, secretName, key, destPath string) error {
-	cmd := exec.Command("kubectl", "get", "secret", secretName,
-		"-n", namespace,
-		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(key, ".", "\\.")))
-	out, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("kubectl get secret: %w", err)
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(string(out))
-	if err != nil {
-		return fmt.Errorf("base64 decode: %w", err)
-	}
-
-	perm := os.FileMode(0644)
-	if strings.Contains(key, "key") {
-		perm = 0600
-	}
-	return os.WriteFile(destPath, decoded, perm)
-}
-
 func printGatewayConnectionInfo(w io.Writer, gw *sdktypes.Gateway) {
 	namespace := strings.ToLower(gw.ProjectID)
 	fmt.Fprintf(w, "\nConnection Info:\n")
@@ -1169,7 +995,7 @@ func printGatewayConnectionInfo(w io.Writer, gw *sdktypes.Gateway) {
 	}
 	fmt.Fprintf(w, "  TLS Secret:   openshell-server-tls (namespace: %s)\n", namespace)
 	fmt.Fprintf(w, "\nSetup openshell CLI:\n")
-	fmt.Fprintf(w, "  acpctl get gateway %s --setup\n", gw.Name)
+	fmt.Fprintf(w, "  acpctl gateway setup %s\n", gw.Name)
 }
 
 func sessionChanged(old, current sdktypes.Session) bool {

--- a/components/ambient-cli/cmd/acpctl/get/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd.go
@@ -995,7 +995,7 @@ func printGatewayConnectionInfo(w io.Writer, gw *sdktypes.Gateway) {
 	}
 	fmt.Fprintf(w, "  TLS Secret:   openshell-server-tls (namespace: %s)\n", namespace)
 	fmt.Fprintf(w, "\nSetup openshell CLI:\n")
-	fmt.Fprintf(w, "  acpctl gateway setup %s\n", gw.Name)
+	fmt.Fprintf(w, "  acpctl gateway setup-cli %s\n", gw.Name)
 }
 
 func sessionChanged(old, current sdktypes.Session) bool {

--- a/components/ambient-cli/cmd/acpctl/get/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd.go
@@ -2,11 +2,15 @@
 package get
 
 import (
+	"bufio"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -23,6 +27,7 @@ var args struct {
 	limit        int
 	watch        bool
 	watchTimeout time.Duration
+	setup        bool
 }
 
 var Cmd = &cobra.Command{
@@ -43,6 +48,7 @@ Valid resource types:
   role-bindings       (aliases: role-binding, rb)
   credentials         (aliases: credential, cred)
   applications        (aliases: application, app, apps)
+  gateways            (aliases: gateway, gw)
 `,
 	Args:    cobra.RangeArgs(1, 2),
 	RunE:    run,
@@ -61,6 +67,7 @@ func init() {
 	Cmd.Flags().DurationVar(&args.watchTimeout, "watch-timeout", 30*time.Minute, "Timeout for watch mode (e.g. 1h, 10m)")
 	Cmd.Flags().StringVar(&projectAgentArgs.projectID, "project", "", "Project ID (required for project-agents)")
 	Cmd.Flags().StringVar(&projectAgentArgs.paID, "project-agent", "", "Filter sessions by project-agent ID (requires --project)")
+	Cmd.Flags().BoolVar(&args.setup, "setup", false, "Configure openshell CLI access for a gateway (gateways only)")
 }
 
 func run(cmd *cobra.Command, cmdArgs []string) error {
@@ -147,8 +154,10 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		return getCredentials(ctx, client, printer, name)
 	case "applications":
 		return getApplications(ctx, client, printer, name)
+	case "gateways":
+		return getGateways(ctx, client, printer, name)
 	default:
-		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-agents, project-settings, users, agents, providers, policies, roles, role-bindings, credentials", cmdArgs[0])
+		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-agents, project-settings, users, agents, providers, policies, roles, role-bindings, credentials, gateways", cmdArgs[0])
 	}
 }
 
@@ -178,6 +187,8 @@ func normalizeResource(r string) string {
 		return "credentials"
 	case "application", "applications", "app", "apps":
 		return "applications"
+	case "gateway", "gateways", "gw":
+		return "gateways"
 	default:
 		return r
 	}
@@ -903,6 +914,250 @@ func printApplicationTable(printer *output.Printer, applications []sdktypes.Appl
 		table.WriteRow(a.ID, a.Name, source, a.DestinationProject, a.SyncStatus, a.HealthStatus, age)
 	}
 	return nil
+}
+
+func getGateways(ctx context.Context, client *sdkclient.Client, printer *output.Printer, name string) error {
+	if args.setup {
+		if name == "" {
+			return fmt.Errorf("--setup requires a gateway name: acpctl get gateway <name> --setup")
+		}
+		gw, err := findGateway(ctx, client, name)
+		if err != nil {
+			return err
+		}
+		return setupOpenshellGateway(printer.Writer(), gw)
+	}
+
+	if name != "" {
+		gw, err := findGateway(ctx, client, name)
+		if err != nil {
+			return err
+		}
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(gw)
+		}
+		if err := printGatewayTable(printer, []sdktypes.Gateway{*gw}); err != nil {
+			return err
+		}
+		printGatewayConnectionInfo(printer.Writer(), gw)
+		return nil
+	}
+
+	opts := sdktypes.NewListOptions().Size(args.limit).Build()
+	list, err := client.Gateways().List(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("list gateways: %w", err)
+	}
+
+	if printer.Format() == output.FormatJSON {
+		return printer.PrintJSON(list)
+	}
+
+	return printGatewayTable(printer, list.Items)
+}
+
+func findGateway(ctx context.Context, client *sdkclient.Client, nameOrID string) (*sdktypes.Gateway, error) {
+	// Try by ID first
+	gw, err := client.Gateways().Get(ctx, nameOrID)
+	if err == nil {
+		return gw, nil
+	}
+
+	// Fall back to name search
+	opts := sdktypes.NewListOptions().Size(100).Build()
+	list, err2 := client.Gateways().List(ctx, opts)
+	if err2 != nil {
+		return nil, fmt.Errorf("list gateways: %w", err2)
+	}
+	for i := range list.Items {
+		if list.Items[i].Name == nameOrID {
+			return &list.Items[i], nil
+		}
+	}
+	return nil, fmt.Errorf("gateway %q not found", nameOrID)
+}
+
+func printGatewayTable(printer *output.Printer, gateways []sdktypes.Gateway) error {
+	columns := []output.Column{
+		{Name: "NAME", Width: 24},
+		{Name: "IMAGE", Width: 50},
+		{Name: "DNS NAMES", Width: 50},
+		{Name: "AGE", Width: 10},
+	}
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+	for _, gw := range gateways {
+		age := ""
+		if gw.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*gw.CreatedAt))
+		}
+		dnsNames := strings.Join(gw.ServerDnsNames, ",")
+		table.WriteRow(gw.Name, gw.Image, dnsNames, age)
+	}
+	return nil
+}
+
+func setupOpenshellGateway(w io.Writer, gw *sdktypes.Gateway) error {
+	namespace := strings.ToLower(gw.ProjectID)
+	gwName := gw.Name
+
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		return fmt.Errorf("kubectl not found in PATH: required for --setup")
+	}
+	if _, err := exec.LookPath("openshell"); err != nil {
+		return fmt.Errorf("openshell not found in PATH: required for --setup")
+	}
+
+	if !kubectlNamespaceExists(namespace) {
+		return fmt.Errorf("namespace %q does not exist in the cluster", namespace)
+	}
+
+	if !kubectlSecretExists(namespace, "openshell-server-tls") {
+		return fmt.Errorf("openshell-server-tls secret not found in namespace %q; gateway may not be fully provisioned", namespace)
+	}
+
+	// Extract mTLS certs before registering
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home directory: %w", err)
+	}
+	certDir := filepath.Join(homeDir, ".config", "openshell", "gateways", gwName, "mtls")
+	if err := os.MkdirAll(certDir, 0700); err != nil {
+		return fmt.Errorf("create cert directory: %w", err)
+	}
+
+	fmt.Fprintf(w, "Extracting mTLS certs from openshell-server-tls...\n")
+	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
+		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
+			return fmt.Errorf("extract %s: %w", key, err)
+		}
+	}
+
+	// Start port-forward
+	fmt.Fprintf(w, "Starting port-forward to openshell-gateway in %s...\n", namespace)
+	pfCmd := exec.Command("kubectl", "port-forward", "-n", namespace,
+		"statefulset/openshell-gateway", ":8080")
+	pfOut, err := pfCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("create port-forward pipe: %w", err)
+	}
+	pfCmd.Stderr = pfCmd.Stdout
+	if err := pfCmd.Start(); err != nil {
+		return fmt.Errorf("start port-forward: %w", err)
+	}
+	defer func() {
+		_ = pfCmd.Process.Kill()
+		_ = pfCmd.Wait()
+	}()
+
+	// Wait for port-forward to print the assigned port
+	port := ""
+	scanner := bufio.NewScanner(pfOut)
+	deadline := time.After(15 * time.Second)
+	portCh := make(chan string, 1)
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			if idx := strings.Index(line, "Forwarding from 127.0.0.1:"); idx >= 0 {
+				rest := line[idx+len("Forwarding from 127.0.0.1:"):]
+				if end := strings.Index(rest, " "); end > 0 {
+					portCh <- rest[:end]
+				}
+			}
+		}
+	}()
+
+	select {
+	case port = <-portCh:
+	case <-deadline:
+		return fmt.Errorf("timeout waiting for port-forward to start")
+	}
+
+	fmt.Fprintf(w, "Port-forward active on localhost:%s\n", port)
+
+	// Remove existing gateway registration
+	_ = exec.Command("openshell", "gateway", "remove", gwName).Run()
+
+	// Register gateway
+	fmt.Fprintf(w, "Registering gateway %s -> https://localhost:%s...\n", gwName, port)
+	addCmd := exec.Command("openshell", "gateway", "add",
+		"--name", gwName, "--local",
+		fmt.Sprintf("https://localhost:%s", port))
+	addOut, err := addCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("openshell gateway add: %s", string(addOut))
+	}
+
+	// Re-extract certs after add (add --local generates self-signed ones that overwrite ours)
+	for _, key := range []string{"ca.crt", "tls.crt", "tls.key"} {
+		if err := extractSecretKey(namespace, "openshell-server-tls", key, filepath.Join(certDir, key)); err != nil {
+			return fmt.Errorf("re-extract %s: %w", key, err)
+		}
+	}
+
+	// Verify connectivity
+	fmt.Fprintf(w, "Verifying connectivity...\n")
+	statusCmd := exec.Command("openshell", "-g", gwName, "provider", "list")
+	if err := statusCmd.Run(); err != nil {
+		fmt.Fprintf(w, "Warning: connectivity check failed — verify gateway pod is running:\n")
+		fmt.Fprintf(w, "  kubectl logs -l app.kubernetes.io/instance=openshell-gateway -n %s\n", namespace)
+	} else {
+		fmt.Fprintf(w, "✓ Gateway %s connected successfully\n", gwName)
+	}
+
+	fmt.Fprintf(w, "\nUsage:\n")
+	fmt.Fprintf(w, "  openshell sandbox list --gateway %s\n", gwName)
+
+	// Keep port-forward running — detach it from this process
+	fmt.Fprintf(w, "\nPort-forward is running in the foreground (PID %d). Press Ctrl+C to stop.\n", pfCmd.Process.Pid)
+
+	// Wait for the port-forward to end (user will Ctrl+C)
+	_ = pfCmd.Wait()
+
+	return nil
+}
+
+func kubectlNamespaceExists(namespace string) bool {
+	cmd := exec.Command("kubectl", "get", "namespace", namespace)
+	return cmd.Run() == nil
+}
+
+func kubectlSecretExists(namespace, name string) bool {
+	cmd := exec.Command("kubectl", "get", "secret", name, "-n", namespace)
+	return cmd.Run() == nil
+}
+
+func extractSecretKey(namespace, secretName, key, destPath string) error {
+	cmd := exec.Command("kubectl", "get", "secret", secretName,
+		"-n", namespace,
+		"-o", fmt.Sprintf("jsonpath={.data.%s}", strings.ReplaceAll(key, ".", "\\.")))
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("kubectl get secret: %w", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(string(out))
+	if err != nil {
+		return fmt.Errorf("base64 decode: %w", err)
+	}
+
+	perm := os.FileMode(0644)
+	if strings.Contains(key, "key") {
+		perm = 0600
+	}
+	return os.WriteFile(destPath, decoded, perm)
+}
+
+func printGatewayConnectionInfo(w io.Writer, gw *sdktypes.Gateway) {
+	namespace := strings.ToLower(gw.ProjectID)
+	fmt.Fprintf(w, "\nConnection Info:\n")
+	fmt.Fprintf(w, "  Cluster DNS:  openshell-gateway.%s.svc.cluster.local:8080\n", namespace)
+	if len(gw.ServerDnsNames) > 0 {
+		fmt.Fprintf(w, "  Server SANs:  %s\n", strings.Join(gw.ServerDnsNames, ", "))
+	}
+	fmt.Fprintf(w, "  TLS Secret:   openshell-server-tls (namespace: %s)\n", namespace)
+	fmt.Fprintf(w, "\nSetup openshell CLI:\n")
+	fmt.Fprintf(w, "  acpctl get gateway %s --setup\n", gw.Name)
 }
 
 func sessionChanged(old, current sdktypes.Session) bool {

--- a/components/ambient-cli/cmd/acpctl/login/authcode.go
+++ b/components/ambient-cli/cmd/acpctl/login/authcode.go
@@ -267,6 +267,36 @@ func parseTokensResponse(body []byte) (*tokenResult, error) {
 	}, nil
 }
 
+func runPasswordGrantFlow(issuerURL, clientID, username, password string) (*tokenResult, error) {
+	issuerURL = strings.TrimRight(issuerURL, "/")
+	tokenURL := issuerURL + "/protocol/openid-connect/token"
+
+	params := url.Values{
+		"grant_type": {"password"},
+		"client_id":  {clientID},
+		"username":   {username},
+		"password":   {password},
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.PostForm(tokenURL, params)
+	if err != nil {
+		return nil, fmt.Errorf("POST to token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, tokenEndpointError(resp.StatusCode, body)
+	}
+
+	return parseTokensResponse(body)
+}
+
 func runClientCredentialsFlow(issuerURL, clientID, clientSecret string) (*tokenResult, error) {
 	issuerURL = strings.TrimRight(issuerURL, "/")
 	tokenURL := issuerURL + "/protocol/openid-connect/token"

--- a/components/ambient-cli/cmd/acpctl/login/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/login/cmd.go
@@ -17,6 +17,9 @@ var args struct {
 	insecureSkipVerify bool
 	useAuthCode        bool
 	clientCredentials  bool
+	passwordGrant      bool
+	username           string
+	password           string
 	issuerURL          string
 	clientID           string
 	clientSecret       string
@@ -35,7 +38,10 @@ To log in via browser (OAuth2 authorization code + PKCE via Red Hat SSO):
   acpctl login --use-auth-code --url https://api.example.com
 
 To log in as a service account (headless, OAuth2 client_credentials grant):
-  acpctl login --client-credentials --client-id <id> --client-secret <secret> --url https://api.example.com`,
+  acpctl login --client-credentials --client-id <id> --client-secret <secret> --url https://api.example.com
+
+To log in with username/password (headless, OAuth2 resource owner password grant):
+  acpctl login --password-grant --username developer --password developer --issuer-url http://localhost:11880/realms/ambient-code --url http://localhost:12080`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: run,
 }
@@ -48,6 +54,9 @@ func init() {
 	flags.BoolVar(&args.insecureSkipVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification (insecure)")
 	flags.BoolVar(&args.useAuthCode, "use-auth-code", false, "Log in via browser using OAuth2 authorization code flow (Red Hat SSO)")
 	flags.BoolVar(&args.clientCredentials, "client-credentials", false, "Log in using OAuth2 client_credentials grant (headless service accounts)")
+	flags.BoolVar(&args.passwordGrant, "password-grant", false, "Log in using OAuth2 resource owner password grant (headless, requires --username and --password)")
+	flags.StringVar(&args.username, "username", "", "Username for --password-grant")
+	flags.StringVar(&args.password, "password", "", "Password for --password-grant")
 	flags.StringVar(&args.issuerURL, "issuer-url", defaultIssuerURL, "OIDC issuer URL (used with --use-auth-code)")
 	flags.StringVar(&args.clientID, "client-id", defaultClientID, "OAuth2 client ID (used with --use-auth-code)")
 	flags.StringVar(&args.clientSecret, "client-secret", "", "OAuth2 client secret (used with --use-auth-code for confidential clients; never persisted to config)")
@@ -64,11 +73,17 @@ func run(cmd *cobra.Command, positional []string) error {
 	if args.clientCredentials {
 		modes++
 	}
+	if args.passwordGrant {
+		modes++
+	}
 	if modes != 1 {
-		return fmt.Errorf("exactly one of --token, --use-auth-code, or --client-credentials is required")
+		return fmt.Errorf("exactly one of --token, --use-auth-code, --client-credentials, or --password-grant is required")
 	}
 	if args.clientCredentials && args.clientSecret == "" {
 		return fmt.Errorf("--client-secret is required with --client-credentials")
+	}
+	if args.passwordGrant && (args.username == "" || args.password == "") {
+		return fmt.Errorf("--username and --password are required with --password-grant")
 	}
 	cfg, err := config.Load()
 	if err != nil {
@@ -115,6 +130,15 @@ func run(cmd *cobra.Command, positional []string) error {
 		}
 		accessToken = tokens.AccessToken
 		cfg.RefreshToken = ""
+		cfg.IssuerURL = args.issuerURL
+		cfg.ClientID = args.clientID
+	case args.passwordGrant:
+		tokens, err := runPasswordGrantFlow(args.issuerURL, args.clientID, args.username, args.password)
+		if err != nil {
+			return fmt.Errorf("password-grant login: %w", err)
+		}
+		accessToken = tokens.AccessToken
+		cfg.RefreshToken = tokens.RefreshToken
 		cfg.IssuerURL = args.issuerURL
 		cfg.ClientID = args.clientID
 	default:

--- a/components/ambient-cli/cmd/acpctl/main.go
+++ b/components/ambient-cli/cmd/acpctl/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/credential"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/delete"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/describe"
+	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/gateway"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/get"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/inbox"
 	"github.com/ambient-code/platform/components/ambient-cli/cmd/acpctl/login"
@@ -72,6 +73,7 @@ func init() {
 	root.AddCommand(provider.Cmd)
 	root.AddCommand(policy.Cmd)
 	root.AddCommand(inbox.Cmd)
+	root.AddCommand(gateway.Cmd)
 	root.AddCommand(get.Cmd)
 	root.AddCommand(create.Cmd)
 	root.AddCommand(delete.Cmd)

--- a/components/ambient-cli/cmd/acpctl/main.go
+++ b/components/ambient-cli/cmd/acpctl/main.go
@@ -58,7 +58,7 @@ var root = &cobra.Command{
 
 func init() {
 	root.PersistentFlags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification (insecure)")
-	root.PersistentFlags().StringVar(&apiURLOverride, "api-url", "", "Override the API server URL for this invocation")
+	root.PersistentFlags().StringVarP(&apiURLOverride, "api-url", "U", "", "Override the API server URL for this invocation")
 	root.AddCommand(login.Cmd)
 	root.AddCommand(logout.Cmd)
 	root.AddCommand(version.Cmd)

--- a/specs/cli/gateway-cli.spec.md
+++ b/specs/cli/gateway-cli.spec.md
@@ -1,0 +1,175 @@
+# Gateway CLI Management
+
+## Purpose
+
+The `acpctl` CLI SHALL support gateway resources as a first-class resource type across `get`, `delete`, and a dedicated `gateway` subcommand tree. This provides operators with full CLI access to inspect gateway connection details and configure local openshell CLI access against provisioned gateways.
+
+**Related:** `gateway-provisioning.spec.md` — gateway resource model and reconciliation; `openshell-sandbox.spec.md` — sandbox execution via gateways
+
+---
+
+## Requirements
+
+### Requirement: Get Gateways
+
+The `acpctl get` command SHALL support `gateways` as a resource type with aliases `gateway` and `gw`.
+
+When listing all gateways (`acpctl get gateways`), the output SHALL display a table with the following columns:
+
+| Column | Width | Content |
+|--------|-------|---------|
+| NAME | 24 | `gateway.name` |
+| IMAGE | 50 | `gateway.image` |
+| DNS NAMES | 50 | Comma-separated `gateway.serverDnsNames` |
+| AGE | 10 | Relative time since `created_at` |
+
+When retrieving a single gateway by name or ID (`acpctl get gateway <name>`), the output SHALL display the table row followed by a connection info block.
+
+The command SHALL support JSON output via the standard `--output json` flag.
+
+#### Scenario: List all gateways
+
+- GIVEN gateways "alpha" and "beta" exist
+- WHEN the user runs `acpctl get gateways`
+- THEN a table renders with NAME, IMAGE, DNS NAMES, and AGE columns
+- AND both gateways appear as rows
+
+#### Scenario: Get a single gateway by name
+
+- GIVEN gateway "alpha" exists in project "platform"
+- WHEN the user runs `acpctl get gateway alpha`
+- THEN the table renders with one row for "alpha"
+- AND a connection info block is printed below the table
+
+#### Scenario: Gateway not found
+
+- GIVEN no gateway named "nonexistent" exists
+- WHEN the user runs `acpctl get gateway nonexistent`
+- THEN the command exits with an error: `gateway "nonexistent" not found`
+
+#### Scenario: JSON output
+
+- GIVEN gateway "alpha" exists
+- WHEN the user runs `acpctl get gateway alpha -o json`
+- THEN the gateway object is printed as JSON
+
+### Requirement: Gateway Connection Info
+
+When a single gateway is retrieved, the CLI SHALL print a connection info block after the table containing:
+
+- **Cluster DNS**: The in-cluster service address (`openshell-gateway.<namespace>.svc.cluster.local:8080`)
+- **Server SANs**: The gateway's configured DNS names (only if `serverDnsNames` is non-empty)
+- **TLS Secret**: The name and namespace of the mTLS secret (`openshell-server-tls`)
+- **Setup hint**: The `acpctl gateway setup-cli <name>` command to configure local CLI access
+
+The namespace SHALL be derived from the gateway's `projectID`, lowercased.
+
+#### Scenario: Connection info with DNS names
+
+- GIVEN gateway "alpha" has `serverDnsNames: ["gw.example.com"]` and belongs to project "PLATFORM"
+- WHEN the user runs `acpctl get gateway alpha`
+- THEN the connection info shows:
+  - Cluster DNS: `openshell-gateway.platform.svc.cluster.local:8080`
+  - Server SANs: `gw.example.com`
+  - TLS Secret: `openshell-server-tls (namespace: platform)`
+  - Setup hint: `acpctl gateway setup-cli alpha`
+
+#### Scenario: Connection info without DNS names
+
+- GIVEN gateway "beta" has an empty `serverDnsNames` list
+- WHEN the user runs `acpctl get gateway beta`
+- THEN the Server SANs line is omitted from the connection info
+
+### Requirement: Delete Gateway
+
+The `acpctl delete` command SHALL support `gateway` as a resource type with aliases `gateways` and `gw`.
+
+#### Scenario: Delete a gateway
+
+- GIVEN gateway "alpha" exists
+- WHEN the user runs `acpctl delete gateway alpha`
+- THEN the gateway is deleted via the API
+- AND the output shows `gateway/alpha deleted`
+
+#### Scenario: Delete nonexistent gateway
+
+- GIVEN no gateway named "nonexistent" exists
+- WHEN the user runs `acpctl delete gateway nonexistent`
+- THEN the command exits with an error
+
+### Requirement: Gateway Subcommand Tree
+
+The `acpctl gateway` top-level command SHALL provide a subcommand tree for gateway management operations. Running `acpctl gateway` without a subcommand SHALL display help text.
+
+### Requirement: Gateway Setup CLI
+
+The `acpctl gateway setup-cli <name>` command SHALL configure local openshell CLI access for a named gateway. The command performs the following steps in order:
+
+1. **Resolve gateway** — Fetch the gateway by name or ID from the API server
+2. **Prerequisite checks** — Verify `kubectl` and `openshell` are in PATH; verify the target namespace exists in the cluster; verify the `openshell-server-tls` secret exists
+3. **Extract mTLS certificates** — Extract `ca.crt`, `tls.crt`, and `tls.key` from the `openshell-server-tls` secret and write them to `~/.config/openshell/gateways/<name>/mtls/`
+4. **Start port-forward** — Run `kubectl port-forward` to the `openshell-gateway` StatefulSet on port 8080 with an ephemeral local port
+5. **Register gateway** — Remove any existing openshell gateway registration with the same name, then register the gateway via `openshell gateway add --name <name> --local https://localhost:<port>`
+6. **Verify connectivity** — Run `openshell -g <name> provider list` to verify the connection works
+7. **Hold port-forward** — Keep the port-forward running in the foreground until the user presses Ctrl+C
+
+The namespace SHALL be derived from the gateway's `projectID`, lowercased.
+
+Private key files (`tls.key`) SHALL be written with `0600` permissions. Other certificate files SHALL use `0644`.
+
+#### Scenario: Successful setup
+
+- GIVEN gateway "alpha" exists in project "platform"
+- AND kubectl is configured with access to namespace "platform"
+- AND the `openshell-server-tls` secret exists in namespace "platform"
+- AND `kubectl` and `openshell` are installed
+- WHEN the user runs `acpctl gateway setup-cli alpha`
+- THEN mTLS certs are extracted to `~/.config/openshell/gateways/alpha/mtls/`
+- AND a port-forward starts to `statefulset/openshell-gateway` in namespace "platform"
+- AND the gateway is registered with the openshell CLI
+- AND a connectivity check runs
+- AND the port-forward remains active until interrupted
+
+#### Scenario: kubectl not installed
+
+- GIVEN `kubectl` is not in PATH
+- WHEN the user runs `acpctl gateway setup-cli alpha`
+- THEN the command exits with error: `kubectl not found in PATH: required for gateway setup`
+
+#### Scenario: openshell not installed
+
+- GIVEN `openshell` is not in PATH
+- WHEN the user runs `acpctl gateway setup-cli alpha`
+- THEN the command exits with error: `openshell not found in PATH: required for gateway setup`
+
+#### Scenario: Namespace does not exist
+
+- GIVEN gateway "alpha" belongs to project "missing"
+- AND namespace "missing" does not exist in the cluster
+- WHEN the user runs `acpctl gateway setup-cli alpha`
+- THEN the command exits with error: `namespace "missing" does not exist in the cluster`
+
+#### Scenario: TLS secret not found
+
+- GIVEN gateway "alpha" belongs to project "platform"
+- AND the `openshell-server-tls` secret does not exist in namespace "platform"
+- WHEN the user runs `acpctl gateway setup-cli alpha`
+- THEN the command exits with error indicating the secret is not found and the gateway may not be fully provisioned
+
+#### Scenario: Connectivity check fails
+
+- GIVEN all setup steps succeed
+- BUT `openshell provider list` fails
+- WHEN the user runs `acpctl gateway setup-cli alpha`
+- THEN a warning is printed with troubleshooting guidance
+- AND the port-forward remains active (the command does not exit on verification failure)
+
+### Requirement: API URL Short Flag
+
+The `acpctl` root command SHALL support `-U` as a short flag alias for `--api-url`, allowing `acpctl -U https://api.example.com get gateways`.
+
+#### Scenario: Short flag for API URL
+
+- GIVEN a valid API server at `https://api.example.com`
+- WHEN the user runs `acpctl -U https://api.example.com get gateways`
+- THEN the command uses `https://api.example.com` as the API server URL

--- a/specs/cli/gateway-cli.spec.md
+++ b/specs/cli/gateway-cli.spec.md
@@ -123,17 +123,30 @@ The command operates in one of three modes based on the current state:
 2. Write `metadata.json` to `~/.config/openshell/gateways/<local-name>/` with gateway endpoint, auth mode, and OIDC configuration
 3. Write `oidc_token.json` with the user's acpctl access token and refresh token
 4. Attempt to fetch mTLS certificates from the `openshell-client-tls` K8s secret in the gateway's namespace via `kubectl`, writing `ca.crt`, `tls.crt`, and `tls.key` to `~/.config/openshell/gateways/<local-name>/mtls/`
-5. If mTLS fetch fails, warn the user that `--gateway-insecure` may be needed (non-fatal)
+5. If mTLS fetch fails, warn the user to ensure kubectl access or manually provision certs (non-fatal)
+6. Verify connectivity via `openshell status -g <local-name>` — if the gateway is unreachable, clean up the written config and fail with an error
 
 **Non-interactive re-authentication** (gateway already registered + acpctl credentials available):
 
 1. Refresh the `oidc_token.json` with current acpctl credentials
 2. Attempt to refresh mTLS certificates (non-fatal on failure)
+3. Verify connectivity via `openshell status -g <local-name>`
 
 **Interactive fallback** (no acpctl credentials OR non-OIDC gateway):
 
 1. For new registrations: delegate to `openshell gateway add` with appropriate flags
 2. For re-authentication: delegate to `openshell gateway login`
+3. Verify connectivity via `openshell status -g <local-name>`
+
+#### Connectivity Validation
+
+After all registration or re-authentication paths, the command SHALL run `openshell status -g <local-name>` to verify the gateway is reachable. If the check fails:
+
+- For **new registrations**: the gateway config directory (`~/.config/openshell/gateways/<local-name>/`) is removed so broken state is not left behind
+- For **re-authentication**: the existing config is preserved (the gateway was previously working)
+- The command exits with an error indicating the gateway URL is not reachable
+
+This prevents users from successfully "configuring" a gateway that points to a wrong URL, wrong port, or a gateway that isn't running.
 
 #### mTLS Certificate Handling
 
@@ -185,6 +198,14 @@ When `--print` is specified, the command SHALL print the equivalent openshell co
 - WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url https://gw.example.com:8080`
 - THEN `openshell gateway add` is invoked with OIDC flags
 - AND the browser-based OIDC login flow opens
+
+#### Scenario: Unreachable gateway URL
+
+- GIVEN gateway "alpha" exists in the API server
+- AND the user provides `--gateway-url https://localhost:99999` (nothing listening)
+- WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url https://localhost:99999`
+- THEN the command exits with error: `gateway at https://localhost:99999 is not reachable`
+- AND no gateway config is left in `~/.config/openshell/gateways/`
 
 #### Scenario: openshell not installed
 

--- a/specs/cli/gateway-cli.spec.md
+++ b/specs/cli/gateway-cli.spec.md
@@ -59,8 +59,7 @@ When a single gateway is retrieved, the CLI SHALL print a connection info block 
 
 - **Cluster DNS**: The in-cluster service address (`openshell-gateway.<namespace>.svc.cluster.local:8080`)
 - **Server SANs**: The gateway's configured DNS names (only if `serverDnsNames` is non-empty)
-- **TLS Secret**: The name and namespace of the mTLS secret (`openshell-server-tls`)
-- **Setup hint**: The `acpctl gateway setup-cli <name>` command to configure local CLI access
+- **Setup hint**: The `acpctl gateway setup-cli <name> --gateway-url <url>` command to configure local CLI access
 
 The namespace SHALL be derived from the gateway's `projectID`, lowercased.
 
@@ -71,8 +70,7 @@ The namespace SHALL be derived from the gateway's `projectID`, lowercased.
 - THEN the connection info shows:
   - Cluster DNS: `openshell-gateway.platform.svc.cluster.local:8080`
   - Server SANs: `gw.example.com`
-  - TLS Secret: `openshell-server-tls (namespace: platform)`
-  - Setup hint: `acpctl gateway setup-cli alpha`
+  - Setup hint: `acpctl gateway setup-cli alpha --gateway-url <url>`
 
 #### Scenario: Connection info without DNS names
 
@@ -99,70 +97,184 @@ The `acpctl delete` command SHALL support `gateway` as a resource type with alia
 
 ### Requirement: Gateway Subcommand Tree
 
-The `acpctl gateway` top-level command SHALL provide a subcommand tree for gateway management operations. Running `acpctl gateway` without a subcommand SHALL display help text.
+The `acpctl gateway` top-level command SHALL provide a subcommand tree for gateway management operations. Running `acpctl gateway` without a subcommand SHALL display help text listing available subcommands (`setup-cli`, `remove-cli`).
 
 ### Requirement: Gateway Setup CLI
 
-The `acpctl gateway setup-cli <name>` command SHALL configure local openshell CLI access for a named gateway. The command performs the following steps in order:
+The `acpctl gateway setup-cli [name]` command SHALL configure local openshell CLI access for a named gateway.
 
-1. **Resolve gateway** — Fetch the gateway by name or ID from the API server
-2. **Prerequisite checks** — Verify `kubectl` and `openshell` are in PATH; verify the target namespace exists in the cluster; verify the `openshell-server-tls` secret exists
-3. **Extract mTLS certificates** — Extract `ca.crt`, `tls.crt`, and `tls.key` from the `openshell-server-tls` secret and write them to `~/.config/openshell/gateways/<name>/mtls/`
-4. **Start port-forward** — Run `kubectl port-forward` to the `openshell-gateway` StatefulSet on port 8080 with an ephemeral local port
-5. **Register gateway** — Remove any existing openshell gateway registration with the same name, then register the gateway via `openshell gateway add --name <name> --local https://localhost:<port>`
-6. **Verify connectivity** — Run `openshell -g <name> provider list` to verify the connection works
-7. **Hold port-forward** — Keep the port-forward running in the foreground until the user presses Ctrl+C
+#### Flags
 
-The namespace SHALL be derived from the gateway's `projectID`, lowercased.
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--gateway-url` | Yes | — | Gateway URL (e.g. `https://gateway.example.com:8080`) |
+| `--project` | No | Configured project | Project/namespace to look up the gateway in |
+| `--print` | No | `false` | Print openshell commands instead of running them |
 
-Private key files (`tls.key`) SHALL be written with `0600` permissions. Other certificate files SHALL use `0644`.
+The API-side gateway name defaults to `openshell-gateway` if the positional `[name]` argument is omitted. The local openshell registration is named `<project>-<gateway-name>`.
 
-#### Scenario: Successful setup
+#### Modes of Operation
 
-- GIVEN gateway "alpha" exists in project "platform"
-- AND kubectl is configured with access to namespace "platform"
-- AND the `openshell-server-tls` secret exists in namespace "platform"
-- AND `kubectl` and `openshell` are installed
-- WHEN the user runs `acpctl gateway setup-cli alpha`
-- THEN mTLS certs are extracted to `~/.config/openshell/gateways/alpha/mtls/`
-- AND a port-forward starts to `statefulset/openshell-gateway` in namespace "platform"
-- AND the gateway is registered with the openshell CLI
-- AND a connectivity check runs
-- AND the port-forward remains active until interrupted
+The command operates in one of three modes based on the current state:
 
-#### Scenario: kubectl not installed
+**Non-interactive new registration** (OIDC gateway + acpctl credentials available):
 
-- GIVEN `kubectl` is not in PATH
-- WHEN the user runs `acpctl gateway setup-cli alpha`
-- THEN the command exits with error: `kubectl not found in PATH: required for gateway setup`
+1. Fetch the gateway resource from the API server
+2. Write `metadata.json` to `~/.config/openshell/gateways/<local-name>/` with gateway endpoint, auth mode, and OIDC configuration
+3. Write `oidc_token.json` with the user's acpctl access token and refresh token
+4. Attempt to fetch mTLS certificates from the `openshell-client-tls` K8s secret in the gateway's namespace via `kubectl`, writing `ca.crt`, `tls.crt`, and `tls.key` to `~/.config/openshell/gateways/<local-name>/mtls/`
+5. If mTLS fetch fails, warn the user that `--gateway-insecure` may be needed (non-fatal)
+
+**Non-interactive re-authentication** (gateway already registered + acpctl credentials available):
+
+1. Refresh the `oidc_token.json` with current acpctl credentials
+2. Attempt to refresh mTLS certificates (non-fatal on failure)
+
+**Interactive fallback** (no acpctl credentials OR non-OIDC gateway):
+
+1. For new registrations: delegate to `openshell gateway add` with appropriate flags
+2. For re-authentication: delegate to `openshell gateway login`
+
+#### mTLS Certificate Handling
+
+The `openshell-client-tls` K8s secret in the gateway's namespace contains `ca.crt`, `tls.crt`, and `tls.key`. These are fetched via `kubectl get secret` and written to the openshell config directory.
+
+- `ca.crt` enables openshell to verify the gateway's TLS certificate without `--gateway-insecure`
+- `tls.crt` and `tls.key` provide mTLS client authentication
+- Private key files (`tls.key`) SHALL be written with `0600` permissions. Other certificate files SHALL use `0644`.
+- `kubectl` must be in PATH and configured with access to the gateway's namespace
+- mTLS fetch failure is non-fatal: the gateway registration succeeds but may require `--gateway-insecure`
+
+#### Print Mode
+
+When `--print` is specified, the command SHALL print the equivalent openshell commands (gateway add, gateway login, provider list) instead of executing them. This is useful for debugging or manual execution.
+
+#### Scenario: Non-interactive setup with OIDC credentials
+
+- GIVEN gateway "alpha" exists with OIDC config in project "platform"
+- AND the user has a valid acpctl OIDC token (via `acpctl login --password-grant` or `--use-auth-code`)
+- AND `kubectl` has access to namespace "platform"
+- AND the `openshell-client-tls` secret exists in namespace "platform"
+- WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url https://gw.example.com:8080`
+- THEN metadata.json and oidc_token.json are written to `~/.config/openshell/gateways/platform-alpha/`
+- AND mTLS certs are written to `~/.config/openshell/gateways/platform-alpha/mtls/`
+- AND `openshell -g platform-alpha provider list` works without `--gateway-insecure`
+
+#### Scenario: Non-interactive setup without kubectl access
+
+- GIVEN gateway "alpha" exists with OIDC config
+- AND the user has a valid acpctl OIDC token
+- BUT `kubectl` is not in PATH or lacks access to the namespace
+- WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url https://gw.example.com:8080`
+- THEN metadata.json and oidc_token.json are written successfully
+- AND a warning is printed: `Warning: could not fetch mTLS certs`
+- AND the user is advised to manually provision mTLS certificates or ensure kubectl access
+
+#### Scenario: Re-authentication of existing gateway
+
+- GIVEN gateway "platform-alpha" is already registered in openshell
+- AND the user has refreshed their acpctl credentials
+- WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url https://gw.example.com:8080`
+- THEN the oidc_token.json is updated with current credentials
+- AND mTLS certs are refreshed
+
+#### Scenario: Interactive fallback without credentials
+
+- GIVEN gateway "alpha" exists with OIDC config
+- AND the user has no acpctl access token
+- WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url https://gw.example.com:8080`
+- THEN `openshell gateway add` is invoked with OIDC flags
+- AND the browser-based OIDC login flow opens
 
 #### Scenario: openshell not installed
 
 - GIVEN `openshell` is not in PATH
-- WHEN the user runs `acpctl gateway setup-cli alpha`
+- WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url ...`
 - THEN the command exits with error: `openshell not found in PATH: required for gateway setup`
 
-#### Scenario: Namespace does not exist
+#### Scenario: Print mode
 
-- GIVEN gateway "alpha" belongs to project "missing"
-- AND namespace "missing" does not exist in the cluster
-- WHEN the user runs `acpctl gateway setup-cli alpha`
-- THEN the command exits with error: `namespace "missing" does not exist in the cluster`
+- GIVEN gateway "alpha" exists
+- WHEN the user runs `acpctl gateway setup-cli alpha --gateway-url https://gw.example.com:8080 --print`
+- THEN the output shows the openshell gateway add, login, and verify commands
+- AND no commands are executed
 
-#### Scenario: TLS secret not found
+### Requirement: Gateway Remove CLI
 
-- GIVEN gateway "alpha" belongs to project "platform"
-- AND the `openshell-server-tls` secret does not exist in namespace "platform"
-- WHEN the user runs `acpctl gateway setup-cli alpha`
-- THEN the command exits with error indicating the secret is not found and the gateway may not be fully provisioned
+The `acpctl gateway remove-cli [name]` command SHALL remove a local openshell CLI gateway registration.
 
-#### Scenario: Connectivity check fails
+#### Flags
 
-- GIVEN all setup steps succeed
-- BUT `openshell provider list` fails
-- WHEN the user runs `acpctl gateway setup-cli alpha`
-- THEN a warning is printed with troubleshooting guidance
-- AND the port-forward remains active (the command does not exit on verification failure)
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--project` | No | Configured project | Project/namespace used to derive the gateway name |
+
+If the positional `[name]` argument is omitted, the gateway name is derived as `<project>-openshell-gateway`.
+
+The command delegates to `openshell gateway remove <name>`.
+
+#### Scenario: Remove a registered gateway
+
+- GIVEN gateway "platform-openshell-gateway" is registered in openshell
+- WHEN the user runs `acpctl gateway remove-cli --project platform`
+- THEN the gateway registration is removed from openshell
+- AND the output shows `Gateway platform-openshell-gateway removed`
+
+#### Scenario: Remove by explicit name
+
+- GIVEN gateway "my-gateway" is registered in openshell
+- WHEN the user runs `acpctl gateway remove-cli my-gateway`
+- THEN the gateway registration is removed
+
+#### Scenario: Gateway not registered
+
+- GIVEN gateway "missing" is not registered in openshell
+- WHEN the user runs `acpctl gateway remove-cli missing`
+- THEN the command exits with error: `gateway "missing" is not registered in openshell`
+
+#### Scenario: openshell not installed
+
+- GIVEN `openshell` is not in PATH
+- WHEN the user runs `acpctl gateway remove-cli ...`
+- THEN the command exits with error: `openshell not found in PATH: required for gateway removal`
+
+### Requirement: OIDC Password Grant Login
+
+The `acpctl login` command SHALL support `--password-grant` for headless OIDC token acquisition via the OAuth2 Resource Owner Password Credentials (ROPC) grant.
+
+#### Flags
+
+| Flag | Required with `--password-grant` | Description |
+|------|----------------------------------|-------------|
+| `--password-grant` | — | Enable ROPC grant mode |
+| `--username` | Yes | OIDC username |
+| `--password` | Yes | OIDC password |
+| `--issuer-url` | No (default: Red Hat SSO) | OIDC issuer URL |
+| `--client-id` | No (default: `ocm-cli`) | OAuth2 client ID |
+
+The command POSTs to `<issuer-url>/protocol/openid-connect/token` with `grant_type=password`. Both access and refresh tokens are saved to the acpctl config.
+
+`--password-grant` is mutually exclusive with `--token`, `--use-auth-code`, and `--client-credentials`.
+
+This mode enables non-interactive gateway setup in CI/CD, local dev (`make kind-acpctl-login`), and environments where browser-based OIDC is unavailable.
+
+#### Scenario: Headless OIDC login
+
+- GIVEN a Keycloak realm at `http://localhost:11880/realms/ambient-code` with user `developer`/`developer`
+- WHEN the user runs `acpctl login --password-grant --username developer --password developer --issuer-url http://localhost:11880/realms/ambient-code --client-id openshell-cli --url http://localhost:13080`
+- THEN an OIDC JWT access token and refresh token are saved to the acpctl config
+- AND subsequent `acpctl gateway setup-cli` commands use the OIDC token for non-interactive registration
+
+#### Scenario: Missing credentials
+
+- WHEN the user runs `acpctl login --password-grant --username developer`
+- THEN the command exits with error: `--username and --password are required with --password-grant`
+
+#### Scenario: Invalid credentials
+
+- GIVEN a valid OIDC issuer
+- WHEN the user runs `acpctl login --password-grant --username wrong --password wrong ...`
+- THEN the command exits with an error from the token endpoint (e.g. `Invalid user credentials`)
 
 ### Requirement: API URL Short Flag
 
@@ -173,3 +285,15 @@ The `acpctl` root command SHALL support `-U` as a short flag alias for `--api-ur
 - GIVEN a valid API server at `https://api.example.com`
 - WHEN the user runs `acpctl -U https://api.example.com get gateways`
 - THEN the command uses `https://api.example.com` as the API server URL
+
+### Requirement: Deterministic Gateway Port-Forwards (Local Dev)
+
+In the local Kind development environment, gateway port-forwards SHALL use deterministic ports based on `KIND_FWD_GATEWAY_BASE_PORT` (default `15080`) with a per-namespace offset.
+
+- Gateways are discovered by label `app.kubernetes.io/instance=openshell-gateway`
+- Namespaces are sorted alphabetically; the first gets port `15080`, the second `15081`, etc.
+- The assigned port is written to `$(KIND_PF_DIR)/kind-pf-openshell-<namespace>.port`
+- Status checks, access printout, and cleanup targets read from `.port` files (not log scraping)
+- `make kind-port-forward-stop` removes `.pid`, `.log`, and `.port` files
+
+This replaces the previous ephemeral port allocation where ports were discovered by parsing `kubectl port-forward` log output.


### PR DESCRIPTION
## Summary
- Add `acpctl get gateways` to list/get gateway resources with connection info (cluster DNS, SANs, TLS secret)
- Add `acpctl get gateway <name> --setup` to auto-configure the openshell CLI (extract certs, port-forward, register gateway)
- Add `acpctl delete gateway` support
- Gateway lookup works by both name and ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)