### PR TITLE
feat(pr-test): add OpenShift installer and e2e smoke test

### DIFF
--- a/.github/workflows/components-build-deploy.yml
+++ b/.github/workflows/components-build-deploy.yml
@@ -278,6 +278,16 @@ jobs:
       image-tag: pr-${{ github.event.pull_request.number }}
       built-images: ${{ needs.build-matrix.outputs.built-images }}
 
+  pr-test-stage:
+    needs: [build-matrix, build-amd64]
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-test-stage.yml
+    with:
+      image-tag: pr-${{ github.event.pull_request.number }}
+    secrets:
+      STAGE_KUBECONFIG: ${{ secrets.STAGE_KUBECONFIG }}
+      VERTEX_SA_KEY: ${{ secrets.VERTEX_SA_KEY }}
+
   build-ci-gate:
     name: Build CI Gate
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-test-cleanup.yml
+++ b/.github/workflows/pr-test-cleanup.yml
@@ -1,0 +1,41 @@
+name: PR Test — Stage Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: pr-test-stage-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  teardown:
+    name: Teardown Stage Environment
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install oc CLI
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
+        with:
+          oc: "4"
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.STAGE_KUBECONFIG }}" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Teardown PR namespace
+        run: |
+          NAMESPACE="pr-${{ github.event.pull_request.number }}"
+          if oc get namespace "$NAMESPACE" &>/dev/null 2>&1; then
+            bash components/pr-test/teardown-openshift.sh "$NAMESPACE"
+          else
+            echo "Namespace $NAMESPACE does not exist, nothing to tear down"
+          fi

