### PR TITLE
Fix/keycloak aarch64 crash

### DIFF
--- a/components/manifests/overlays/hcmais/keycloak/keycloak-deployment.yaml
+++ b/components/manifests/overlays/hcmais/keycloak/keycloak-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.0
+          image: quay.io/keycloak/keycloak:26.6.3
           args:
             - start
             - --import-realm

--- a/components/manifests/overlays/kind/keycloak-deployment.yaml
+++ b/components/manifests/overlays/kind/keycloak-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: false # Keycloak upstream image requires root; acceptable in Kind dev only
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.0
+          image: quay.io/keycloak/keycloak:26.6.3
           args:
             - start-dev
             - --import-realm

--- a/tests/infra/setup-kind.sh
+++ b/tests/infra/setup-kind.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "======================================"
-echo "Setting up kind cluster for Ambient"
-echo "======================================"
+echo "=================================================="
+echo "Setting up kind cluster for Agent Control Plane"
+echo "=================================================="
 
 # Cluster name (override via env var for multi-worktree support)
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-ambient-local}"


### PR DESCRIPTION
# Summary

Keycloak 26.0 ships JDK 21.0.6, which has a fatal SIGILL in System.registerNatives() on linux-aarch64. This causes CrashLoopBackOff on Apple Silicon Kind clusters, completely blocking local development with SSO enabled. Bumps the Keycloak image from 26.0 to 26.6.3 in both the kind and hcmais overlays, which ships a patched JDK build.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

