### PR TITLE
fix(gateway): restore fsGroup and runAsUser to fix CrashLoopBackOff in Kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1013,9 +1013,13 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 					"--from-literal=token=$$(cat '$(VERTEX_CRED)')" \
 					--dry-run=client -o yaml | kubectl apply -f - 2>/dev/null; \
 			fi; \
-			VERTEX_SA_KEY=$$(cat "$(VERTEX_CRED)" 2>/dev/null || echo "") \
-			$$ACPCTL apply -k "examples/overlays/$$ns/" --project "$$ns" && \
-			echo "  $$ns: applied"; \
+			if [ -d "examples/overlays/$$ns" ]; then \
+				VERTEX_SA_KEY=$$(cat "$(VERTEX_CRED)" 2>/dev/null || echo "") \
+				$$ACPCTL apply -k "examples/overlays/$$ns/" --project "$$ns" && \
+				echo "  $$ns: applied"; \
+			else \
+				echo "  $$ns: no overlay directory — skipping fleet"; \
+			fi; \
 		done; \
 		kill $$PF_PID 2>/dev/null || true; \
 	fi

--- a/components/ambient-control-plane/manifests/gateway/statefulset.yaml
+++ b/components/ambient-control-plane/manifests/gateway/statefulset.yaml
@@ -26,6 +26,8 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       serviceAccountName: openshell-gateway
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: openshell-gateway
           securityContext:
@@ -36,6 +38,7 @@ spec:
               drop:
               - ALL
             runAsNonRoot: true
+            runAsUser: 1000
             readOnlyRootFilesystem: true
           image: IMAGE_PLACEHOLDER
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- Restores `fsGroup: 1000` and `runAsUser: 1000` in the gateway StatefulSet template, which were removed in #404 for OpenShift SCC compatibility. The runtime function `applyOpenShiftOverrides()` already handles removing these fields on OpenShift — removing them from the template broke Kind deployments where PVC volumes are root-owned and the non-root container cannot write its SQLite database.
- Adds a directory existence check in the `kind-up` Makefile target before running `acpctl apply -k` on tenant overlays, matching the pattern already used by `crc-up`. Prevents errors for `vteam-product-swarm` and `codebase-maintainers` whose fleet definitions live under `examples/vteam-catalog/`, not `examples/overlays/`.

## Test plan

- [ ] `make kind-up` completes without kustomize errors for vteam tenants
- [ ] Gateway pods in tenant-a, tenant-b, tenant-c start without CrashLoopBackOff
- [ ] Gateway pod can write to `/var/openshell` (SQLite DB accessible)
- [ ] Verify `applyOpenShiftOverrides()` still removes `fsGroup`/`runAsUser` on OpenShift (existing unit test path)

🤖 Generated with [Claude Code](https://claude.ai/code)