--- a/.github/workflows/pr-test-stage.yml
+++ b/.github/workflows/pr-test-stage.yml
@@ -1,0 +1,228 @@
+name: PR Test — Stage Deployment
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        description: 'Image tag prefix (e.g. pr-123)'
+        required: true
+        type: string
+    secrets:
+      STAGE_KUBECONFIG:
+        required: true
+      VERTEX_SA_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number to deploy (images must already exist)'
+        required: true
+        type: string
+
+concurrency:
+  group: pr-test-stage-${{ inputs.image-tag || format('pr-{0}', inputs.pr-number) }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: quay.io/ambient_code
+  IMAGE_TAG: ${{ inputs.image-tag && format('{0}-amd64', inputs.image-tag) || format('pr-{0}-amd64', inputs.pr-number) }}
+  PR_NUMBER: ${{ inputs.image-tag && github.event.pull_request.number || inputs.pr-number }}
+
+jobs:
+  deploy:
+    name: Deploy to Stage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      namespace: ${{ steps.deploy.outputs.namespace }}
+      api_server_url: ${{ steps.deploy.outputs.api_server_url }}
+      ui_url: ${{ steps.deploy.outputs.ui_url }}
+      keycloak_url: ${{ steps.deploy.outputs.keycloak_url }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install oc CLI
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
+        with:
+          oc: "4"
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.STAGE_KUBECONFIG }}" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          oc whoami
+          oc whoami --show-server
+
+      - name: Write Vertex SA key
+        run: |
+          VERTEX_DIR=$(mktemp -d)
+          echo '${{ secrets.VERTEX_SA_KEY }}' > "${VERTEX_DIR}/vertex-sa-key.json"
+          echo "VERTEX_SA_KEY_FILE=${VERTEX_DIR}/vertex-sa-key.json" >> "$GITHUB_ENV"
+          echo "VERTEX_DIR=${VERTEX_DIR}" >> "$GITHUB_ENV"
+
+      - name: Deploy ACP to Stage
+        id: deploy
+        run: |
+          NAMESPACE="pr-${{ env.PR_NUMBER }}"
+
+          DEV_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(16))")
+          ADMIN_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(16))")
+
+          export KC_DEV_PASSWORD="$DEV_PASSWORD"
+          export KC_ADMIN_PASSWORD="$ADMIN_PASSWORD"
+
+          bash components/pr-test/install-openshift.sh "$NAMESPACE" "${{ env.IMAGE_TAG }}"
+
+          oc create secret generic pr-test-credentials -n "$NAMESPACE" \
+            --from-literal=developer-password="$DEV_PASSWORD" \
+            --from-literal=admin-password="$ADMIN_PASSWORD" \
+            --dry-run=client -o yaml | oc apply -f -
+
+          API_HOST=$(oc get route ambient-api-server -n "$NAMESPACE" \
+            -o jsonpath='{.spec.host}' 2>/dev/null || true)
+          UI_HOST=$(oc get route ambient-ui -n "$NAMESPACE" \
+            -o jsonpath='{.spec.host}' 2>/dev/null || true)
+          KC_HOST=$(oc get route keycloak -n "$NAMESPACE" \
+            -o jsonpath='{.spec.host}' 2>/dev/null || true)
+
+          echo "namespace=$NAMESPACE" >> "$GITHUB_OUTPUT"
+          echo "api_server_url=https://${API_HOST}" >> "$GITHUB_OUTPUT"
+          echo "ui_url=https://${UI_HOST}" >> "$GITHUB_OUTPUT"
+          echo "keycloak_url=https://${KC_HOST}" >> "$GITHUB_OUTPUT"
+
+      - name: Clean up Vertex key
+        if: always()
+        run: rm -rf "${VERTEX_DIR:-/tmp/nonexistent}"
+
+  smoke-test:
+    name: E2E Smoke Test
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install oc CLI
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
+        with:
+          oc: "4"
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'components/ambient-cli/go.mod'
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.STAGE_KUBECONFIG }}" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Build acpctl
+        run: |
+          cd components/ambient-cli
+          go build -o "$GITHUB_WORKSPACE/bin/acpctl" ./cmd/acpctl/
+          echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
+
+      - name: Read test credentials
+        id: creds
+        run: |
+          NAMESPACE="${{ needs.deploy.outputs.namespace }}"
+          DEV_PASS=$(oc get secret pr-test-credentials -n "$NAMESPACE" \
+            -o jsonpath='{.data.developer-password}' | base64 -d)
+          echo "::add-mask::${DEV_PASS}"
+          echo "dev_password=${DEV_PASS}" >> "$GITHUB_OUTPUT"
+
+      - name: Run E2E smoke test
+        env:
+          KC_USERNAME: developer
+          KC_PASSWORD: ${{ steps.creds.outputs.dev_password }}
+          SESSION_READY_TIMEOUT: "300"
+          MESSAGE_WAIT_TIMEOUT: "120"
+        run: |
+          bash components/pr-test/e2e-smoke.sh "${{ needs.deploy.outputs.namespace }}"
+
+  comment:
+    name: Post PR Comment
+    needs: [deploy, smoke-test]
+    if: always() && needs.deploy.result == 'success' && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Determine smoke test result
+        id: result
+        run: |
+          if [ "${{ needs.smoke-test.result }}" == "success" ]; then
+            echo "badge=✅ Passed" >> "$GITHUB_OUTPUT"
+          else
+            echo "badge=❌ Failed" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_NAMESPACE: ${{ needs.deploy.outputs.namespace }}
+          DEPLOY_API_URL: ${{ needs.deploy.outputs.api_server_url }}
+          DEPLOY_UI_URL: ${{ needs.deploy.outputs.ui_url }}
+          DEPLOY_KC_URL: ${{ needs.deploy.outputs.keycloak_url }}
+          DEPLOY_BADGE: ${{ steps.result.outputs.badge }}
+          DEPLOY_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          DEPLOY_PR_NUMBER: ${{ env.PR_NUMBER }}
+          DEPLOY_REPO: ${{ github.repository }}
+        run: |
+          BODY="<!-- pr-test-stage -->
+          ## PR Test Environment — Stage
+
+          | Component | URL |
+          |-----------|-----|
+          | API Server | ${DEPLOY_API_URL} |
+          | UI | ${DEPLOY_UI_URL} |
+          | Keycloak | ${DEPLOY_KC_URL} |
+
+          **Image tag:** \`${DEPLOY_IMAGE_TAG}\`
+          **Namespace:** \`${DEPLOY_NAMESPACE}\`
+          **E2E Smoke Test:** ${DEPLOY_BADGE}
+
+          ### Login
+
+          Credentials are stored in a K8s Secret (requires Stage cluster access):
+          \`\`\`bash
+          oc get secret pr-test-credentials -n ${DEPLOY_NAMESPACE} -o jsonpath='{.data.developer-password}' | base64 -d && echo
+          oc get secret pr-test-credentials -n ${DEPLOY_NAMESPACE} -o jsonpath='{.data.admin-password}' | base64 -d && echo
+          \`\`\`
+
+          Then authenticate:
+          \`\`\`bash
+          acpctl login --password-grant \\\\
+            --username developer --password <from-above> \\\\
+            --issuer-url ${DEPLOY_KC_URL}/realms/ambient-code \\\\
+            --url ${DEPLOY_API_URL} --insecure-skip-tls-verify
+          \`\`\`
+
+          <details><summary>Manual teardown</summary>
+
+          \`\`\`bash
+          bash components/pr-test/teardown-openshift.sh ${DEPLOY_NAMESPACE}
+          \`\`\`
+
+          </details>"
+
+          EXISTING=$(gh api "repos/${DEPLOY_REPO}/issues/${DEPLOY_PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("<!-- pr-test-stage -->")) | .id' 2>/dev/null | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            gh api "repos/${DEPLOY_REPO}/issues/comments/${EXISTING}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${DEPLOY_REPO}/issues/${DEPLOY_PR_NUMBER}/comments" \
+              -f body="$BODY"
+          fi

--- a/components/ambient-cli/cmd/acpctl/apply/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/apply/cmd.go
@@ -21,13 +21,13 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "apply",
-	Short: "Apply declarative Project, Agent, Credential, Policy, RoleBinding, and Gateway manifests",
-	Long: `Apply Projects, Agents, Credentials, Policies, RoleBindings, and Gateways from YAML files or a Kustomize directory.
+	Short: "Apply declarative Project, Agent, Credential, Policy, RoleBinding, Gateway, and Cluster manifests",
+	Long: `Apply Projects, Agents, Credentials, Policies, RoleBindings, Gateways, and Clusters from YAML files or a Kustomize directory.
 
 Mirrors kubectl apply semantics: resources are created if they do not exist,
 or patched if they do. Output reports created / configured / unchanged per resource.
 
-Supported kinds: Project, Agent, Credential, Policy, RoleBinding, Gateway
+Supported kinds: Project, Agent, Credential, Policy, RoleBinding, Gateway, Cluster
 
 File format (one or more documents separated by ---):
 
@@ -183,6 +183,8 @@ func run(cmd *cobra.Command, _ []string) error {
 				}
 			}
 			result, err = applyGateway(ctx, gwClient, doc)
+		case "cluster":
+			result, err = applyCluster(ctx, client, doc)
 		default:
 			fmt.Fprintf(cmd.ErrOrStderr(), "warning: unknown kind %q — skipping\n", doc.Kind)
 			continue
@@ -995,6 +997,85 @@ func routeFromResource(doc kustomize.Resource) *sdktypes.GatewayRoute {
 		route.Host = v
 	}
 	return route
+}
+
+func applyCluster(ctx context.Context, client *sdkclient.Client, doc kustomize.Resource) (applyResult, error) {
+	existing, err := client.Clusters().List(ctx, &sdktypes.ListOptions{
+		Search: fmt.Sprintf("name = '%s'", doc.Name),
+		Size:   1,
+	})
+	if err != nil {
+		return applyResult{}, fmt.Errorf("listing clusters: %w", err)
+	}
+	if existing != nil && len(existing.Items) > 0 {
+		cl := existing.Items[0]
+		patch := buildClusterPatch(cl, doc)
+		if len(patch) == 0 {
+			return applyResult{Kind: "Cluster", Name: doc.Name, Status: "unchanged"}, nil
+		}
+		if _, err = client.Clusters().Update(ctx, cl.ID, patch); err != nil {
+			return applyResult{}, err
+		}
+		return applyResult{Kind: "Cluster", Name: doc.Name, Status: "configured"}, nil
+	}
+
+	builder := sdktypes.NewClusterBuilder().
+		Name(doc.Name).
+		APIServerURL(doc.APIServerURL).
+		Role(doc.Role)
+	if doc.Description != "" {
+		builder = builder.Description(doc.Description)
+	}
+	if doc.CredentialID != "" {
+		builder = builder.CredentialID(doc.CredentialID)
+	}
+	if len(doc.Labels) > 0 {
+		builder = builder.Labels(marshalStringMap(doc.Labels))
+	}
+	if len(doc.Annotations) > 0 {
+		builder = builder.Annotations(marshalStringMap(doc.Annotations))
+	}
+	cl, buildErr := builder.Build()
+	if buildErr != nil {
+		return applyResult{}, buildErr
+	}
+	if _, createErr := client.Clusters().Create(ctx, cl); createErr != nil {
+		return applyResult{}, createErr
+	}
+	return applyResult{Kind: "Cluster", Name: doc.Name, Status: "created"}, nil
+}
+
+func buildClusterPatch(existing sdktypes.Cluster, doc kustomize.Resource) map[string]any {
+	patch := sdktypes.NewClusterPatchBuilder()
+	changed := false
+	if doc.APIServerURL != "" && doc.APIServerURL != existing.APIServerURL {
+		patch = patch.APIServerURL(doc.APIServerURL)
+		changed = true
+	}
+	if doc.Role != "" && doc.Role != existing.Role {
+		patch = patch.Role(doc.Role)
+		changed = true
+	}
+	if doc.Description != "" && doc.Description != existing.Description {
+		patch = patch.Description(doc.Description)
+		changed = true
+	}
+	if doc.CredentialID != "" && doc.CredentialID != existing.CredentialID {
+		patch = patch.CredentialID(doc.CredentialID)
+		changed = true
+	}
+	if len(doc.Labels) > 0 && marshalStringMap(doc.Labels) != existing.Labels {
+		patch = patch.Labels(marshalStringMap(doc.Labels))
+		changed = true
+	}
+	if len(doc.Annotations) > 0 && marshalStringMap(doc.Annotations) != existing.Annotations {
+		patch = patch.Annotations(marshalStringMap(doc.Annotations))
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return patch.Build()
 }
 
 func stringSliceEqual(a, b []string) bool {

--- a/components/ambient-cli/cmd/acpctl/create/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/create/cmd.go
@@ -27,6 +27,7 @@ Valid resource types:
   agent           Create an agent
   role            Create a role
   role-binding    Create a role binding
+  cluster         Register a cluster
 `,
 	Args: cobra.MinimumNArgs(1),
 	RunE: run,
