### PR TITLE
feat(spec): add Learn view specification

### DIFF
--- a/specs/index.spec.md
+++ b/specs/index.spec.md
@@ -52,6 +52,7 @@ Machine-readable index for autonomous reconciliation (`/reconcile` skill).
 | `ui/project-sharing.spec.md` | ui | Project sharing, ownership transfer | FE, BE | rbac-enforcement |
 | `ui/scheduled-sessions.spec.md` | ui | Schedule CRUD UI | FE | scheduled-session-execution |
 | `ui/work-tracking-dashboard.spec.md` | ui | Dashboard, work annotations | FE | annotations, views |
+| `ui/learn.spec.md` | ui | Learn catalog, static content | FE | architecture |
 | `standards/control-plane/conventions.spec.md` | standards | - | CP | - |
 | `standards/platform/cross-cutting.spec.md` | standards | - | ALL | - |
 | `standards/security/security.spec.md` | standards | - | ALL | - |

--- a/specs/ui/index.spec.md
+++ b/specs/ui/index.spec.md
@@ -19,3 +19,7 @@ Structured metadata on sessions, agents, and projects. Covers annotation schemas
 ### [Live Preview and Real-Time Updates](live-preview.spec.md)
 
 Visual feedback for running sessions including live preview, screenshot capture, real-time update streaming, and WebSocket integration.
+
+### [Learn](learn.spec.md)
+
+In-app catalog of learning resources rendered from markdown files in `examples/docs/`. Static build-time content, global scope.

--- a/specs/ui/index.spec.md
+++ b/specs/ui/index.spec.md
@@ -22,4 +22,4 @@ Visual feedback for running sessions including live preview, screenshot capture,
 
 ### [Learn](learn.spec.md)
 
-In-app catalog of learning resources rendered from markdown files in `examples/docs/`. Static build-time content, global scope.
+In-app catalog of learning resources compiled from `docs/src/content/docs/concepts/` (Concepts) and `examples/docs/` (Examples). Static build-time content, global scope.

