### PR TITLE
fix(cli): allow acpctl create project without existing project context

### DIFF
--- a/components/ambient-cli/cmd/acpctl/create/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/create/cmd.go
@@ -124,7 +124,14 @@ func init() {
 func run(cmd *cobra.Command, cmdArgs []string) error {
 	resource := strings.ToLower(cmdArgs[0])
 
-	client, err := connection.NewClientFromConfig()
+	var client *sdkclient.Client
+	var err error
+
+	if resource == "project" || resource == "proj" {
+		client, err = newProjectScopedClient()
+	} else {
+		client, err = connection.NewClientFromConfig()
+	}
 	if err != nil {
 		return err
 	}
@@ -157,6 +164,24 @@ func run(cmd *cobra.Command, cmdArgs []string) error {
 	default:
 		return fmt.Errorf("unknown resource type: %s\nValid types: session, project, project-agent, agent, role, role-binding, gateway, cluster", cmdArgs[0])
 	}
+}
+
+func newProjectScopedClient() (*sdkclient.Client, error) {
+	factory, err := connection.NewClientFactory()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	project := cfg.GetProject()
+	if project == "" {
+		project = "_"
+	}
+	return factory.ForProject(project)
 }
 
 func warnUnusedFlags(cmd *cobra.Command, names ...string) {


### PR DESCRIPTION
## Summary
- Fixes `acpctl create project` failing with "no project set" when no project context exists yet
- Adds `newProjectScopedClient()` helper that uses `NewClientFactory()` with a placeholder project, bypassing the chicken-and-egg problem where `NewClientFromConfig()` requires a project to be set before one can be created
- This was the remaining e2e-smoke test failure after the Keycloak secret reconciliation fix in #403

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass in `components/ambient-cli/`
- [ ] `/pr-test` passes all e2e-smoke steps including project creation (step 6)
- [ ] Manual: `acpctl create project --name test` works without prior `acpctl project set`

🤖 Generated with [Claude Code](https://claude.ai/code)