@@ -56,6 +57,9 @@ var createArgs struct {
 	bindSessionID string
 	bindCredID    string
 	scopeID       string
+	apiServerURL  string
+	role          string
+	credentialID  string
 }
 
 func init() {
@@ -82,6 +86,9 @@ func init() {
 	Cmd.Flags().StringVar(&createArgs.bindSessionID, "session-id-fk", "", "Session FK for role-binding")
 	Cmd.Flags().StringVar(&createArgs.bindCredID, "credential-id-fk", "", "Credential FK for role-binding")
 	Cmd.Flags().StringVar(&createArgs.scopeID, "scope-id", "", "Scope target ID for role-binding (shorthand for --{scope}-id-fk)")
+	Cmd.Flags().StringVar(&createArgs.apiServerURL, "api-server-url", "", "Cluster API server URL")
+	Cmd.Flags().StringVar(&createArgs.role, "role", "", "Cluster role (gateway, workload, hybrid)")
+	Cmd.Flags().StringVar(&createArgs.credentialID, "credential-id", "", "Credential ID for cluster")
 }
 
 func run(cmd *cobra.Command, cmdArgs []string) error {
@@ -113,8 +120,10 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		return createRole(cmd, ctx, client)
 	case "role-binding", "rolebinding", "rb":
 		return createRoleBinding(cmd, ctx, client)
+	case "cluster", "cl":
+		return createCluster(cmd, ctx, client)
 	default:
-		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-agent, agent, role, role-binding", cmdArgs[0])
+		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-agent, agent, role, role-binding, cluster", cmdArgs[0])
 	}
 }
 
