### PR TITLE
fix(kind): restart deployments after loading local images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -909,6 +909,8 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 		$(MAKE) --no-print-directory _kind-load-images; \
 		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Deploying with locally-built images..."; \
 		kubectl apply --validate=false -k components/manifests/overlays/kind-local/; \
+		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Restarting deployments to pick up freshly built images..."; \
+		kubectl rollout restart deployment -n $(NAMESPACE); \
 		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Patching agent registry for local images..."; \
 		REGISTRY=$$(kubectl get configmap ambient-agent-registry -n $(NAMESPACE) -o jsonpath='{.data.agent-registry\.json}'); \
 		kubectl patch configmap ambient-agent-registry -n $(NAMESPACE) --type=merge \


### PR DESCRIPTION
## Summary

- Fixes stale images when running `make kind-up LOCAL_IMAGES=true` against an existing cluster
- When `setup-kind.sh` detects the cluster already exists it exits early, then `kubectl apply` sees no spec change (image tag is still `:latest`) and doesn't trigger a rollout — pods keep running old containers
- Adds `kubectl rollout restart deployment` after `kubectl apply` in the `LOCAL_IMAGES=true` path so pods always pick up freshly built images from containerd

## Test plan

- [ ] Run `make kind-up LOCAL_IMAGES=true` on a fresh cluster — verify images match current source
- [ ] Make a source change, then run `make kind-up LOCAL_IMAGES=true` again on the same cluster — verify pods restart and pick up the new images
- [ ] Confirm `make kind-rebuild` still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)