--- a/specs/ui/learn.spec.md
+++ b/specs/ui/learn.spec.md
@@ -1,0 +1,146 @@
+# Learn Specification
+
+## Purpose
+
+The Learn view provides an in-app learning hub with two sections: **Concepts** (platform fundamentals) and **Examples** (runnable demos). Users can browse and read all learning content without leaving the UI or navigating to the source repository. The content is static — compiled at build time from markdown files already present in the repository. Inspired by OpenShift AI's "Resources" page and Developer Hub's "Learning Paths".
+
+## Content Sources
+
+| Section | Source directory | Scope |
+|---------|-----------------|-------|
+| Concepts | `docs/src/content/docs/concepts/*.md` | Platform fundamentals (agents, sessions, projects, credentials, workflows, scheduled sessions, context & artifacts) |
+| Examples | `examples/docs/*.md` | Runnable demos and use-case walkthroughs |
+
+> **Note:** The `examples/docs/` directory does not currently exist in the repository. It is created as part of this feature. The `docs/src/content/docs/concepts/` directory already exists with 7 concept files.
+
+## Requirements
+
+### Requirement: Learn Landing Page
+
+The Ambient UI SHALL include a "Learn" view accessible from the main sidebar navigation. The landing page SHALL display two sections: **Concepts** and **Examples**. Each section SHALL render a card grid of its learning resources.
+
+Each card SHALL display:
+
+- **Title** — extracted from the `title` frontmatter field if present, otherwise from the first `# heading`, otherwise the filename (without extension).
+- **Description** — extracted from the first paragraph after the heading (truncated to 200 characters).
+
+#### Scenario: Landing page renders both sections
+
+- GIVEN `docs/src/content/docs/concepts/` contains `agents.md`, `sessions.md`, and `projects.md`
+- AND `examples/docs/` contains `hello-world.md` and `pr-review.md`
+- WHEN the Learn view renders
+- THEN a "Concepts" section appears with 3 cards
+- AND an "Examples" section appears with 2 cards
+
+#### Scenario: Section with no content shows empty state
+
+- GIVEN `examples/docs/` contains no markdown files
+- AND `docs/src/content/docs/concepts/` contains 7 files
+- WHEN the Learn view renders
+- THEN the "Concepts" section renders 7 cards
+- AND the "Examples" section displays "No examples available"
+
+#### Scenario: Loading state
+
+- GIVEN the user navigates to the Learn view
+- WHEN the page is loading
+- THEN skeleton card placeholders are displayed until the catalog renders
+
+### Requirement: Concept Detail Rendering
+
+Clicking a Concepts card SHALL navigate to a detail page that renders the full markdown content of the concept file. The rendered content SHALL support standard GitHub-flavored Markdown: headings, lists, code blocks with syntax highlighting, tables, links, and inline images.
+
+Concept files use Starlight frontmatter (`title`, etc.). The renderer SHALL extract the `title` field for the page heading and strip the frontmatter before rendering the body.
+
+#### Scenario: User reads a concept
+
+- GIVEN the Concepts section displays "Agents", "Sessions", and "Projects"
+- WHEN the user clicks "Agents"
+- THEN the view navigates to `/learn/concepts/agents`
+- AND the page heading displays "Agents" (from frontmatter `title`)
+- AND the full body of `agents.md` is rendered as formatted HTML
+- AND code blocks display syntax highlighting
+
+#### Scenario: Back navigation
+
+- GIVEN the user is viewing a concept detail page
+- WHEN the user clicks the back button or breadcrumb
+- THEN the view returns to the Learn landing page
+
+#### Scenario: Malformed markdown graceful degradation
+
+- GIVEN a concept file contains malformed markdown
+- WHEN the user navigates to its detail page
+- THEN the page heading displays the filename as title
+- AND the detail page renders the raw text as fallback
+
+### Requirement: Example Detail Rendering
+
+Clicking an Examples card SHALL navigate to a detail page that renders the full markdown content of the example file. Behavior is identical to concept detail rendering.
+
+#### Scenario: User reads an example
+
+- GIVEN the Examples section displays "Hello World" and "PR Review"
+- WHEN the user clicks "Hello World"
+- THEN the view navigates to `/learn/examples/hello-world`
+- AND the full content of `hello-world.md` is rendered as formatted HTML
+
+### Requirement: Static Build-Time Discovery
+
+All learning content SHALL be statically imported at build time. Adding a new concept or example SHALL require only adding a new `.md` file to the corresponding source directory — no code changes, no configuration updates, no database entries.
+
+The build process SHALL discover all `.md` files in each source directory (non-recursive — subdirectories are ignored) and include their content in the UI bundle.
+
+> **Build pipeline dependency:** Both source directories live outside the UI component tree (`components/ambient-ui/`). The build pipeline MUST make this content available to the Next.js build process. The mechanism (pre-build copy step, Dockerfile COPY, or content relocation) is an implementation detail.
+
+#### Scenario: Adding a new concept
+
+- GIVEN `docs/src/content/docs/concepts/` contains 7 files
+- WHEN a developer adds `gateways.md` with frontmatter `title: "Gateways"`
+- AND the UI is rebuilt
+- THEN the Concepts section displays 8 cards including "Gateways"
+- AND no other file was modified
+
+#### Scenario: Adding a new example
+
+- GIVEN `examples/docs/` contains `hello-world.md`
+- WHEN a developer adds `jira-categorizer.md` to `examples/docs/`
+- AND the UI is rebuilt
+- THEN the Examples section displays both "Hello World" and "Jira Categorizer"
+
+#### Scenario: Subdirectories are ignored
+
+- GIVEN `docs/src/content/docs/concepts/drafts/wip.md` exists
+- WHEN the UI is built
+- THEN "wip" does NOT appear in the Concepts section
+
+### Requirement: Sidebar Navigation Entry
+
+The Learn view SHALL appear as an ungrouped entry in the main sidebar navigation, below the existing "Configure" group. The entry SHALL be visible to all authenticated users regardless of role or project context. The Learn view is global — it is NOT scoped to a project.
+
+#### Scenario: Navigation entry visible
+
+- GIVEN an authenticated user with any role
+- WHEN the sidebar renders
+- THEN a "Learn" entry is visible at the bottom of the sidebar, below Configure
+- AND clicking it navigates to `/learn`
+
+## URL Routes
+
+| Route | View | Scope |
+|-------|------|-------|
+| `/learn` | Learn landing page (Concepts + Examples card grids) | Global |
+| `/learn/concepts/{slug}` | Concept detail (rendered markdown) | Global |
+| `/learn/examples/{slug}` | Example detail (rendered markdown) | Global |
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Reuse existing concept docs | `docs/src/content/docs/concepts/` already contains well-structured concept files. Single source of truth avoids duplication and maintenance drift. |
+| Static build-time content, no API | Learning content changes infrequently and lives in the repository. No backend, no database, no runtime fetch. |
+| Global (not project-scoped) | Learning resources describe platform capabilities, not project-specific resources. |
+| Port/adapter exemption | Static build-time content does not flow through the API server. The port/adapter pattern defined in the architecture spec applies to API-backed data sources. Build-time content is exempt. |
+| No search/filter initially | The catalog is expected to remain small (<20 entries across both sections). Search is deferred until the catalog grows. |
+| Card grid layout | Consistent with OpenShift AI Resources and Developer Hub Learning Paths patterns. |
+| Frontmatter title extraction | Concept files use Starlight frontmatter with `title` field. Reusing this avoids parsing inconsistencies and matches the existing authoring convention. |