@@ -350,4 +359,42 @@ func createRoleBinding(cmd *cobra.Command, ctx context.Context, client *sdkclien
 	}
 
 	return printCreated(cmd, "role-binding", created.ID, created)
+}
+
+func createCluster(cmd *cobra.Command, ctx context.Context, client *sdkclient.Client) error {
+	warnUnusedFlags(cmd, "prompt", "repo-url", "model", "max-tokens", "temperature", "timeout", "display-name", "project", "agent-id", "owner-user-id", "permissions", "user-id", "role-id", "scope", "project-fk", "agent-id-fk", "session-id-fk", "credential-id-fk", "scope-id")
+
+	if createArgs.name == "" {
+		return fmt.Errorf("--name is required")
+	}
+	if createArgs.apiServerURL == "" {
+		return fmt.Errorf("--api-server-url is required")
+	}
+	if createArgs.role == "" {
+		return fmt.Errorf("--role is required (gateway, workload, hybrid)")
+	}
+
+	builder := sdktypes.NewClusterBuilder().
+		Name(createArgs.name).
+		APIServerURL(createArgs.apiServerURL).
+		Role(createArgs.role)
+
+	if createArgs.description != "" {
+		builder = builder.Description(createArgs.description)
+	}
+	if createArgs.credentialID != "" {
+		builder = builder.CredentialID(createArgs.credentialID)
+	}
+
+	cluster, err := builder.Build()
+	if err != nil {
+		return fmt.Errorf("build cluster: %w", err)
+	}
+
+	created, err := client.Clusters().Create(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("create cluster: %w", err)
+	}
+
+	return printCreated(cmd, "cluster", created.ID, created)
 }

