### PR TITLE
style(tests): add run_cmd to all e2e tests for command visibility

### DIFF
--- a/specs/platform/e2e-test-tooling.spec.md
+++ b/specs/platform/e2e-test-tooling.spec.md
@@ -417,7 +417,22 @@ run_cmd() {
 
 Scripts SHALL use `run_cmd` for all `kubectl`, `acpctl`, `openshell`, `oc`, and `ssh` commands. Commands whose output was previously suppressed with `>/dev/null 2>&1` SHALL be converted to use `run_cmd` so their output is visible during test runs.
 
-After calling `run_cmd`, scripts access results via:
+Commands that pass secrets, tokens, or passwords as CLI arguments (e.g., `--token`, `--client-secret`, `-d password=`, `-H "Authorization: Bearer ..."`) SHALL use `run_cmd_redact` instead of `run_cmd`. This variant prints the command with sensitive values masked as `[REDACTED]` and suppresses output display (since auth responses typically contain tokens):
+
+```bash
+run_cmd_redact() {
+  CMD_RC=0
+  echo ""
+  local redacted
+  redacted=$(printf '%s ' "$@" | sed -E \
+    -e 's/(--token |--client-secret |password=|client_secret=|clientSecret[":= ]*|Authorization: Bearer )[^ "}]*/\1[REDACTED]/g')
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "${redacted% }" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  echo ""
+}
+```
+
+After calling `run_cmd` or `run_cmd_redact`, scripts access results via:
 - `CMD_RC` — the command's exit code (0 on success)
 - `CMD_OUTPUT` — the command's combined stdout+stderr output
 

--- a/specs/platform/e2e-test-tooling.spec.md
+++ b/specs/platform/e2e-test-tooling.spec.md
@@ -355,7 +355,7 @@ The `test-agent-mock-llm` agent references this policy via `sandbox_policy: mock
 
 ## E2E Test Shell Script Style
 
-All e2e test scripts in `tests/e2e/` SHALL follow the human-readable style established by `openshell-cli-e2e.sh` ([PR #390](https://github.com/openshift-online/agent-control-plane/pull/390)). This style prioritizes scan-readable terminal output and consistent structure across all test scripts. Existing tests SHOULD be migrated to this style when they are next modified.
+All e2e test scripts in `tests/e2e/` SHALL follow the human-readable style established by `openshell-cli-e2e.sh` ([PR #390](https://github.com/openshift-online/agent-control-plane/pull/390)). This style prioritizes scan-readable terminal output and consistent structure across all test scripts. All existing tests have been migrated to this style. New tests MUST adopt it from the start.
 
 ### Requirement: Unified Output Helpers
 
@@ -393,6 +393,50 @@ echo -e "${BOLD}Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${
 - WHEN the script runs
 - THEN each assertion SHALL produce output matching `  ✓ <description>`, `  ✗ <description>`, or `  ⊘ <description> (skipped: <reason>)`
 - AND the final line SHALL be `Results: N passed, M failed`
+
+### Requirement: Command Visibility with run_cmd
+
+Every e2e test script SHALL define and use a `run_cmd` helper function that prints the command being executed and its output. This makes test runs self-documenting — when a test fails, the operator can see exactly which commands ran and what they returned without re-running with debug flags.
+
+```bash
+ORANGE='\033[38;5;214m'
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+```
+
+Scripts SHALL use `run_cmd` for all `kubectl`, `acpctl`, `openshell`, `oc`, and `ssh` commands. Commands whose output was previously suppressed with `>/dev/null 2>&1` SHALL be converted to use `run_cmd` so their output is visible during test runs.
+
+After calling `run_cmd`, scripts access results via:
+- `CMD_RC` — the command's exit code (0 on success)
+- `CMD_OUTPUT` — the command's combined stdout+stderr output
+
+Scripts SHALL NOT use `run_cmd` for internal helper functions (e.g., the `api()` wrapper) that have their own output handling. `run_cmd` is for direct CLI invocations.
+
+#### Scenario: Commands are visible in test output
+
+- GIVEN any e2e test script in `tests/e2e/`
+- WHEN a `kubectl`, `acpctl`, or `openshell` command is executed
+- THEN the command SHALL be printed with `▶  $ <command>` formatting
+- AND up to 20 lines of command output SHALL be displayed, indented
+
+#### Scenario: Command output is captured for assertions
+
+- GIVEN a test uses `run_cmd kubectl get pod -o jsonpath='{.status.phase}'`
+- WHEN the command completes
+- THEN `CMD_OUTPUT` SHALL contain the command's output
+- AND `CMD_RC` SHALL contain the exit code
+- AND the test SHALL use these variables for pass/fail assertions
 
 ### Requirement: Section Structure
 

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -131,6 +131,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[36m'
+ORANGE='\033[38;5;214m'
 DIM='\033[2m'
 BOLD='\033[1m'
 NC='\033[0m'
@@ -139,11 +140,24 @@ PASSED=0
 FAILED=0
 CREATED_SESSION_ID=""
 CREATED_SESSIONS=()
+CMD_OUTPUT=""
+CMD_RC=0
 
 sep()     { printf '%b%s%b\n' "${DIM}" "──────────────────────────────────────────────────" "${NC}"; }
 pass()    { echo -e "  ${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
 fail()    { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
 skip()    { echo -e "  ${YELLOW}⊘${NC} $1 (skipped: $2)"; }
+
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
 
 section() {
   echo ""
@@ -272,8 +286,11 @@ fi
 
 section "2. Login acpctl"
 
-if $ACPCTL login --url "$API_URL" --token "$TOKEN" --project "$TENANT" >/dev/null 2>&1 && \
-   $ACPCTL whoami >/dev/null 2>&1; then
+run_cmd $ACPCTL login --url "$API_URL" --token "$TOKEN" --project "$TENANT"
+if [ "$CMD_RC" -eq 0 ]; then
+  run_cmd $ACPCTL whoami
+fi
+if [ "$CMD_RC" -eq 0 ]; then
   pass "acpctl login succeeded (${API_URL}, project: ${TENANT})"
 else
   fail "acpctl login failed — is the API server reachable at ${API_URL}?"
@@ -306,7 +323,8 @@ if [ -n "$_db_pod" ]; then
     >/dev/null 2>&1 || true
 fi
 
-if $ACPCTL apply -k "$E2E_GW_FIXTURE" --project "$E2E_GW_PROJECT" >/dev/null 2>&1; then
+run_cmd $ACPCTL apply -k "$E2E_GW_FIXTURE" --project "$E2E_GW_PROJECT"
+if [ "$CMD_RC" -eq 0 ]; then
   pass "acpctl apply -k fixtures/gateway-apply succeeded"
 else
   fail "acpctl apply -k fixtures/gateway-apply failed"
@@ -318,8 +336,9 @@ if [ "$E2E_GW_CLEANUP" = "true" ]; then
   # StatefulSet to appear, checking every 5s.
   GW_DEPLOYED=false
   for i in $(seq 1 24); do
-    GW_STS=$(kubectl get statefulset openshell-gateway -n "$E2E_GW_PROJECT" \
-      -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+    run_cmd kubectl get statefulset openshell-gateway -n "$E2E_GW_PROJECT" \
+      -o jsonpath='{.metadata.name}'
+    GW_STS="${CMD_OUTPUT:-}"
     if [ "$GW_STS" = "openshell-gateway" ]; then
       GW_DEPLOYED=true
       break
@@ -335,8 +354,9 @@ if [ "$E2E_GW_CLEANUP" = "true" ]; then
   fi
 
   # Verify the certgen job ran (creates TLS secrets the session reconciler needs)
-  CERTGEN_JOB=$(kubectl get job openshell-gateway-certgen -n "$E2E_GW_PROJECT" \
-    -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+  run_cmd kubectl get job openshell-gateway-certgen -n "$E2E_GW_PROJECT" \
+    -o jsonpath='{.metadata.name}'
+  CERTGEN_JOB="${CMD_OUTPUT:-}"
   if [ "$CERTGEN_JOB" = "openshell-gateway-certgen" ]; then
     pass "Certgen job created in namespace '${E2E_GW_PROJECT}'"
   else
@@ -344,8 +364,9 @@ if [ "$E2E_GW_CLEANUP" = "true" ]; then
   fi
 
   # Verify TLS secrets were created (needed for session provisioning)
-  SERVER_TLS=$(kubectl get secret openshell-server-tls -n "$E2E_GW_PROJECT" \
-    -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+  run_cmd kubectl get secret openshell-server-tls -n "$E2E_GW_PROJECT" \
+    -o jsonpath='{.metadata.name}'
+  SERVER_TLS="${CMD_OUTPUT:-}"
   if [ "$SERVER_TLS" = "openshell-server-tls" ]; then
     pass "TLS secret openshell-server-tls created"
   else
@@ -353,7 +374,8 @@ if [ "$E2E_GW_CLEANUP" = "true" ]; then
   fi
 
   # Cleanup: delete the test project (namespace will be deprovisioned by project reconciler)
-  if $ACPCTL delete project "$E2E_GW_PROJECT" --yes >/dev/null 2>&1; then
+  run_cmd $ACPCTL delete project "$E2E_GW_PROJECT" --yes
+  if [ "$CMD_RC" -eq 0 ]; then
     echo "  Cleaned up project '${E2E_GW_PROJECT}'"
   else
     echo "  Could not delete project '${E2E_GW_PROJECT}' (non-fatal)"
@@ -408,15 +430,17 @@ section "6. Apply sandbox policies"
 # Policies must exist before any session starts — agents reference them by
 # name (sandbox_policy: permissive) and the control plane will fail the
 # session if the policy is not found.
-if $ACPCTL apply -f "$REPO_ROOT/examples/base/policies/permissive.yaml" \
-  --project "$TENANT" >/dev/null 2>&1; then
+run_cmd $ACPCTL apply -f "$REPO_ROOT/examples/base/policies/permissive.yaml" \
+  --project "$TENANT"
+if [ "$CMD_RC" -eq 0 ]; then
   pass "Permissive policy applied to ${TENANT}"
 else
   fail "Could not apply permissive policy to ${TENANT}"
 fi
 
-if $ACPCTL apply -f "$REPO_ROOT/examples/base/policies/locked-down.yaml" \
-  --project "$TENANT" >/dev/null 2>&1; then
+run_cmd $ACPCTL apply -f "$REPO_ROOT/examples/base/policies/locked-down.yaml" \
+  --project "$TENANT"
+if [ "$CMD_RC" -eq 0 ]; then
   pass "Locked-down policy applied to ${TENANT}"
 else
   fail "Could not apply locked-down policy to ${TENANT}"
@@ -454,9 +478,9 @@ fi
 
 section "8. OpenShell gateway healthy"
 
-GW_READY=$(kubectl get statefulset openshell-gateway -n "$TENANT" \
-  -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-GW_READY="${GW_READY:-0}"
+run_cmd kubectl get statefulset openshell-gateway -n "$TENANT" \
+  -o jsonpath='{.status.readyReplicas}'
+GW_READY="${CMD_OUTPUT:-0}"
 
 if [ "${GW_READY}" -ge 1 ]; then
   pass "openshell-gateway in ${TENANT} ready (replicas: ${GW_READY})"
@@ -464,9 +488,10 @@ else
   fail "openshell-gateway in ${TENANT} not ready (readyReplicas=${GW_READY})"
 fi
 
-CONTROLLER_READY=$(kubectl get deployment agent-sandbox-controller \
+run_cmd kubectl get deployment agent-sandbox-controller \
   -n agent-sandbox-system \
-  -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  -o jsonpath='{.status.readyReplicas}'
+CONTROLLER_READY="${CMD_OUTPUT:-0}"
 
 if [ "${CONTROLLER_READY:-0}" -ge 1 ]; then
   pass "agent-sandbox controller ready"
@@ -530,8 +555,8 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fail "Session project mismatch: expected ${PROJECT_ID}, got ${SESSION_PROJECT}"
   fi
 
-  SANDBOX_COUNT=$(kubectl get sandboxes -n "$TENANT" \
-    --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+  run_cmd kubectl get sandboxes -n "$TENANT" --no-headers
+  SANDBOX_COUNT=$(echo "$CMD_OUTPUT" | grep -c . 2>/dev/null || echo "0")
   if [ "${SANDBOX_COUNT}" -ge 1 ]; then
     pass "Sandbox resource created in namespace '${TENANT}' (${SANDBOX_COUNT})"
   else
@@ -589,8 +614,8 @@ if [ -n "$CREATED_SESSION_ID" ]; then
       # Poll briefly for the file to appear.
       PAYLOAD_READY=false
       for j in $(seq 1 10); do
-        PAYLOAD_CONTENT=$(kubectl exec -n "$TENANT" "$SBX_NAME" -- \
-          cat /sandbox/CLAUDE.md 2>/dev/null || echo "")
+        run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- cat /sandbox/CLAUDE.md
+        PAYLOAD_CONTENT="${CMD_OUTPUT:-}"
         if echo "$PAYLOAD_CONTENT" | grep -q "mock LLM"; then
           PAYLOAD_READY=true
           break
@@ -609,8 +634,9 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10b. Agent environment variable passed through to sandbox
-    ENV_VAL=$(kubectl exec -n "$TENANT" "$SBX_NAME" -- \
-      printenv CLAUDE_CODE_ATTRIBUTION_HEADER 2>/dev/null || echo "")
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+      printenv CLAUDE_CODE_ATTRIBUTION_HEADER
+    ENV_VAL="${CMD_OUTPUT:-}"
     if [ "$ENV_VAL" = "0" ]; then
       pass "Agent env var CLAUDE_CODE_ATTRIBUTION_HEADER passed through to sandbox"
     else
@@ -618,8 +644,9 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10c. MCP config env var patterns preserved (not auto-expanded)
-    MCP_CONTENT=$(kubectl exec -n "$TENANT" "$SBX_NAME" -- \
-      cat /sandbox/.mcp.json 2>/dev/null || echo "")
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+      cat /sandbox/.mcp.json
+    MCP_CONTENT="${CMD_OUTPUT:-}"
     if [ -n "$MCP_CONTENT" ]; then
       # Check that any ${...} patterns in the config were NOT replaced with
       # empty strings or resolved values — they should survive as literals.
@@ -635,8 +662,9 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10d. Claude settings baked into image match source
-    SETTINGS_ACTUAL=$(kubectl exec -n "$TENANT" "$SBX_NAME" -- \
-      cat /sandbox/.claude/settings.json 2>/dev/null || echo "")
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+      cat /sandbox/.claude/settings.json
+    SETTINGS_ACTUAL="${CMD_OUTPUT:-}"
     SETTINGS_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/claude-settings.json" 2>/dev/null || echo "")
     if [ -n "$SETTINGS_ACTUAL" ] && [ "$SETTINGS_ACTUAL" = "$SETTINGS_EXPECTED" ]; then
       pass "Claude settings.json matches source in image"
@@ -647,8 +675,9 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10e. Claude settings.local.json baked into image matches source
-    SETTINGS_LOCAL_ACTUAL=$(kubectl exec -n "$TENANT" "$SBX_NAME" -- \
-      cat /sandbox/.claude/settings.local.json 2>/dev/null || echo "")
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+      cat /sandbox/.claude/settings.local.json
+    SETTINGS_LOCAL_ACTUAL="${CMD_OUTPUT:-}"
     SETTINGS_LOCAL_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/claude-settings-local.json" 2>/dev/null || echo "")
     if [ -n "$SETTINGS_LOCAL_ACTUAL" ] && [ "$SETTINGS_LOCAL_ACTUAL" = "$SETTINGS_LOCAL_EXPECTED" ]; then
       pass "Claude settings.local.json matches source in image"
@@ -659,8 +688,9 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10f. Sandbox network policy present at /etc/openshell/policy.yaml
-    POLICY_ACTUAL=$(kubectl exec -n "$TENANT" "$SBX_NAME" -- \
-      cat /etc/openshell/policy.yaml 2>/dev/null || echo "")
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+      cat /etc/openshell/policy.yaml
+    POLICY_ACTUAL="${CMD_OUTPUT:-}"
     POLICY_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/policy.yaml" 2>/dev/null || echo "")
     if [ -n "$POLICY_ACTUAL" ] && [ "$POLICY_ACTUAL" = "$POLICY_EXPECTED" ]; then
       pass "Sandbox policy.yaml matches source in image"
@@ -693,7 +723,8 @@ if [ -n "$CREATED_SESSION_ID" ] && [ "${SESSION_RUNNING:-false}" = "true" ]; the
   MSG_COUNT=0
   LLM_RESPONSE_FOUND=0
   for i in $(seq 1 90); do
-    MESSAGES_OUTPUT=$($ACPCTL session messages "$CREATED_SESSION_ID" -o json 2>/dev/null || echo "[]")
+    run_cmd $ACPCTL session messages "$CREATED_SESSION_ID" -o json
+    MESSAGES_OUTPUT="${CMD_OUTPUT:-[]}"
     MSG_COUNT=$(echo "$MESSAGES_OUTPUT" | jq 'length' 2>/dev/null || echo "0")
     LLM_RESPONSE_FOUND=$(echo "$MESSAGES_OUTPUT" \
       | jq -r '[.[] | select(.event_type == "assistant" or .event_type == "TEXT_MESSAGE_CONTENT" or .event_type == "MESSAGES_SNAPSHOT")] | length' 2>/dev/null || echo "0")
@@ -857,7 +888,8 @@ if [ -n "$SHORT_SESSION_ID" ]; then
   # Wait for LLM response (same polling as long-running)
   SHORT_LLM_FOUND=0
   for i in $(seq 1 90); do
-    SHORT_MESSAGES=$($ACPCTL session messages "$SHORT_SESSION_ID" -o json 2>/dev/null || echo "[]")
+    run_cmd $ACPCTL session messages "$SHORT_SESSION_ID" -o json
+    SHORT_MESSAGES="${CMD_OUTPUT:-[]}"
     SHORT_LLM_FOUND=$(echo "$SHORT_MESSAGES" \
       | jq -r '[.[] | select(.event_type == "assistant" or .event_type == "TEXT_MESSAGE_CONTENT" or .event_type == "MESSAGES_SNAPSHOT")] | length' 2>/dev/null || echo "0")
     if [ "${SHORT_LLM_FOUND}" -gt 0 ]; then
@@ -988,10 +1020,13 @@ fi
 # Policies were already applied in section 6; only the test-specific agents
 # need to be created here.
 
-$ACPCTL apply -k "$SCRIPT_DIR/fixtures/network-policy-test" \
-  --project "$TENANT" >/dev/null 2>&1 && \
-  pass "Network test agents applied to ${TENANT}" || \
+run_cmd $ACPCTL apply -k "$SCRIPT_DIR/fixtures/network-policy-test" \
+  --project "$TENANT"
+if [ "$CMD_RC" -eq 0 ]; then
+  pass "Network test agents applied to ${TENANT}"
+else
   fail "Could not apply network test agents"
+fi
 
 # Look up the locked-down agent
 AGENTS_RESP=$(api GET "/api/ambient/v1/projects/${PROJECT_ID}/agents?size=50" || echo "")
@@ -1043,11 +1078,12 @@ if [ -n "$LOCKED_AGENT_ID" ]; then
       # (HTTPS would fail at the CONNECT tunnel level with no response body.)
       # FIXME: switch to `openshell sandbox exec` when it is fixed upstream.
       if [ "$LOCKED_SESSION_RUNNING" = "true" ]; then
-        LOCKED_CURL_OUTPUT=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        run_cmd ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
           -o LogLevel=ERROR \
           -o "ProxyCommand=openshell ssh-proxy --gateway-name $TENANT --name $LOCKED_SBX_NAME" \
           "user@$LOCKED_SBX_NAME" \
-          'curl http://update.code.visualstudio.com 2>/dev/null' 2>/dev/null) || true
+          'curl http://update.code.visualstudio.com 2>/dev/null'
+        LOCKED_CURL_OUTPUT="${CMD_OUTPUT:-}"
 
         if echo "$LOCKED_CURL_OUTPUT" | grep -q "policy_denied"; then
           pass "Locked-down policy denied outbound network access (policy_denied)"
@@ -1137,11 +1173,12 @@ if [ -n "$PERM_AGENT_ID" ]; then
       # appears, the proxy blocked it; any other response means it got through.
       # FIXME: switch to `openshell sandbox exec` when it is fixed upstream.
       if [ "$PERM_SESSION_RUNNING" = "true" ]; then
-        PERM_CURL_OUTPUT=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        run_cmd ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
           -o LogLevel=ERROR \
           -o "ProxyCommand=openshell ssh-proxy --gateway-name $TENANT --name $PERM_SBX_NAME" \
           "user@$PERM_SBX_NAME" \
-          'curl https://update.code.visualstudio.com 2>/dev/null' 2>/dev/null) || true
+          'curl https://update.code.visualstudio.com 2>/dev/null'
+        PERM_CURL_OUTPUT="${CMD_OUTPUT:-}"
 
         if echo "$PERM_CURL_OUTPUT" | grep -q "policy_denied"; then
           fail "Permissive policy denied update.code.visualstudio.com (policy_denied)"

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -159,6 +159,17 @@ run_cmd() {
   echo ""
 }
 
+run_cmd_redact() {
+  CMD_RC=0
+  echo ""
+  local redacted
+  redacted=$(printf '%s ' "$@" | sed -E \
+    -e 's/(--token |--client-secret |password=|client_secret=|clientSecret[":= ]*|Authorization: Bearer )[^ "}]*/\1[REDACTED]/g')
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "${redacted% }" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  echo ""
+}
+
 section() {
   echo ""
   sep
@@ -286,7 +297,7 @@ fi
 
 section "2. Login acpctl"
 
-run_cmd $ACPCTL login --url "$API_URL" --token "$TOKEN" --project "$TENANT"
+run_cmd_redact $ACPCTL login --url "$API_URL" --token "$TOKEN" --project "$TENANT"
 if [ "$CMD_RC" -eq 0 ]; then
   run_cmd $ACPCTL whoami
 fi

--- a/tests/e2e/hcmai-smoke.sh
+++ b/tests/e2e/hcmai-smoke.sh
@@ -111,6 +111,17 @@ run_cmd() {
   echo ""
 }
 
+run_cmd_redact() {
+  CMD_RC=0
+  echo ""
+  local redacted
+  redacted=$(printf '%s ' "$@" | sed -E \
+    -e 's/(--token |--client-secret |password=|client_secret=|clientSecret[":= ]*|Authorization: Bearer )[^ "}]*/\1[REDACTED]/g')
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "${redacted% }" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  echo ""
+}
+
 json_field() {
   local json="$1" field="$2"
   echo "$json" | python3 -c "
@@ -248,7 +259,7 @@ announce "1 · Authenticate"
 
 AUTH_MODE="oidc"
 
-run_cmd "$ACPCTL" login \
+run_cmd_redact "$ACPCTL" login \
   --client-credentials \
   --client-id "${OIDC_CLIENT_ID}" \
   --client-secret "${OIDC_CLIENT_SECRET}" \

--- a/tests/e2e/hcmai-smoke.sh
+++ b/tests/e2e/hcmai-smoke.sh
@@ -98,6 +98,19 @@ step_silent() {
   echo
 }
 
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
 json_field() {
   local json="$1" field="$2"
   echo "$json" | python3 -c "
@@ -235,19 +248,14 @@ announce "1 · Authenticate"
 
 AUTH_MODE="oidc"
 
-sep
-bold "▶  Login via client_credentials"
-printf "${ORANGE}   $ acpctl login --client-credentials --client-id %s --issuer-url %s${NC}\n" "${OIDC_CLIENT_ID}" "${OIDC_ISSUER_URL}"
-"$ACPCTL" login \
+run_cmd "$ACPCTL" login \
   --client-credentials \
   --client-id "${OIDC_CLIENT_ID}" \
   --client-secret "${OIDC_CLIENT_SECRET}" \
   --issuer-url "${OIDC_ISSUER_URL}" \
   --url "${API_URL}" \
   --project "${PROJECT_NAME}" \
-  --insecure-skip-tls-verify \
-  >/dev/null 2>&1
-echo
+  --insecure-skip-tls-verify
 
 AUTH_BEARER=$(jq -r '.access_token' ~/.config/ambient/config.json 2>/dev/null || echo "")
 if [[ -n "${AUTH_BEARER}" && "${AUTH_BEARER}" != "null" ]]; then
@@ -290,7 +298,8 @@ print(items[0]['id'] if items else '')
     die "project ${PROJECT_NAME} not found"
   fi
 else
-  PROJECT_JSON=$("$ACPCTL" create project --name "${PROJECT_NAME}" --description "hcmai smoke test ${RUN_ID}" -o json 2>/dev/null || echo "")
+  run_cmd "$ACPCTL" create project --name "${PROJECT_NAME}" --description "hcmai smoke test ${RUN_ID}" -o json
+  PROJECT_JSON="$CMD_OUTPUT"
   PROJECT_ID=$(json_field "${PROJECT_JSON}" "id")
 
   if [[ -n "${PROJECT_ID}" && "${PROJECT_ID}" != "" ]]; then
@@ -300,7 +309,7 @@ else
   fi
 fi
 
-"$ACPCTL" project "${PROJECT_NAME}" >/dev/null 2>&1 || true
+run_cmd "$ACPCTL" project "${PROJECT_NAME}"
 
 step "Confirm project context" "$ACPCTL" project current
 
@@ -349,21 +358,23 @@ EOF
 
 ensure_token
 
-sep
-bold "▶  Apply provider manifest"
-printf "${ORANGE}   $ acpctl apply -f provider-vertex.yaml${NC}\n"
-SMOKE_VERTEX_SA_KEY="${VERTEX_SA_KEY}" \
-  "$ACPCTL" apply -f "${MANIFEST_DIR}/provider-vertex.yaml" --project "${PROJECT_NAME}" 2>/dev/null && \
-  pass "provider '${PROVIDER_NAME}' applied" || \
-  fail "provider '${PROVIDER_NAME}' apply failed"
+export SMOKE_VERTEX_SA_KEY="${VERTEX_SA_KEY}"
 
-sep
-bold "▶  Apply credential manifest"
-printf "${ORANGE}   $ acpctl apply -f credential-vertex.yaml${NC}\n"
-SMOKE_VERTEX_SA_KEY="${VERTEX_SA_KEY}" \
-  "$ACPCTL" apply -f "${MANIFEST_DIR}/credential-vertex.yaml" --project "${PROJECT_NAME}" 2>/dev/null && \
-  pass "credential '${CREDENTIAL_NAME}' applied" || \
+run_cmd "$ACPCTL" apply -f "${MANIFEST_DIR}/provider-vertex.yaml" --project "${PROJECT_NAME}"
+if [[ $CMD_RC -eq 0 ]]; then
+  pass "provider '${PROVIDER_NAME}' applied"
+else
+  fail "provider '${PROVIDER_NAME}' apply failed"
+fi
+
+run_cmd "$ACPCTL" apply -f "${MANIFEST_DIR}/credential-vertex.yaml" --project "${PROJECT_NAME}"
+if [[ $CMD_RC -eq 0 ]]; then
+  pass "credential '${CREDENTIAL_NAME}' applied"
+else
   fail "credential '${CREDENTIAL_NAME}' apply failed"
+fi
+
+unset SMOKE_VERTEX_SA_KEY
 
 rm -rf "${MANIFEST_DIR}"
 
@@ -377,7 +388,8 @@ else
 fi
 
 ensure_token
-CREDS_RESP=$("$ACPCTL" credential list -o json 2>/dev/null || echo "")
+run_cmd "$ACPCTL" credential list -o json
+CREDS_RESP="$CMD_OUTPUT"
 FOUND_CREDENTIAL=$(echo "$CREDS_RESP" \
   | python3 -c "
 import sys, json
@@ -403,18 +415,18 @@ echo
 announce "4 · Create Agent"
 
 ensure_token
-AGENT_JSON=$(
-  "$ACPCTL" agent create \
-    --name "${AGENT_NAME}" \
-    --prompt "You are a concise test assistant. Answer questions directly and briefly." \
-    -o json 2>/dev/null || echo ""
-)
+run_cmd "$ACPCTL" agent create \
+  --name "${AGENT_NAME}" \
+  --prompt "You are a concise test assistant. Answer questions directly and briefly." \
+  -o json
+AGENT_JSON="$CMD_OUTPUT"
 AGENT_ID=$(json_field "${AGENT_JSON}" "id")
 
 if [[ -n "${AGENT_ID}" && "${AGENT_ID}" != "" ]]; then
   pass "agent created: ${AGENT_NAME} (${AGENT_ID})"
 else
-  EXISTING_AGENTS=$("$ACPCTL" get agents -o json 2>/dev/null || echo "")
+  run_cmd "$ACPCTL" get agents -o json
+  EXISTING_AGENTS="$CMD_OUTPUT"
   AGENT_ID=$(echo "$EXISTING_AGENTS" \
     | python3 -c "
 import sys, json
@@ -462,17 +474,12 @@ announce "5 · Create Session"
 
 ensure_token
 
-sep
-bold "▶  Create session"
-printf "${ORANGE}   $ acpctl create session --name llm-smoke-${RUN_ID} --agent-id ${AGENT_ID}${NC}\n"
-
-SESSION_JSON=$(
-  "$ACPCTL" create session \
-    --name "llm-smoke-${RUN_ID}" \
-    --agent-id "${AGENT_ID}" \
-    --prompt "You are a concise test assistant. Answer questions directly and briefly." \
-    -o json 2>/dev/null || echo ""
-)
+run_cmd "$ACPCTL" create session \
+  --name "llm-smoke-${RUN_ID}" \
+  --agent-id "${AGENT_ID}" \
+  --prompt "You are a concise test assistant. Answer questions directly and briefly." \
+  -o json
+SESSION_JSON="$CMD_OUTPUT"
 
 CREATED_SESSION_ID=$(json_field "${SESSION_JSON}" "id")
 if [[ -z "${CREATED_SESSION_ID}" || "${CREATED_SESSION_ID}" == "" ]]; then
@@ -566,13 +573,8 @@ announce "8 · Send Question & Stream LLM Response"
 
 USER_MESSAGE="What is 2+2? Reply with only the number, nothing else."
 
-sep
-bold "▶  Sending user message"
-printf "${ORANGE}   $ acpctl session send %s \"%s\"${NC}\n" "${CREATED_SESSION_ID}" "${USER_MESSAGE}"
-
 ensure_token
-"$ACPCTL" session send "${CREATED_SESSION_ID}" "${USER_MESSAGE}" 2>/dev/null || true
-echo
+run_cmd "$ACPCTL" session send "${CREATED_SESSION_ID}" "${USER_MESSAGE}"
 
 bold "▶  Waiting for LLM response (stream running in background)..."
 

--- a/tests/e2e/local-dev-test.sh
+++ b/tests/e2e/local-dev-test.sh
@@ -82,6 +82,21 @@ fail() { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
 skip() { echo -e "  ${YELLOW}⊘${NC} $1 (skipped: $2)"; }
 section() { echo ""; echo -e "${BOLD}$1${NC}"; }
 
+ORANGE='\033[38;5;214m'
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
 # Informational helpers (not test results)
 log_info() {
     echo -e "${BLUE}ℹ${NC} $*"
@@ -158,7 +173,8 @@ assert_pod_running() {
     local label=$1
     local description=$2
 
-    if kubectl get pods -n "$NAMESPACE" -l "$label" 2>/dev/null | grep -q "Running"; then
+    run_cmd kubectl get pods -n "$NAMESPACE" -l "$label"
+    if echo "$CMD_OUTPUT" | grep -q "Running"; then
         pass "$description"
         return 0
     else
@@ -215,12 +231,13 @@ test_kind_status() {
 
     section "3. Kind Status"
 
-    if kind get clusters 2>/dev/null | grep -q .; then
+    run_cmd kind get clusters
+    if echo "$CMD_OUTPUT" | grep -q . && [ "$CMD_RC" -eq 0 ]; then
         pass "Kind cluster is running"
 
         # Check kind version
-        local version
-        version=$(kind version 2>/dev/null || echo "unknown")
+        run_cmd kind version
+        local version="${CMD_OUTPUT:-unknown}"
         log_info "Kind version: $version"
     else
         fail "No Kind cluster is running"
@@ -237,12 +254,14 @@ test_kubernetes_context() {
     section "4. Kubernetes Context"
 
     local context
-    context=$(kubectl config current-context 2>/dev/null || echo "none")
+    run_cmd kubectl config current-context
+    context="${CMD_OUTPUT:-none}"
 
     assert_contains "$context" "kind-" "kubectl context is set to a kind cluster"
 
     # Test kubectl connectivity
-    if kubectl cluster-info >/dev/null 2>&1; then
+    run_cmd kubectl cluster-info
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "kubectl can connect to cluster"
     else
         fail "kubectl cannot connect to cluster"
@@ -257,7 +276,8 @@ test_namespace_exists() {
 
     section "5. Namespace Existence"
 
-    if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+    run_cmd kubectl get namespace "$NAMESPACE"
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "Namespace '$NAMESPACE' exists"
     else
         fail "Namespace '$NAMESPACE' does NOT exist"
@@ -278,8 +298,9 @@ test_pods_running() {
     assert_pod_running "app=ambient-control-plane" "Control plane pod is running"
 
     # Check pod readiness
+    run_cmd kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running
     local not_ready
-    not_ready=$(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running 2>/dev/null | grep -v "NAME" | wc -l)
+    not_ready=$(echo "$CMD_OUTPUT" | grep -v "NAME" | wc -l)
 
     if [ "$not_ready" -eq 0 ]; then
         pass "All pods are in Running state"
@@ -299,7 +320,8 @@ test_services_exist() {
     local services=("ambient-api-server" "ambient-ui-service")
 
     for svc in "${services[@]}"; do
-        if kubectl get svc "$svc" -n "$NAMESPACE" >/dev/null 2>&1; then
+        run_cmd kubectl get svc "$svc" -n "$NAMESPACE"
+        if [ "$CMD_RC" -eq 0 ]; then
             pass "Service '$svc' exists"
         else
             fail "Service '$svc' does NOT exist"
@@ -317,7 +339,8 @@ test_backend_health() {
 
     # Check backend health via pod readiness (kubectl wait already validates the
     # readiness probe which hits /health). Verify pod is ready as a proxy.
-    if kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then
+    run_cmd kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}'
+    if echo "$CMD_OUTPUT" | grep -q "True"; then
         pass "Backend health endpoint responds (pod readiness probe passes)"
     else
         fail "Backend pod is not ready (health endpoint may not be responding)"
@@ -333,7 +356,8 @@ test_frontend_accessibility() {
     section "9. Frontend Accessibility"
 
     # Check frontend health via pod readiness
-    if kubectl get pods -n "$NAMESPACE" -l app=ambient-ui -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then
+    run_cmd kubectl get pods -n "$NAMESPACE" -l app=ambient-ui -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}'
+    if echo "$CMD_OUTPUT" | grep -q "True"; then
         pass "Frontend is accessible (pod readiness probe passes)"
     else
         fail "Frontend pod is not ready"
@@ -351,7 +375,8 @@ test_rbac() {
     local roles=("ambient-project-admin" "ambient-project-edit" "ambient-project-view")
 
     for role in "${roles[@]}"; do
-        if kubectl get clusterrole "$role" >/dev/null 2>&1; then
+        run_cmd kubectl get clusterrole "$role"
+        if [ "$CMD_RC" -eq 0 ]; then
             pass "ClusterRole '$role' exists"
         else
             fail "ClusterRole '$role' does NOT exist"
@@ -367,19 +392,22 @@ test_build_command() {
 
     section "11. Build Commands (Dry Run)"
 
-    if make -n build-api-server >/dev/null 2>&1; then
+    run_cmd make -n build-api-server
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "make build-api-server syntax is valid"
     else
         fail "make build-api-server has syntax errors"
     fi
 
-    if make -n build-ambient-ui >/dev/null 2>&1; then
+    run_cmd make -n build-ambient-ui
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "make build-ambient-ui syntax is valid"
     else
         fail "make build-ambient-ui has syntax errors"
     fi
 
-    if make -n build-control-plane >/dev/null 2>&1; then
+    run_cmd make -n build-control-plane
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "make build-control-plane syntax is valid"
     else
         fail "make build-control-plane has syntax errors"
@@ -394,13 +422,15 @@ test_benchmark_syntax() {
 
     section "12. Benchmark Harness Syntax"
 
-    if bash -n scripts/benchmarks/component-bench.sh 2>/dev/null; then
+    run_cmd bash -n scripts/benchmarks/component-bench.sh
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "component-bench.sh syntax is valid"
     else
         fail "component-bench.sh has syntax errors"
     fi
 
-    if make -n benchmark >/dev/null 2>&1; then
+    run_cmd make -n benchmark
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "make benchmark syntax is valid"
     else
         fail "make benchmark has syntax errors"
@@ -419,7 +449,8 @@ test_logging_commands() {
     local components=("ambient-api-server" "ambient-ui" "ambient-control-plane")
 
     for component in "${components[@]}"; do
-        if kubectl logs -n "$NAMESPACE" -l "app=$component" --tail=1 >/dev/null 2>&1; then
+        run_cmd kubectl logs -n "$NAMESPACE" -l "app=$component" --tail=1
+        if [ "$CMD_RC" -eq 0 ]; then
             pass "Can retrieve logs from $component"
         else
             log_warning "Cannot retrieve logs from $component (pod may not be running)"
@@ -436,12 +467,13 @@ test_storage() {
     section "14. Storage Configuration"
 
     # Check if workspace PVC exists
-    if kubectl get pvc workspace-pvc -n "$NAMESPACE" >/dev/null 2>&1; then
+    run_cmd kubectl get pvc workspace-pvc -n "$NAMESPACE"
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "Workspace PVC exists"
 
         # Check PVC status
-        local status
-        status=$(kubectl get pvc workspace-pvc -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
+        run_cmd kubectl get pvc workspace-pvc -n "$NAMESPACE" -o jsonpath='{.status.phase}'
+        local status="${CMD_OUTPUT:-}"
         if [ "$status" = "Bound" ]; then
             pass "Workspace PVC is bound"
         else
@@ -464,8 +496,8 @@ test_resource_limits() {
     local deployments=("ambient-api-server" "ambient-ui" "ambient-control-plane")
 
     for deployment in "${deployments[@]}"; do
-        local resources
-        resources=$(kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].resources}' 2>/dev/null || echo "{}")
+        run_cmd kubectl get deployment "$deployment" -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].resources}'
+        local resources="${CMD_OUTPUT:-{}}"
 
         if [ "$resources" != "{}" ]; then
             pass "Deployment '$deployment' has resource configuration"
@@ -508,7 +540,8 @@ test_security_local_dev_user() {
     log_info "Verifying test-user service account exists..."
 
     # Kind creates a test-user service account with a pre-generated token
-    if kubectl get serviceaccount test-user -n "$NAMESPACE" >/dev/null 2>&1; then
+    run_cmd kubectl get serviceaccount test-user -n "$NAMESPACE"
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "test-user service account exists"
     else
         log_warning "test-user service account does not exist (may not be set up yet)"
@@ -518,7 +551,8 @@ test_security_local_dev_user() {
     fi
 
     # Check that the test-user token secret exists
-    if kubectl get secret test-user-token -n "$NAMESPACE" >/dev/null 2>&1; then
+    run_cmd kubectl get secret test-user-token -n "$NAMESPACE"
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "test-user-token secret exists"
     else
         log_warning "test-user-token secret does not exist"
@@ -538,7 +572,8 @@ test_security_prod_namespace_rejection() {
 
     # Test 1: Check backend middleware has protection
     local backend_pod
-    backend_pod=$(kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    run_cmd kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].metadata.name}'
+    backend_pod="${CMD_OUTPUT:-}"
 
     if [ -z "$backend_pod" ]; then
         log_warning "Backend pod not found, skipping namespace rejection test"
@@ -572,7 +607,8 @@ test_security_mock_token_logging() {
     log_info "Verifying backend logs show dev mode activation..."
 
     local backend_pod
-    backend_pod=$(kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    run_cmd kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].metadata.name}'
+    backend_pod="${CMD_OUTPUT:-}"
 
     if [ -z "$backend_pod" ]; then
         log_warning "Backend pod not found, skipping log test"
@@ -581,7 +617,8 @@ test_security_mock_token_logging() {
 
     # Get recent backend logs
     local logs
-    logs=$(kubectl logs -n "$NAMESPACE" "$backend_pod" --tail=100 2>/dev/null || echo "")
+    run_cmd kubectl logs -n "$NAMESPACE" "$backend_pod" --tail=100
+    logs="${CMD_OUTPUT:-}"
 
     if [ -z "$logs" ]; then
         log_warning "Could not retrieve backend logs"
@@ -628,7 +665,8 @@ test_security_token_redaction() {
     log_info "Verifying tokens are properly redacted in logs..."
 
     local backend_pod
-    backend_pod=$(kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    run_cmd kubectl get pods -n "$NAMESPACE" -l app=ambient-api-server -o jsonpath='{.items[0].metadata.name}'
+    backend_pod="${CMD_OUTPUT:-}"
 
     if [ -z "$backend_pod" ]; then
         log_warning "Backend pod not found, skipping token redaction test"
@@ -637,7 +675,8 @@ test_security_token_redaction() {
 
     # Get all backend logs
     local logs
-    logs=$(kubectl logs -n "$NAMESPACE" "$backend_pod" --tail=500 2>/dev/null || echo "")
+    run_cmd kubectl logs -n "$NAMESPACE" "$backend_pod" --tail=500
+    logs="${CMD_OUTPUT:-}"
 
     if [ -z "$logs" ]; then
         log_warning "Could not retrieve backend logs"
@@ -678,7 +717,8 @@ test_critical_token_minting() {
     # stored in a secret. Validate that this exists.
 
     # Step 1: test-user ServiceAccount must exist
-    if kubectl get serviceaccount test-user -n "$NAMESPACE" >/dev/null 2>&1; then
+    run_cmd kubectl get serviceaccount test-user -n "$NAMESPACE"
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "Step 1/2: test-user ServiceAccount exists"
     else
         log_warning "Step 1/2: test-user ServiceAccount does not exist (kind-up may not have completed)"
@@ -691,7 +731,8 @@ test_critical_token_minting() {
     fi
 
     # Step 2: test-user-token secret must exist
-    if kubectl get secret test-user-token -n "$NAMESPACE" >/dev/null 2>&1; then
+    run_cmd kubectl get secret test-user-token -n "$NAMESPACE"
+    if [ "$CMD_RC" -eq 0 ]; then
         pass "Step 2/2: test-user-token secret exists"
     else
         log_warning "Step 2/2: test-user-token secret does not exist"

--- a/tests/e2e/openshell-dual-tenant.sh
+++ b/tests/e2e/openshell-dual-tenant.sh
@@ -103,6 +103,17 @@ run_cmd() {
   echo ""
 }
 
+run_cmd_redact() {
+  CMD_RC=0
+  echo ""
+  local redacted
+  redacted=$(printf '%s ' "$@" | sed -E \
+    -e 's/(--token |--client-secret |password=|client_secret=|clientSecret[":= ]*|Authorization: Bearer )[^ "}]*/\1[REDACTED]/g')
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "${redacted% }" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  echo ""
+}
+
 require_token() {
   if [ -z "$TOKEN" ]; then
     echo -e "${RED}Error:${NC} TEST_TOKEN not set. Run 'make kind-up OPENSHELL_USE_GATEWAY=true' first."
@@ -453,7 +464,7 @@ fi
 section "Cleanup"
 
 for SESSION_ID in "${CREATED_SESSION_IDS[@]}"; do
-  run_cmd curl -sf --max-time 10 -X DELETE \
+  run_cmd_redact curl -sf --max-time 10 -X DELETE \
     -H "Authorization: Bearer ${TOKEN}" "${API_URL}/api/ambient/v1/sessions/${SESSION_ID}"
   if [ "$CMD_RC" -eq 0 ]; then
     echo "  Deleted session $SESSION_ID"

--- a/tests/e2e/openshell-dual-tenant.sh
+++ b/tests/e2e/openshell-dual-tenant.sh
@@ -88,6 +88,21 @@ api_delete() {
     -H "Authorization: Bearer ${TOKEN}" "${API_URL}${1}" 2>/dev/null || true
 }
 
+ORANGE='\033[38;5;214m'
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
 require_token() {
   if [ -z "$TOKEN" ]; then
     echo -e "${RED}Error:${NC} TEST_TOKEN not set. Run 'make kind-up OPENSHELL_USE_GATEWAY=true' first."
@@ -103,9 +118,9 @@ require_token() {
 section "1. OpenShell gateway deployments"
 
 for TENANT in "${TENANTS[@]}"; do
-  GW_READY=$(kubectl get statefulset openshell-gateway -n "$TENANT" \
-    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-  GW_READY="${GW_READY:-0}"
+  run_cmd kubectl get statefulset openshell-gateway -n "$TENANT" \
+    -o jsonpath='{.status.readyReplicas}'
+  GW_READY="${CMD_OUTPUT:-0}"
   if [ "${GW_READY}" -ge 1 ]; then
     pass "openshell-gateway in $TENANT is ready (replicas: $GW_READY)"
   else
@@ -119,16 +134,18 @@ done
 
 section "2. Agent Sandbox CRD and controller"
 
-CONTROLLER_READY=$(kubectl get deployment agent-sandbox-controller \
+run_cmd kubectl get deployment agent-sandbox-controller \
   -n agent-sandbox-system \
-  -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-if [ "${CONTROLLER_READY:-0}" -ge 1 ]; then
+  -o jsonpath='{.status.readyReplicas}'
+CONTROLLER_READY="${CMD_OUTPUT:-0}"
+if [ "${CONTROLLER_READY}" -ge 1 ]; then
   pass "agent-sandbox controller is ready"
 else
-  fail "agent-sandbox controller is not ready (readyReplicas=${CONTROLLER_READY:-0})"
+  fail "agent-sandbox controller is not ready (readyReplicas=${CONTROLLER_READY})"
 fi
 
-if kubectl get crd sandboxes.agents.x-k8s.io >/dev/null 2>&1; then
+run_cmd kubectl get crd sandboxes.agents.x-k8s.io
+if [ "$CMD_RC" -eq 0 ]; then
   pass "AgentSandbox CRD exists (sandboxes.agents.x-k8s.io)"
 else
   fail "AgentSandbox CRD not found"
@@ -227,16 +244,17 @@ else
   sleep 5
 
   for TENANT in "${TENANTS[@]}"; do
-    SANDBOX_COUNT=$(kubectl get sandboxes -n "$TENANT" \
-      --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+    run_cmd kubectl get sandboxes -n "$TENANT" --no-headers
+    SANDBOX_COUNT=$(echo "$CMD_OUTPUT" | grep -c . 2>/dev/null || echo "0")
     if [ "${SANDBOX_COUNT}" -ge 1 ]; then
       pass "Sandbox resource created in namespace '$TENANT' ($SANDBOX_COUNT sandbox(s))"
     else
       # The gateway may buffer the request or not expose it as a K8s CR depending
       # on gateway mode — downgrade to informational if gateways are healthy.
-      GATEWAY_HEALTHY=$(kubectl get statefulset openshell-gateway -n "$TENANT" \
-        -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-      if [ "${GATEWAY_HEALTHY:-0}" -ge 1 ]; then
+      run_cmd kubectl get statefulset openshell-gateway -n "$TENANT" \
+        -o jsonpath='{.status.readyReplicas}'
+      GATEWAY_HEALTHY="${CMD_OUTPUT:-0}"
+      if [ "${GATEWAY_HEALTHY}" -ge 1 ]; then
         skip "Sandbox CR in '$TENANT'" "gateway is healthy; sandbox may be internal to gateway"
       else
         fail "No sandbox resource in '$TENANT' and gateway is not ready"
@@ -435,9 +453,13 @@ fi
 section "Cleanup"
 
 for SESSION_ID in "${CREATED_SESSION_IDS[@]}"; do
-  api_delete "/api/ambient/v1/sessions/${SESSION_ID}" >/dev/null && \
-    echo "  Deleted session $SESSION_ID" || \
+  run_cmd curl -sf --max-time 10 -X DELETE \
+    -H "Authorization: Bearer ${TOKEN}" "${API_URL}/api/ambient/v1/sessions/${SESSION_ID}"
+  if [ "$CMD_RC" -eq 0 ]; then
+    echo "  Deleted session $SESSION_ID"
+  else
     echo "  Could not delete session $SESSION_ID (non-fatal)"
+  fi
 done
 
 # ============================================================================

--- a/tests/e2e/rbac_e2e_test.sh
+++ b/tests/e2e/rbac_e2e_test.sh
@@ -47,6 +47,17 @@ run_cmd() {
   echo ""
 }
 
+run_cmd_redact() {
+  CMD_RC=0
+  echo ""
+  local redacted
+  redacted=$(printf '%s ' "$@" | sed -E \
+    -e 's/(--token |--client-secret |password=|client_secret=|clientSecret[":= ]*|Authorization: Bearer )[^ "}]*/\1[REDACTED]/g')
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "${redacted% }" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  echo ""
+}
+
 HTTP_STATUS=""
 HTTP_BODY=""
 
@@ -131,7 +142,7 @@ assert_list_count() {
 KC_ADMIN_TOKEN=""
 
 get_admin_token() {
-  run_cmd curl -s --max-time 10 -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+  run_cmd_redact curl -s --max-time 10 -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
     -d "client_id=admin-cli" \
     -d "grant_type=password" \
     -d "username=${KC_ADMIN_USER}" \
@@ -146,7 +157,7 @@ get_admin_token() {
 KC_CLIENT_SECRET=""
 
 get_client_secret() {
-  run_cmd curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
+  run_cmd_redact curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
     "${KC_URL}/admin/realms/${KC_REALM}/clients?clientId=${KC_CLIENT_ID}"
   local clients="${CMD_OUTPUT:-}"
   local client_uuid
@@ -155,7 +166,7 @@ get_client_secret() {
     echo "WARN: Could not find client ${KC_CLIENT_ID} (response: $(echo "$clients" | head -c 120)), trying without secret"
     return
   fi
-  run_cmd curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
+  run_cmd_redact curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
     "${KC_URL}/admin/realms/${KC_REALM}/clients/${client_uuid}/client-secret"
   KC_CLIENT_SECRET=$(echo "$CMD_OUTPUT" | jq -r '.value // empty')
 }
@@ -163,7 +174,7 @@ get_client_secret() {
 create_keycloak_user() {
   local username="$1" password="$2" email="$3"
   local firstname="${4:-Test}" lastname="${5:-User}"
-  run_cmd curl -s -X POST \
+  run_cmd_redact curl -s -X POST \
     -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
     "${KC_URL}/admin/realms/${KC_REALM}/users" \
@@ -172,12 +183,12 @@ create_keycloak_user() {
 
 delete_keycloak_user() {
   local username="$1"
-  run_cmd curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
+  run_cmd_redact curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
     "${KC_URL}/admin/realms/${KC_REALM}/users?username=${username}&exact=true"
   local kc_uid
   kc_uid=$(echo "$CMD_OUTPUT" | jq -r '.[0].id // empty')
   if [[ -n "$kc_uid" ]]; then
-    run_cmd curl -s -X DELETE \
+    run_cmd_redact curl -s -X DELETE \
       -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
       "${KC_URL}/admin/realms/${KC_REALM}/users/${kc_uid}"
   fi
@@ -354,7 +365,7 @@ echo "  Updated ambient-api-server-auth ConfigMap with Keycloak JWKS"
 # 2. Patch ambient-api-server secret to include OIDC client credentials.
 #    The control plane reads clientId / clientSecret from this secret to
 #    authenticate to the API server via OIDC client_credentials grant.
-run_cmd kubectl patch secret ambient-api-server -n "$NS" -p \
+run_cmd_redact kubectl patch secret ambient-api-server -n "$NS" -p \
   "{\"stringData\":{\"clientId\":\"${OIDC_CLIENT_ID_CP}\",\"clientSecret\":\"${OIDC_CLIENT_SECRET_CP}\"}}"
 echo "  Patched ambient-api-server secret with OIDC client credentials"
 

--- a/tests/e2e/rbac_e2e_test.sh
+++ b/tests/e2e/rbac_e2e_test.sh
@@ -27,11 +27,25 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 BOLD='\033[1m'
 NC='\033[0m'
+ORANGE='\033[38;5;214m'
 
 pass() { echo -e "  ${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
 fail() { echo -e "  ${RED}✗${NC} $1${2:+: $2}"; FAILED=$((FAILED + 1)); }
 skip() { echo -e "  ${YELLOW}⊘${NC} $1 (skipped${2:+: $2})"; }
 section() { echo ""; echo -e "${BOLD}$1${NC}"; }
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
 
 HTTP_STATUS=""
 HTTP_BODY=""
@@ -117,11 +131,12 @@ assert_list_count() {
 KC_ADMIN_TOKEN=""
 
 get_admin_token() {
-  KC_ADMIN_TOKEN=$(curl -s --max-time 10 -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+  run_cmd curl -s --max-time 10 -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
     -d "client_id=admin-cli" \
     -d "grant_type=password" \
     -d "username=${KC_ADMIN_USER}" \
-    -d "password=${KC_ADMIN_PASS}" 2>/dev/null | jq -r '.access_token // empty')
+    -d "password=${KC_ADMIN_PASS}"
+  KC_ADMIN_TOKEN=$(echo "$CMD_OUTPUT" | jq -r '.access_token // empty')
   if [[ -z "$KC_ADMIN_TOKEN" || "$KC_ADMIN_TOKEN" == "null" ]]; then
     echo "ERROR: Failed to get Keycloak admin token from ${KC_URL}"
     return 1
@@ -131,38 +146,38 @@ get_admin_token() {
 KC_CLIENT_SECRET=""
 
 get_client_secret() {
-  local clients
-  clients=$(curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
-    "${KC_URL}/admin/realms/${KC_REALM}/clients?clientId=${KC_CLIENT_ID}")
+  run_cmd curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
+    "${KC_URL}/admin/realms/${KC_REALM}/clients?clientId=${KC_CLIENT_ID}"
+  local clients="${CMD_OUTPUT:-}"
   local client_uuid
   client_uuid=$(echo "$clients" | jq -r '.[0].id // empty' 2>/dev/null)
   if [[ -z "$client_uuid" ]]; then
     echo "WARN: Could not find client ${KC_CLIENT_ID} (response: $(echo "$clients" | head -c 120)), trying without secret"
     return
   fi
-  local secret_resp
-  secret_resp=$(curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
-    "${KC_URL}/admin/realms/${KC_REALM}/clients/${client_uuid}/client-secret")
-  KC_CLIENT_SECRET=$(echo "$secret_resp" | jq -r '.value // empty')
+  run_cmd curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
+    "${KC_URL}/admin/realms/${KC_REALM}/clients/${client_uuid}/client-secret"
+  KC_CLIENT_SECRET=$(echo "$CMD_OUTPUT" | jq -r '.value // empty')
 }
 
 create_keycloak_user() {
   local username="$1" password="$2" email="$3"
   local firstname="${4:-Test}" lastname="${5:-User}"
-  curl -s -o /dev/null -X POST \
+  run_cmd curl -s -X POST \
     -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
     "${KC_URL}/admin/realms/${KC_REALM}/users" \
-    -d "{\"username\":\"${username}\",\"email\":\"${email}\",\"firstName\":\"${firstname}\",\"lastName\":\"${lastname}\",\"emailVerified\":true,\"enabled\":true,\"requiredActions\":[],\"credentials\":[{\"type\":\"password\",\"value\":\"${password}\",\"temporary\":false}]}" 2>/dev/null || true
+    -d "{\"username\":\"${username}\",\"email\":\"${email}\",\"firstName\":\"${firstname}\",\"lastName\":\"${lastname}\",\"emailVerified\":true,\"enabled\":true,\"requiredActions\":[],\"credentials\":[{\"type\":\"password\",\"value\":\"${password}\",\"temporary\":false}]}"
 }
 
 delete_keycloak_user() {
   local username="$1"
+  run_cmd curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
+    "${KC_URL}/admin/realms/${KC_REALM}/users?username=${username}&exact=true"
   local kc_uid
-  kc_uid=$(curl -s -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
-    "${KC_URL}/admin/realms/${KC_REALM}/users?username=${username}&exact=true" | jq -r '.[0].id // empty')
+  kc_uid=$(echo "$CMD_OUTPUT" | jq -r '.[0].id // empty')
   if [[ -n "$kc_uid" ]]; then
-    curl -s -o /dev/null -X DELETE \
+    run_cmd curl -s -X DELETE \
       -H "Authorization: Bearer $KC_ADMIN_TOKEN" \
       "${KC_URL}/admin/realms/${KC_REALM}/users/${kc_uid}"
   fi
@@ -286,12 +301,13 @@ OIDC_CLIENT_SECRET_CP="e2e-secret-do-not-use-in-prod"
 # 0.5a. Align Keycloak KC_HOSTNAME with the external URL so signing keys
 #        match between internal and external access paths.
 KC_WANT_HOSTNAME="${KC_URL}"
-KC_CUR_HOSTNAME=$(kubectl get deployment keycloak -n "$NS" \
-  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="KC_HOSTNAME")].value}' 2>/dev/null || true)
+run_cmd kubectl get deployment keycloak -n "$NS" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="KC_HOSTNAME")].value}'
+KC_CUR_HOSTNAME="${CMD_OUTPUT:-}"
 if [[ "$KC_CUR_HOSTNAME" != "$KC_WANT_HOSTNAME" ]]; then
   echo "  Patching Keycloak hostname: $KC_CUR_HOSTNAME → $KC_WANT_HOSTNAME"
-  kubectl set env deployment/keycloak -n "$NS" KC_HOSTNAME="$KC_WANT_HOSTNAME" >/dev/null 2>&1
-  kubectl rollout status deployment/keycloak -n "$NS" --timeout=120s >/dev/null 2>&1 || true
+  run_cmd kubectl set env deployment/keycloak -n "$NS" KC_HOSTNAME="$KC_WANT_HOSTNAME"
+  run_cmd kubectl rollout status deployment/keycloak -n "$NS" --timeout=120s
   # Re-establish Keycloak port-forward after rollout
   if [[ "$KC_URL" == *"localhost"* ]]; then
     KC_PORT=$(echo "$KC_URL" | sed -n 's|.*localhost:\([0-9]*\).*|\1|p' | head -1)
@@ -328,16 +344,17 @@ if [[ -z "$KC_JWKS" || "$KC_JWKS" == "null" ]]; then
   echo "FATAL: Cannot fetch Keycloak JWKS from ${KC_URL}/realms/${KC_REALM}/protocol/openid-connect/certs"
   exit 1
 fi
-kubectl create configmap ambient-api-server-auth \
+KC_CM_YAML=$(kubectl create configmap ambient-api-server-auth \
   --from-literal="jwks.json=${KC_JWKS}" \
   --from-literal="acl.yml=" \
-  -n "$NS" --dry-run=client -o yaml | kubectl apply -f -
+  -n "$NS" --dry-run=client -o yaml 2>&1)
+run_cmd kubectl apply -f - <<< "$KC_CM_YAML"
 echo "  Updated ambient-api-server-auth ConfigMap with Keycloak JWKS"
 
 # 2. Patch ambient-api-server secret to include OIDC client credentials.
 #    The control plane reads clientId / clientSecret from this secret to
 #    authenticate to the API server via OIDC client_credentials grant.
-kubectl patch secret ambient-api-server -n "$NS" -p \
+run_cmd kubectl patch secret ambient-api-server -n "$NS" -p \
   "{\"stringData\":{\"clientId\":\"${OIDC_CLIENT_ID_CP}\",\"clientSecret\":\"${OIDC_CLIENT_SECRET_CP}\"}}"
 echo "  Patched ambient-api-server secret with OIDC client credentials"
 
@@ -346,7 +363,7 @@ echo "  Patched ambient-api-server secret with OIDC client credentials"
 #    - JWK_CERT_URL            (Keycloak JWKS for the production env fallback)
 #    - GRPC_SERVICE_ACCOUNT    (so the pre-auth interceptor tags OIDC SAs as CallerTypeService)
 #    - command args            (--enable-jwt=true --enable-authz=true)
-kubectl patch deployment/ambient-api-server -n "$NS" --type=json -p "$(cat <<'EOF'
+API_PATCH_JSON=$(cat <<'EOF'
 [
   {"op":"replace","path":"/spec/template/spec/containers/0/command","value":[
     "/usr/local/bin/ambient-api-server","serve",
@@ -378,8 +395,9 @@ kubectl patch deployment/ambient-api-server -n "$NS" --type=json -p "$(cat <<'EO
   ]}
 ]
 EOF
-)"
-kubectl set env deployment/ambient-api-server -n "$NS" \
+)
+run_cmd kubectl patch deployment/ambient-api-server -n "$NS" --type=json -p "$API_PATCH_JSON"
+run_cmd kubectl set env deployment/ambient-api-server -n "$NS" \
   AMBIENT_ENV=production \
   JWK_CERT_URL="$KC_JWKS_URL" \
   GRPC_SERVICE_ACCOUNT="service-account-${OIDC_CLIENT_ID_CP}"
@@ -387,9 +405,10 @@ echo "  Patched API server deployment (JWT + authz enabled, production env)"
 
 # 4. Wait for API server rollout FIRST — it must be healthy before CP starts
 echo "  Waiting for API server rollout..."
-if ! kubectl rollout status deployment/ambient-api-server -n "$NS" --timeout=120s; then
+run_cmd kubectl rollout status deployment/ambient-api-server -n "$NS" --timeout=120s
+if [ "$CMD_RC" -ne 0 ]; then
   echo "FATAL: API server rollout failed"
-  kubectl describe deployment/ambient-api-server -n "$NS" | tail -20
+  run_cmd kubectl describe deployment/ambient-api-server -n "$NS"
   exit 1
 fi
 
@@ -426,10 +445,11 @@ fi
 
 # 7. Verify API server accepts Keycloak JWTs (smoke test with client_credentials token)
 echo "  Verifying API server JWT auth..."
-VERIFY_TOKEN=$(curl -sf -X POST "${KC_URL}/realms/${KC_REALM}/protocol/openid-connect/token" \
+run_cmd curl -s -X POST "${KC_URL}/realms/${KC_REALM}/protocol/openid-connect/token" \
   -d "client_id=${OIDC_CLIENT_ID_CP}" \
   -d "client_secret=${OIDC_CLIENT_SECRET_CP}" \
-  -d "grant_type=client_credentials" | jq -r '.access_token // empty')
+  -d "grant_type=client_credentials"
+VERIFY_TOKEN=$(echo "$CMD_OUTPUT" | jq -r '.access_token // empty')
 if [[ -z "$VERIFY_TOKEN" ]]; then
   echo "FATAL: Cannot get OIDC token from Keycloak for ${OIDC_CLIENT_ID_CP}"
   exit 1
@@ -448,31 +468,33 @@ done
 if [[ "$JWT_VERIFIED" != "true" ]]; then
   echo "FATAL: API server not accepting Keycloak JWTs after 30s (last status=$VERIFY_STATUS)"
   echo "  API server logs:"
-  kubectl logs -n "$NS" deploy/ambient-api-server -c api-server --tail=30 2>/dev/null || true
+  run_cmd kubectl logs -n "$NS" deploy/ambient-api-server -c api-server --tail=30
   exit 1
 fi
 
 # 8. NOW patch and restart the control plane (API server is verified healthy)
-kubectl set env deployment/ambient-control-plane -n "$NS" \
+run_cmd kubectl set env deployment/ambient-control-plane -n "$NS" \
   OIDC_CLIENT_ID="$OIDC_CLIENT_ID_CP" \
   OIDC_CLIENT_SECRET="$OIDC_CLIENT_SECRET_CP" \
   OIDC_TOKEN_URL="$KC_TOKEN_URL"
 # Always restart CP to get fresh gRPC watch streams (set env is a no-op
 # if values unchanged, which means no rollout and stale streams persist)
-kubectl rollout restart deployment/ambient-control-plane -n "$NS" 2>/dev/null || true
+run_cmd kubectl rollout restart deployment/ambient-control-plane -n "$NS"
 echo "  Patched and restarted control plane"
 echo "  Waiting for control plane rollout..."
-if ! kubectl rollout status deployment/ambient-control-plane -n "$NS" --timeout=120s; then
+run_cmd kubectl rollout status deployment/ambient-control-plane -n "$NS" --timeout=120s
+if [ "$CMD_RC" -ne 0 ]; then
   echo "FATAL: Control plane rollout failed"
-  kubectl describe deployment/ambient-control-plane -n "$NS" | tail -20
+  run_cmd kubectl describe deployment/ambient-control-plane -n "$NS"
   exit 1
 fi
 
 # 9. Verify control plane pod is healthy
 CP_READY=false
 for attempt in $(seq 1 10); do
-  CP_STATUS=$(kubectl get pods -n "$NS" -l app=ambient-control-plane \
-    -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null || true)
+  run_cmd kubectl get pods -n "$NS" -l app=ambient-control-plane \
+    -o jsonpath='{.items[0].status.containerStatuses[0].ready}'
+  CP_STATUS="${CMD_OUTPUT:-}"
   if [[ "$CP_STATUS" == "true" ]]; then
     echo "  Control plane is ready (attempt $attempt)"
     CP_READY=true
@@ -483,7 +505,7 @@ done
 if [[ "$CP_READY" != "true" ]]; then
   echo "WARNING: Control plane pod not ready after 20s — sessions may stay Pending"
   echo "  Control plane logs:"
-  kubectl logs -n "$NS" deploy/ambient-control-plane --tail=20 2>/dev/null || true
+  run_cmd kubectl logs -n "$NS" deploy/ambient-control-plane --tail=20
 fi
 
 # 10. Wait for the CP's gRPC watch streams to be established.
@@ -491,7 +513,8 @@ fi
 #     server (~10s lag). Sessions created in that gap are missed.
 CP_STREAMS=false
 for attempt in $(seq 1 20); do
-  if kubectl logs -n "$NS" deploy/ambient-control-plane --tail=50 2>/dev/null | grep -q "session watch stream established"; then
+  run_cmd kubectl logs -n "$NS" deploy/ambient-control-plane --tail=50
+  if echo "$CMD_OUTPUT" | grep -q "session watch stream established"; then
     CP_STREAMS=true
     break
   fi
@@ -1518,16 +1541,17 @@ section "24. Platform Viewer Cannot Escalate to Admin"
 # Grant User C platform:viewer (via direct DB insert since we need a global binding)
 # We can't grant global from a non-admin, so we use the seed-admin pattern via kubectl
 VIEWER_GLOBAL_BIND=""
-DB_POD_NAME=$(kubectl get pods -n "$NS" -l app=ambient-api-server,component=database -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+run_cmd kubectl get pods -n "$NS" -l app=ambient-api-server,component=database -o jsonpath='{.items[0].metadata.name}'
+DB_POD_NAME="${CMD_OUTPUT:-}"
 if [[ -z "$DB_POD_NAME" ]]; then
   fail "Phase 24 setup" "DB pod not found — cannot seed platform:viewer binding; skipping viewer escalation tests"
 else
-  kubectl exec -n "$NS" "$DB_POD_NAME" -- psql -U ambient -d ambient_api_server -t -A -c "
+  run_cmd kubectl exec -n "$NS" "$DB_POD_NAME" -- psql -U ambient -d ambient_api_server -t -A -c "
     INSERT INTO role_bindings (id, role_id, scope, user_id, created_at, updated_at)
     SELECT '$(date +%s)viewerbind', r.id, 'global', 'rbac-user-c', NOW(), NOW()
     FROM roles r WHERE r.name = 'platform:viewer' AND r.deleted_at IS NULL
     ON CONFLICT DO NOTHING;
-  " 2>/dev/null >/dev/null
+  "
 
   # Refresh token for User C
   TOKEN_C=$(get_token "rbac-user-c" "testpass")
@@ -1549,23 +1573,24 @@ section "25. Delete Hierarchy -- owner cannot delete higher-privilege bindings"
 
 # Seed a platform:admin binding scoped to proj-alpha via direct DB insert.
 # No user can grant platform:admin on a project via the API, so we seed it.
-DB_POD=$(kubectl get pods -n "$NS" -l app=ambient-api-server,component=database -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+run_cmd kubectl get pods -n "$NS" -l app=ambient-api-server,component=database -o jsonpath='{.items[0].metadata.name}'
+DB_POD="${CMD_OUTPUT:-}"
 F5_BIND_ID="f5_test_admin_bind"
 if [[ -n "$DB_POD" ]]; then
-  kubectl exec -n "$NS" "$DB_POD" -- psql -U ambient -d ambient_api_server -qc "
+  run_cmd kubectl exec -n "$NS" "$DB_POD" -- psql -U ambient -d ambient_api_server -qc "
     INSERT INTO role_bindings (id, role_id, scope, project_id, user_id, created_at, updated_at)
     SELECT '${F5_BIND_ID}', r.id, 'project', 'rbac-proj-alpha', 'rbac-admin-ghost', NOW(), NOW()
     FROM roles r WHERE r.name = 'platform:admin' AND r.deleted_at IS NULL
     ON CONFLICT DO NOTHING;
-  " 2>/dev/null || true
+  "
 
   # User A (project:owner level 1) tries to delete platform:admin's binding (level 0) → must fail
   api DELETE "/role_bindings/${F5_BIND_ID}" "$TOKEN_A"
   assert_status "403" "$HTTP_STATUS" "F5: project:owner cannot delete platform:admin binding"
 
   # Clean up
-  kubectl exec -n "$NS" "$DB_POD" -- psql -U ambient -d ambient_api_server -qc \
-    "DELETE FROM role_bindings WHERE id = '${F5_BIND_ID}';" 2>/dev/null || true
+  run_cmd kubectl exec -n "$NS" "$DB_POD" -- psql -U ambient -d ambient_api_server -qc \
+    "DELETE FROM role_bindings WHERE id = '${F5_BIND_ID}';"
 else
   skip "F5: DB pod not found"
 fi

--- a/tests/e2e/route-e2e-test.sh
+++ b/tests/e2e/route-e2e-test.sh
@@ -60,6 +60,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BOLD='\033[1m'
+ORANGE='\033[38;5;214m'
 NC='\033[0m'
 
 PASSED=0
@@ -70,14 +71,27 @@ fail() { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
 skip() { echo -e "  ${YELLOW}⊘${NC} $1 (skipped: $2)"; }
 section() { echo ""; echo -e "${BOLD}$1${NC}"; }
 
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
 cleanup() {
   if [ "$SKIP_CLEANUP" = "true" ]; then
     echo "Skipping cleanup (--skip-cleanup)"
     return
   fi
   echo "Cleaning up..."
-  $ACPCTL delete gateway $GW_NAME 2>/dev/null || true
-  $ACPCTL delete project "$TENANT" -y 2>/dev/null || true
+  run_cmd $ACPCTL delete gateway $GW_NAME
+  run_cmd $ACPCTL delete project "$TENANT" -y
 }
 trap cleanup EXIT
 
@@ -87,10 +101,14 @@ echo ""
 
 # Setup: create project and gateway with route
 echo "--- Setup ---"
-$ACPCTL config set api_url "$API_URL"
+run_cmd $ACPCTL config set api_url "$API_URL"
 
 # Get token from Keycloak via password grant (curl bypasses TLS issues with self-signed certs)
-KC_ROUTE_HOST=$(oc get route keycloak -n "$NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || true)
+run_cmd oc get route keycloak -n "$NAMESPACE" -o jsonpath='{.spec.host}'
+KC_ROUTE_HOST=""
+if [ "$CMD_RC" -eq 0 ]; then
+  KC_ROUTE_HOST="${CMD_OUTPUT:-}"
+fi
 if [ -n "$KC_ROUTE_HOST" ] && [ -z "${AMBIENT_TOKEN:-}" ]; then
   AMBIENT_TOKEN=$(curl -sk -X POST "https://${KC_ROUTE_HOST}/realms/ambient-code/protocol/openid-connect/token" \
     -d "grant_type=password" \
@@ -105,12 +123,22 @@ if [ -n "$KC_ROUTE_HOST" ] && [ -z "${AMBIENT_TOKEN:-}" ]; then
   fi
 fi
 
-$ACPCTL apply -f - <<YAML
+echo ""
+printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "acpctl apply -f - <<YAML (Project: $TENANT)" "${NC}"
+CMD_RC=0
+CMD_OUTPUT=$($ACPCTL apply -f - <<YAML 2>&1
 kind: Project
 name: $TENANT
 YAML
+) || CMD_RC=$?
+if [ -n "$CMD_OUTPUT" ]; then
+  echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+fi
+echo ""
 
-TENANT_NS=$($ACPCTL get project "$TENANT" -o json 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4 || echo "$TENANT")
+run_cmd $ACPCTL get project "$TENANT" -o json
+TENANT_NS=$(echo "$CMD_OUTPUT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+TENANT_NS="${TENANT_NS:-$TENANT}"
 
 # ============================================================================
 # Section 1: Route Creation
@@ -118,7 +146,10 @@ TENANT_NS=$($ACPCTL get project "$TENANT" -o json 2>/dev/null | grep -o '"id":"[
 
 section "1. Route Creation"
 
-$ACPCTL apply -f - <<YAML
+echo ""
+printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "acpctl apply -f - <<YAML (Gateway: $GW_NAME, route: {})" "${NC}"
+CMD_RC=0
+CMD_OUTPUT=$($ACPCTL apply -f - <<YAML 2>&1
 kind: Gateway
 name: $GW_NAME
 project: $TENANT
@@ -126,11 +157,17 @@ server_dns_names:
   - openshell-gateway.NAMESPACE_PLACEHOLDER.svc.cluster.local
 route: {}
 YAML
+) || CMD_RC=$?
+if [ -n "$CMD_OUTPUT" ]; then
+  echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+fi
+echo ""
 
 # Wait for route to appear
 ROUTE_FOUND=false
 for i in $(seq 1 30); do
-  if oc get route openshell-gateway -n "$TENANT_NS" &>/dev/null; then
+  run_cmd oc get route openshell-gateway -n "$TENANT_NS"
+  if [ "$CMD_RC" -eq 0 ]; then
     ROUTE_FOUND=true
     break
   fi
@@ -144,7 +181,8 @@ else
 fi
 
 # Verify TLS termination
-TLS_TERM=$(oc get route openshell-gateway -n "$TENANT_NS" -o jsonpath='{.spec.tls.termination}' 2>/dev/null || true)
+run_cmd oc get route openshell-gateway -n "$TENANT_NS" -o jsonpath='{.spec.tls.termination}'
+TLS_TERM="${CMD_OUTPUT:-}"
 if [ "$TLS_TERM" = "reencrypt" ]; then
   pass "Route has reencrypt TLS termination"
 else
@@ -152,7 +190,8 @@ else
 fi
 
 # Verify timeout annotation
-TIMEOUT_ANN=$(oc get route openshell-gateway -n "$TENANT_NS" -o jsonpath='{.metadata.annotations.haproxy\.router\.openshift\.io/timeout}' 2>/dev/null || true)
+run_cmd oc get route openshell-gateway -n "$TENANT_NS" -o jsonpath='{.metadata.annotations.haproxy\.router\.openshift\.io/timeout}'
+TIMEOUT_ANN="${CMD_OUTPUT:-}"
 if [ "$TIMEOUT_ANN" = "3600s" ]; then
   pass "Route has 3600s timeout annotation"
 else
@@ -167,7 +206,8 @@ section "2. Route Address Populated"
 
 ROUTE_ADDR=""
 for i in $(seq 1 20); do
-  ROUTE_ADDR=$($ACPCTL get gateway $GW_NAME --project "$TENANT" -o json 2>/dev/null | grep -o '"route_address": *"[^"]*"' | cut -d'"' -f4 || true)
+  run_cmd $ACPCTL get gateway $GW_NAME --project "$TENANT" -o json
+  ROUTE_ADDR=$(echo "$CMD_OUTPUT" | grep -o '"route_address": *"[^"]*"' | cut -d'"' -f4 || true)
   if [ -n "$ROUTE_ADDR" ]; then
     break
   fi
@@ -188,7 +228,8 @@ else
 fi
 
 # Verify ROUTE column in table output
-ROUTE_COL=$($ACPCTL get gateways --project "$TENANT" 2>/dev/null | grep "$GW_NAME" | grep -o 'https://[^ ]*' || true)
+run_cmd $ACPCTL get gateways --project "$TENANT"
+ROUTE_COL=$(echo "$CMD_OUTPUT" | grep "$GW_NAME" | grep -o 'https://[^ ]*' || true)
 if [ -n "$ROUTE_COL" ]; then
   pass "ROUTE column shows address in table output"
 else
@@ -201,7 +242,8 @@ fi
 
 section "3. setup-cli Via Route"
 
-SETUP_OUTPUT=$($ACPCTL gateway setup-cli $GW_NAME --project "$TENANT" --print 2>/dev/null || true)
+run_cmd $ACPCTL gateway setup-cli $GW_NAME --project "$TENANT" --print
+SETUP_OUTPUT="${CMD_OUTPUT:-}"
 if echo "$SETUP_OUTPUT" | grep -q "$ROUTE_ADDR"; then
   pass "setup-cli --print includes route address"
 else
@@ -215,17 +257,26 @@ fi
 section "4. Route Removal"
 
 # Patch gateway to remove route
-$ACPCTL apply -f - <<YAML
+echo ""
+printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "acpctl apply -f - <<YAML (Gateway: $GW_NAME, no route)" "${NC}"
+CMD_RC=0
+CMD_OUTPUT=$($ACPCTL apply -f - <<YAML 2>&1
 kind: Gateway
 name: $GW_NAME
 project: $TENANT
 server_dns_names:
   - openshell-gateway.NAMESPACE_PLACEHOLDER.svc.cluster.local
 YAML
+) || CMD_RC=$?
+if [ -n "$CMD_OUTPUT" ]; then
+  echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+fi
+echo ""
 
 ROUTE_DELETED=false
 for i in $(seq 1 20); do
-  if ! oc get route openshell-gateway -n "$TENANT_NS" &>/dev/null; then
+  run_cmd oc get route openshell-gateway -n "$TENANT_NS"
+  if [ "$CMD_RC" -ne 0 ]; then
     ROUTE_DELETED=true
     break
   fi
@@ -239,7 +290,8 @@ else
 fi
 
 # Verify routeAddress cleared
-CLEARED_ADDR=$($ACPCTL get gateway $GW_NAME --project "$TENANT" -o json 2>/dev/null | grep -o '"route_address": *"[^"]*"' | cut -d'"' -f4 || true)
+run_cmd $ACPCTL get gateway $GW_NAME --project "$TENANT" -o json
+CLEARED_ADDR=$(echo "$CMD_OUTPUT" | grep -o '"route_address": *"[^"]*"' | cut -d'"' -f4 || true)
 if [ -z "$CLEARED_ADDR" ]; then
   pass "routeAddress cleared after route removal"
 else

--- a/tests/e2e/scheduled_sessions_e2e_test.sh
+++ b/tests/e2e/scheduled_sessions_e2e_test.sh
@@ -43,6 +43,21 @@ fail() { echo -e "  ${RED}✗${NC} $1${2:+: $2}"; FAILED=$((FAILED + 1)); }
 skip() { echo -e "  ${YELLOW}⊘${NC} $1 (skipped${2:+: $2})"; }
 section() { echo ""; echo -e "${BOLD}$1${NC}"; }
 
+ORANGE='\033[38;5;214m'
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
 HTTP_STATUS=""
 HTTP_BODY=""
 
@@ -370,7 +385,8 @@ fi
 
 section "10. Scheduler health check"
 
-SCHEDULER_LOGS=$(kubectl logs -n "$NS" -l app=ambient-api-server --tail=50 2>/dev/null | grep -c "scheduled-session-scheduler" || true)
+run_cmd kubectl logs -n "$NS" -l app=ambient-api-server --tail=50
+SCHEDULER_LOGS=$(echo "${CMD_OUTPUT:-}" | grep -c "scheduled-session-scheduler" || true)
 if [[ "$SCHEDULER_LOGS" -ge 1 ]]; then
   pass "Scheduler advisory lock cycling in API server logs"
 else

--- a/tests/e2e/smoke-test-llm.sh
+++ b/tests/e2e/smoke-test-llm.sh
@@ -110,6 +110,17 @@ run_cmd() {
   echo ""
 }
 
+run_cmd_redact() {
+  CMD_RC=0
+  echo ""
+  local redacted
+  redacted=$(printf '%s ' "$@" | sed -E \
+    -e 's/(--token |--client-secret |password=|client_secret=|clientSecret[":= ]*|Authorization: Bearer )[^ "}]*/\1[REDACTED]/g')
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "${redacted% }" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  echo ""
+}
+
 json_field() {
   local json="$1" field="$2"
   echo "$json" | python3 -c "
@@ -248,7 +259,7 @@ if [[ -n "${OIDC_CLIENT_ID:-}" && -n "${OIDC_CLIENT_SECRET:-}" ]]; then
   dim "issuer: ${OIDC_ISSUER_URL}"
   dim "client: ${OIDC_CLIENT_ID}"
 
-  run_cmd $ACPCTL login \
+  run_cmd_redact $ACPCTL login \
     --client-credentials \
     --client-id "${OIDC_CLIENT_ID}" \
     --client-secret "${OIDC_CLIENT_SECRET}" \
@@ -280,7 +291,7 @@ elif [[ -n "${TEST_TOKEN:-}" ]]; then
   AUTH_MODE="token"
   AUTH_BEARER="${TEST_TOKEN}"
 
-  run_cmd $ACPCTL login "${API_URL}" \
+  run_cmd_redact $ACPCTL login "${API_URL}" \
     --token "${AUTH_BEARER}" \
     --project "${PROJECT_NAME}" \
     --insecure-skip-tls-verify
@@ -299,7 +310,7 @@ elif [[ -f "$SCRIPT_DIR/../cypress/.env.test" ]]; then
   AUTH_BEARER="${TEST_TOKEN:-}"
 
   if [[ -n "${AUTH_BEARER}" ]]; then
-    run_cmd $ACPCTL login "${API_URL}" \
+    run_cmd_redact $ACPCTL login "${API_URL}" \
       --token "${AUTH_BEARER}" \
       --project "${PROJECT_NAME}" \
       --insecure-skip-tls-verify

--- a/tests/e2e/smoke-test-llm.sh
+++ b/tests/e2e/smoke-test-llm.sh
@@ -95,6 +95,21 @@ section() { echo ""; echo -e "${BOLD}$1${NC}"; }
 dim() { echo -e "${DIM}  $1${NC}"; }
 die() { echo -e "${RED}error:${NC} $*" >&2; exit 1; }
 
+ORANGE='\033[38;5;214m'
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
 json_field() {
   local json="$1" field="$2"
   echo "$json" | python3 -c "
@@ -176,15 +191,13 @@ cleanup() {
   ensure_acpctl_token
 
   if [[ -n "${CREATED_SESSION_ID}" ]]; then
-    dim "stopping session ${CREATED_SESSION_ID}..."
-    "$ACPCTL" stop "${CREATED_SESSION_ID}" 2>/dev/null || true
+    run_cmd $ACPCTL stop "${CREATED_SESSION_ID}"
     sleep 2
-    "$ACPCTL" delete session "${CREATED_SESSION_ID}" -y 2>/dev/null || true
+    run_cmd $ACPCTL delete session "${CREATED_SESSION_ID}" -y
   fi
 
   if [[ -n "${CREATED_PROJECT}" ]]; then
-    dim "deleting project ${CREATED_PROJECT}..."
-    "$ACPCTL" delete project "${CREATED_PROJECT}" -y 2>/dev/null || true
+    run_cmd $ACPCTL delete project "${CREATED_PROJECT}" -y
   fi
 }
 trap cleanup EXIT
@@ -235,15 +248,14 @@ if [[ -n "${OIDC_CLIENT_ID:-}" && -n "${OIDC_CLIENT_SECRET:-}" ]]; then
   dim "issuer: ${OIDC_ISSUER_URL}"
   dim "client: ${OIDC_CLIENT_ID}"
 
-  "$ACPCTL" login \
+  run_cmd $ACPCTL login \
     --client-credentials \
     --client-id "${OIDC_CLIENT_ID}" \
     --client-secret "${OIDC_CLIENT_SECRET}" \
     --issuer-url "${OIDC_ISSUER_URL}" \
     --url "${API_URL}" \
     --project "${PROJECT_NAME}" \
-    --insecure-skip-tls-verify \
-    >/dev/null 2>&1
+    --insecure-skip-tls-verify
 
   AUTH_BEARER=$(jq -r '.access_token' ~/.config/ambient/config.json 2>/dev/null || echo "")
   if [[ -n "${AUTH_BEARER}" && "${AUTH_BEARER}" != "null" ]]; then
@@ -268,13 +280,17 @@ elif [[ -n "${TEST_TOKEN:-}" ]]; then
   AUTH_MODE="token"
   AUTH_BEARER="${TEST_TOKEN}"
 
-  "$ACPCTL" login "${API_URL}" \
+  run_cmd $ACPCTL login "${API_URL}" \
     --token "${AUTH_BEARER}" \
     --project "${PROJECT_NAME}" \
-    --insecure-skip-tls-verify \
-    >/dev/null 2>&1
+    --insecure-skip-tls-verify
 
-  pass "bearer token login succeeded"
+  if [ "$CMD_RC" -eq 0 ]; then
+    pass "bearer token login succeeded"
+  else
+    fail "bearer token login failed"
+    die "Authentication failed"
+  fi
 
 elif [[ -f "$SCRIPT_DIR/../cypress/.env.test" ]]; then
   AUTH_MODE="token"
@@ -283,12 +299,17 @@ elif [[ -f "$SCRIPT_DIR/../cypress/.env.test" ]]; then
   AUTH_BEARER="${TEST_TOKEN:-}"
 
   if [[ -n "${AUTH_BEARER}" ]]; then
-    "$ACPCTL" login "${API_URL}" \
+    run_cmd $ACPCTL login "${API_URL}" \
       --token "${AUTH_BEARER}" \
       --project "${PROJECT_NAME}" \
-      --insecure-skip-tls-verify \
-      >/dev/null 2>&1
-    pass "bearer token login succeeded (from .env.test)"
+      --insecure-skip-tls-verify
+
+    if [ "$CMD_RC" -eq 0 ]; then
+      pass "bearer token login succeeded (from .env.test)"
+    else
+      fail "bearer token login failed (from .env.test)"
+      die "Authentication failed"
+    fi
   else
     fail "TEST_TOKEN not found in .env.test"
     die "No authentication method available"
@@ -303,9 +324,9 @@ else
   die "No authentication method available"
 fi
 
-WHOAMI=$("$ACPCTL" whoami 2>/dev/null || echo "")
-if [[ -n "$WHOAMI" ]]; then
-  dim "identity: $(echo "$WHOAMI" | head -1)"
+run_cmd $ACPCTL whoami
+if [ -n "$CMD_OUTPUT" ]; then
+  dim "identity: $(echo "$CMD_OUTPUT" | head -1)"
 else
   fail "acpctl whoami failed after login"
 fi
@@ -332,7 +353,8 @@ print(items[0]['id'] if items else '')
     die "Project not found"
   fi
 else
-  PROJECT_JSON=$("$ACPCTL" create project --name "${PROJECT_NAME}" --description "LLM smoke test ${RUN_ID}" -o json 2>/dev/null || echo "")
+  run_cmd $ACPCTL create project --name "${PROJECT_NAME}" --description "LLM smoke test ${RUN_ID}" -o json
+  PROJECT_JSON="${CMD_OUTPUT:-}"
   PROJECT_ID=$(json_field "${PROJECT_JSON}" "id")
 
   if [[ -n "${PROJECT_ID}" && "${PROJECT_ID}" != "" ]]; then
@@ -357,7 +379,7 @@ print(items[0]['id'] if items else '')
   fi
 fi
 
-"$ACPCTL" project "${PROJECT_NAME}" >/dev/null 2>&1 || true
+run_cmd $ACPCTL project "${PROJECT_NAME}"
 
 # ============================================================================
 # Section 3: Provider & credential setup
@@ -407,15 +429,23 @@ description: Vertex AI credential for LLM smoke test ${RUN_ID}
 EOF
 
   ensure_acpctl_token
-  SMOKE_VERTEX_SA_KEY="${VERTEX_SA_KEY}" \
-    "$ACPCTL" apply -f "${MANIFEST_DIR}/provider-vertex.yaml" --project "${PROJECT_NAME}" 2>/dev/null && \
-    pass "provider '${PROVIDER_NAME}' applied" || \
-    fail "provider '${PROVIDER_NAME}' apply failed"
+  export SMOKE_VERTEX_SA_KEY="${VERTEX_SA_KEY}"
 
-  SMOKE_VERTEX_SA_KEY="${VERTEX_SA_KEY}" \
-    "$ACPCTL" apply -f "${MANIFEST_DIR}/credential-vertex.yaml" --project "${PROJECT_NAME}" 2>/dev/null && \
-    pass "credential '${CREDENTIAL_NAME}' applied" || \
+  run_cmd $ACPCTL apply -f "${MANIFEST_DIR}/provider-vertex.yaml" --project "${PROJECT_NAME}"
+  if [ "$CMD_RC" -eq 0 ]; then
+    pass "provider '${PROVIDER_NAME}' applied"
+  else
+    fail "provider '${PROVIDER_NAME}' apply failed"
+  fi
+
+  run_cmd $ACPCTL apply -f "${MANIFEST_DIR}/credential-vertex.yaml" --project "${PROJECT_NAME}"
+  if [ "$CMD_RC" -eq 0 ]; then
+    pass "credential '${CREDENTIAL_NAME}' applied"
+  else
     fail "credential '${CREDENTIAL_NAME}' apply failed"
+  fi
+
+  unset SMOKE_VERTEX_SA_KEY
 
   rm -rf "${MANIFEST_DIR}"
   trap cleanup EXIT
@@ -430,7 +460,8 @@ EOF
   fi
 
   ensure_acpctl_token
-  CREDS_RESP=$("$ACPCTL" credential list -o json 2>/dev/null || echo "")
+  run_cmd $ACPCTL credential list -o json
+  CREDS_RESP="${CMD_OUTPUT:-}"
   FOUND_CREDENTIAL=$(echo "$CREDS_RESP" \
     | python3 -c "
 import sys, json
@@ -455,18 +486,18 @@ fi
 section "4. Create agent"
 
 ensure_acpctl_token
-AGENT_JSON=$(
-  "$ACPCTL" agent create \
-    --name "${AGENT_NAME}" \
-    --prompt "You are a concise test assistant. Answer questions directly and briefly." \
-    -o json 2>/dev/null || echo ""
-)
+run_cmd $ACPCTL agent create \
+  --name "${AGENT_NAME}" \
+  --prompt "You are a concise test assistant. Answer questions directly and briefly." \
+  -o json
+AGENT_JSON="${CMD_OUTPUT:-}"
 AGENT_ID=$(json_field "${AGENT_JSON}" "id")
 
 if [[ -n "${AGENT_ID}" && "${AGENT_ID}" != "" ]]; then
   pass "agent created: ${AGENT_NAME} (id: ${AGENT_ID})"
 else
-  EXISTING_AGENTS=$("$ACPCTL" get agents -o json 2>/dev/null || echo "")
+  run_cmd $ACPCTL get agents -o json
+  EXISTING_AGENTS="${CMD_OUTPUT:-}"
   AGENT_ID=$(echo "$EXISTING_AGENTS" \
     | python3 -c "
 import sys, json
@@ -492,13 +523,12 @@ fi
 section "5. Create session"
 
 ensure_acpctl_token
-SESSION_JSON=$(
-  "$ACPCTL" create session \
-    --name "llm-smoke-${RUN_ID}" \
-    --agent-id "${AGENT_ID}" \
-    --prompt "You are a concise test assistant. Answer questions directly and briefly." \
-    -o json 2>/dev/null || echo ""
-)
+run_cmd $ACPCTL create session \
+  --name "llm-smoke-${RUN_ID}" \
+  --agent-id "${AGENT_ID}" \
+  --prompt "You are a concise test assistant. Answer questions directly and briefly." \
+  -o json
+SESSION_JSON="${CMD_OUTPUT:-}"
 
 CREATED_SESSION_ID=$(json_field "${SESSION_JSON}" "id")
 if [[ -z "${CREATED_SESSION_ID}" || "${CREATED_SESSION_ID}" == "" ]]; then
@@ -617,7 +647,7 @@ except Exception:
 " 2>/dev/null || echo "0"
 )
 
-"$ACPCTL" session send "${CREATED_SESSION_ID}" "${USER_MESSAGE}" 2>/dev/null || true
+run_cmd $ACPCTL session send "${CREATED_SESSION_ID}" "${USER_MESSAGE}"
 
 RESPONSE_DEADLINE=$(( $(date +%s) + LLM_RESPONSE_TIMEOUT ))
 ASSISTANT_RESPONSE=""

--- a/tests/e2e/vteam-catalog-lab-test.sh
+++ b/tests/e2e/vteam-catalog-lab-test.sh
@@ -22,6 +22,21 @@ fail() { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
 skip() { echo -e "  ${YELLOW}⊘${NC} $1 (skipped${2:+: $2})"; }
 section() { echo ""; echo -e "${BOLD}$1${NC}"; }
 
+ORANGE='\033[38;5;214m'
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
 finish() {
   echo ""
   echo -e "${BOLD}Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}"
@@ -223,8 +238,12 @@ pass "jq is installed"
 command -v kubectl >/dev/null 2>&1 || die "kubectl is installed"
 pass "kubectl is installed"
 
-kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 || die "Kind namespace exists: $NAMESPACE"
-pass "Kind namespace exists: $NAMESPACE"
+run_cmd kubectl get namespace "$NAMESPACE"
+if [ "$CMD_RC" -eq 0 ]; then
+  pass "Kind namespace exists: $NAMESPACE"
+else
+  die "Kind namespace exists: $NAMESPACE"
+fi
 
 ACPCTL="$(find_acpctl)"
 if [ -n "$ACPCTL" ]; then
@@ -271,13 +290,15 @@ ensure_backend_port_forward "Kind backend port-forward is healthy before inspect
 
 run_doc_block "catalog-inspection" 'agent list --project vteam-product-swarm'
 
-if "$ACPCTL" get project "$PROJECT_ID" >/dev/null 2>&1; then
+run_cmd "$ACPCTL" get project "$PROJECT_ID"
+if [ "$CMD_RC" -eq 0 ]; then
   pass "Project exists: $PROJECT_ID"
 else
   fail "Project exists: $PROJECT_ID"
 fi
 
-AGENTS_JSON="$("$ACPCTL" agent list --project "$PROJECT_ID" -o json 2>&1 || true)"
+run_cmd "$ACPCTL" agent list --project "$PROJECT_ID" -o json
+AGENTS_JSON="${CMD_OUTPUT:-}"
 for agent in stella amber parker ryan steve terry; do
   if json_name_exists "$AGENTS_JSON" "$agent"; then
     pass "Agent exists: $agent"
@@ -286,7 +307,8 @@ for agent in stella amber parker ryan steve terry; do
   fi
 done
 
-PROVIDERS_JSON="$("$ACPCTL" provider list --project "$PROJECT_ID" -o json 2>&1 || true)"
+run_cmd "$ACPCTL" provider list --project "$PROJECT_ID" -o json
+PROVIDERS_JSON="${CMD_OUTPUT:-}"
 for provider in vertex github jira; do
   if json_name_exists "$PROVIDERS_JSON" "$provider"; then
     pass "Provider exists: $provider"


### PR DESCRIPTION
## Summary

- Adds the `run_cmd` helper function to all 9 e2e test scripts (`gateway-e2e-test.sh`, `rbac_e2e_test.sh`, `local-dev-test.sh`, `smoke-test-llm.sh`, `route-e2e-test.sh`, `hcmai-smoke.sh`, `openshell-dual-tenant.sh`, `vteam-catalog-lab-test.sh`, `scheduled_sessions_e2e_test.sh`) so that `kubectl`, `acpctl`, `openshell`, and `ssh` commands print the command being executed and their output during test runs
- Converts commands that previously suppressed output via `>/dev/null 2>&1` to use `run_cmd`, capturing results in `CMD_OUTPUT` and `CMD_RC` for assertions
- Updates the e2e test tooling spec (`specs/platform/e2e-test-tooling.spec.md`) with a new "Command Visibility with run_cmd" requirement, codifying the pattern as mandatory for all current and future e2e tests

## Test plan

- [ ] Run `bash -n` on all 9 test scripts to verify syntax (all pass)
- [ ] Run `gateway-e2e-test.sh` against a Kind cluster and verify commands are printed with `▶  $` formatting
- [ ] Verify test pass/fail results are unchanged (functional equivalence)
- [ ] Spot-check other test scripts for consistent `run_cmd` formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)