### PR TITLE
fix(ci): add missing kubectl/kind version env vars to local-dev-simulation

### DIFF
--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -61,6 +61,10 @@ jobs:
       KUBECTL_VERSION: v1.31.4
       KIND_VERSION: v0.31.0
 
+    env:
+      KUBECTL_VERSION: v1.31.4
+      KIND_VERSION: v0.31.0
+
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

The `test-local-dev-simulation` job in `test-local-dev.yml` was failing because `KUBECTL_VERSION` and `KIND_VERSION` environment variables were never defined. The curl download URLs expanded to broken paths (e.g. `/release//bin/linux/amd64/kubectl`), causing GCS to return an XML error page that was saved as the kubectl binary.

This adds the missing `env:` block with `KUBECTL_VERSION: v1.31.4` and `KIND_VERSION: v0.31.0`, matching the values used in `vteam-catalog-lab-e2e.yml`.

## Test plan

- CI should pass the `test-local-dev-simulation` job without the kubectl syntax error
- Verify `kubectl version --client` and `kind version` succeed in the workflow logs