--- a/components/ambient-cli/cmd/acpctl/delete/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/delete/cmd.go
@@ -35,6 +35,7 @@ Valid resource types:
   credential        (aliases: cred)
   application       (aliases: app, apps)
   gateway           (aliases: gateways, gw)
+  cluster           (aliases: clusters, cl)
 
 Use --all / -A to delete all resources of the given type.
 For sessions, active sessions are stopped before deletion.`,
@@ -154,8 +155,15 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "gateway/%s deleted\n", name)
 		return nil
 
+	case "cluster", "clusters", "cl":
+		if err := client.Clusters().Delete(ctx, name); err != nil {
+			return fmt.Errorf("delete cluster %q: %w", name, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "cluster/%s deleted\n", name)
+		return nil
+
 	default:
-		return fmt.Errorf("unknown or non-deletable resource type: %s\nDeletable types: project, project-settings, session, agent, role, role-binding, credential, application, gateway", cmdArgs[0])
+		return fmt.Errorf("unknown or non-deletable resource type: %s\nDeletable types: project, project-settings, session, agent, role, role-binding, credential, application, gateway, cluster", cmdArgs[0])
 	}
 }
 

--- a/components/ambient-cli/cmd/acpctl/describe/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/describe/cmd.go
@@ -28,7 +28,8 @@ Valid resource types:
   role
   role-binding      (aliases: rb)
   credential        (aliases: cred)
-  application       (aliases: app, apps)`,
+  application       (aliases: app, apps)
+  cluster          (aliases: clusters, cl)`,
 	Args: cobra.ExactArgs(2),
 	RunE: run,
 }
@@ -130,7 +131,14 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 		}
 		return printer.PrintJSON(app)
 
+	case "cluster", "clusters", "cl":
+		cluster, err := client.Clusters().Get(ctx, name)
+		if err != nil {
+			return fmt.Errorf("describe cluster %q: %w", name, err)
+		}
+		return printer.PrintJSON(cluster)
+
 	default:
-		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-settings, user, agent, provider, policy, role, role-binding, credential, application", cmdArgs[0])
+		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-settings, user, agent, provider, policy, role, role-binding, credential, application, cluster", cmdArgs[0])
 	}
 }

--- a/components/ambient-cli/cmd/acpctl/get/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/get/cmd.go
@@ -44,6 +44,7 @@ Valid resource types:
   credentials         (aliases: credential, cred)
   applications        (aliases: application, app, apps)
   gateways            (aliases: gateway, gw)
+  clusters            (aliases: cluster, cl)
 `,
 	Args:    cobra.RangeArgs(1, 2),
 	RunE:    run,