--- a/specs/ui/learn.spec.md
+++ b/specs/ui/learn.spec.md
@@ -11,7 +11,7 @@ The Learn view provides an in-app learning hub with two sections: **Concepts** (
 | Concepts | `docs/src/content/docs/concepts/*.md` | Platform fundamentals (agents, sessions, projects, credentials, workflows, scheduled sessions, context & artifacts) |
 | Examples | `examples/docs/*.md` | Runnable demos and use-case walkthroughs |
 
-> **Note:** The `examples/docs/` directory does not currently exist in the repository. It is created as part of this feature. The `docs/src/content/docs/concepts/` directory already exists with 7 concept files.
+> **Note:** The `examples/docs/` directory is located at the repository root (`<repo>/examples/docs/`). It does not currently exist and is created as part of this feature with at least one initial example file to validate the build pipeline. The `docs/src/content/docs/concepts/` directory already exists with 7 concept files.
 
 ## Requirements
 
@@ -39,12 +39,6 @@ Each card SHALL display:
 - WHEN the Learn view renders
 - THEN the "Concepts" section renders 7 cards
 - AND the "Examples" section displays "No examples available"
-
-#### Scenario: Loading state
-
-- GIVEN the user navigates to the Learn view
-- WHEN the page is loading
-- THEN skeleton card placeholders are displayed until the catalog renders
 
 ### Requirement: Concept Detail Rendering
 
@@ -91,7 +85,7 @@ All learning content SHALL be statically imported at build time. Adding a new co
 
 The build process SHALL discover all `.md` files in each source directory (non-recursive — subdirectories are ignored) and include their content in the UI bundle.
 
-> **Build pipeline dependency:** Both source directories live outside the UI component tree (`components/ambient-ui/`). The build pipeline MUST make this content available to the Next.js build process. The mechanism (pre-build copy step, Dockerfile COPY, or content relocation) is an implementation detail.
+> **Build pipeline dependency:** Both source directories live outside the UI component tree (`components/ambient-ui/`). The build pipeline MUST make this content available to the Next.js build process. The preferred mechanism is a **Makefile pre-build copy step** that copies markdown files into a temporary directory inside the build context (`components/ambient-ui/.learn-content/`) before the Docker build, then cleans up after. This approach keeps source files in their canonical locations, works within Docker's single build-context constraint, and requires no changes to the Astro docs site. The content loader resolves paths at runtime: Docker path (`/learn-content/`) first, local development fallback (`../../`) second.
 
 #### Scenario: Adding a new concept
 


### PR DESCRIPTION
## Summary

- Adds new UI spec `specs/ui/learn.spec.md` defining a "Learn" view with two sections: **Concepts** (from `docs/src/content/docs/concepts/`) and **Examples** (from `examples/docs/`)
- Users can browse and read platform learning content directly in the UI without navigating to the source repository
- Content is static, compiled at build time from existing markdown files — no backend changes needed
- Updates `specs/ui/index.spec.md` and `specs/index.spec.md` to register the new spec


🤖 Generated with [Claude Code](https://claude.com/claude-code)