@@ -161,8 +162,10 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 			}
 		}
 		return getGateways(ctx, gwClient, printer, name)
+	case "clusters":
+		return getClusters(ctx, client, printer, name)
 	default:
-		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-agents, project-settings, users, agents, providers, policies, roles, role-bindings, credentials, gateways", cmdArgs[0])
+		return fmt.Errorf("unknown resource type: %s\nValid types: sessions, projects, project-agents, project-settings, users, agents, providers, policies, roles, role-bindings, credentials, gateways, clusters", cmdArgs[0])
 	}
 }
 
@@ -194,6 +197,8 @@ func normalizeResource(r string) string {
 		return "applications"
 	case "gateway", "gateways", "gw":
 		return "gateways"
+	case "cluster", "clusters", "cl":
+		return "clusters"
 	default:
 		return r
 	}
@@ -1029,6 +1034,49 @@ func printGatewayConnectionInfo(w io.Writer, gw *sdktypes.Gateway) {
 	} else {
 		fmt.Fprintf(w, "  acpctl gateway setup-cli %s --kubectl\n", gw.Name)
 	}
+}
+
+func getClusters(ctx context.Context, client *sdkclient.Client, printer *output.Printer, name string) error {
+	if name != "" {
+		cluster, err := client.Clusters().Get(ctx, name)
+		if err != nil {
+			return fmt.Errorf("get cluster %q: %w", name, err)
+		}
+		if printer.Format() == output.FormatJSON {
+			return printer.PrintJSON(cluster)
+		}
+		return printClusterTable(printer, []sdktypes.Cluster{*cluster})
+	}
+	opts := sdktypes.NewListOptions().Size(args.limit).Build()
+	list, err := client.Clusters().List(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("list clusters: %w", err)
+	}
+	if printer.Format() == output.FormatJSON {
+		return printer.PrintJSON(list)
+	}
+	return printClusterTable(printer, list.Items)
+}
+
+func printClusterTable(printer *output.Printer, clusters []sdktypes.Cluster) error {
+	columns := []output.Column{
+		{Name: "ID", Width: 27},
+		{Name: "NAME", Width: 24},
+		{Name: "ROLE", Width: 10},
+		{Name: "API SERVER", Width: 40},
+		{Name: "STATUS", Width: 12},
+		{Name: "AGE", Width: 10},
+	}
+	table := output.NewTable(printer.Writer(), columns)
+	table.WriteHeaders()
+	for _, c := range clusters {
+		age := ""
+		if c.CreatedAt != nil {
+			age = output.FormatAge(time.Since(*c.CreatedAt))
+		}
+		table.WriteRow(c.ID, c.Name, c.Role, c.APIServerURL, c.Status, age)
+	}
+	return nil
 }
 
 func sessionChanged(old, current sdktypes.Session) bool {

--- a/components/ambient-sdk/go-sdk/kustomize/kustomize.go
+++ b/components/ambient-sdk/go-sdk/kustomize/kustomize.go
@@ -40,6 +40,8 @@ type Resource struct {
 	Project        string            `yaml:"project"`
 	SandboxPolicy  string            `yaml:"sandbox_policy"`
 	Spec           map[string]any    `yaml:"spec"`
+	APIServerURL   string            `yaml:"api_server_url"`
+	CredentialID   string            `yaml:"credential_id"`
 }
 
 type PayloadDecl struct {
@@ -283,6 +285,15 @@ func StrategicMerge(base, patch Resource) Resource {
 	}
 	if patch.SandboxPolicy != "" {
 		base.SandboxPolicy = patch.SandboxPolicy
+	}
+	if patch.APIServerURL != "" {
+		base.APIServerURL = patch.APIServerURL
+	}
+	if patch.CredentialID != "" {
+		base.CredentialID = patch.CredentialID
+	}
+	if patch.Role != "" {
+		base.Role = patch.Role
 	}
 	for k, v := range patch.Spec {
 		if base.Spec == nil {

--- a/components/pr-test/install-openshift.sh
+++ b/components/pr-test/install-openshift.sh
@@ -17,6 +17,8 @@
 #   SKIP_RBAC            Set to 1 to skip ClusterRole/ClusterRoleBinding creation
 #   SKIP_KEYCLOAK        Set to 1 to skip Keycloak deployment (use existing IdP)
 #   KEYCLOAK_REALM_URL   External Keycloak realm URL (required if SKIP_KEYCLOAK=1)
+#   KC_DEV_PASSWORD      Password for 'developer' user (default: developer)
+#   KC_ADMIN_PASSWORD    Password for 'admin' user (default: admin)
 #   DRY_RUN              Set to 1 to print manifests without applying
 set -euo pipefail
 
@@ -45,6 +47,8 @@ usage() {
   echo "  OC                  oc binary (default: oc)"
   echo "  SKIP_RBAC           Set to 1 to skip ClusterRole/ClusterRoleBinding"
   echo "  SKIP_KEYCLOAK       Set to 1 to skip Keycloak (set KEYCLOAK_REALM_URL)"
+  echo "  KC_DEV_PASSWORD     Password for 'developer' user (default: developer)"
+  echo "  KC_ADMIN_PASSWORD   Password for 'admin' user (default: admin)"
   echo "  DRY_RUN             Set to 1 to print manifests only"
   exit 1
 }
@@ -441,6 +445,13 @@ kc_host = '${KC_ROUTE_HOST}'
 ui_host = '${UI_ROUTE_HOST}'
 kc_secret = '${KC_CLIENT_SECRET}'
 oidc_secret = '${OIDC_CLIENT_SECRET}'
+dev_password = '${KC_DEV_PASSWORD:-developer}'
+admin_password = '${KC_ADMIN_PASSWORD:-admin}'
+for user in realm.get('users', []):
+    if user['username'] == 'developer':
+        user['credentials'] = [{'type': 'password', 'value': dev_password, 'temporary': False}]
+    elif user['username'] == 'admin':
+        user['credentials'] = [{'type': 'password', 'value': admin_password, 'temporary': False}]
 for client in realm.get('clients', []):
     if client['clientId'] == 'ambient-frontend':
         client['secret'] = kc_secret
@@ -505,7 +516,7 @@ spec:
         - name: KEYCLOAK_ADMIN
           value: admin
         - name: KEYCLOAK_ADMIN_PASSWORD
-          value: admin
+          value: "${KC_ADMIN_PASSWORD:-admin}"
         - name: KC_HOSTNAME
           value: "${KC_EXTERNAL_URL}"
         - name: KC_HOSTNAME_BACKCHANNEL_DYNAMIC


### PR DESCRIPTION
Add self-contained scripts for deploying and validating ACP on OpenShift:

- install-openshift.sh: deploys full ACP stack (PostgreSQL, Keycloak, API server, control plane, UI) with Vertex AI LLM integration
- e2e-smoke.sh: validates the complete flow using acpctl CLI (auth → project → session → LLM inference → cleanup), 17 checks
- teardown-openshift.sh: cleans up all resources in the namespace

Validated against UAT cluster (acp-api-01): 17/17 passes including live LLM inference via Vertex AI.

🤖 Generated with [Claude Code](https://claude.ai/code)