### PR TITLE
fix(security): close 3 RBAC and auth vulnerabilities (S1, S2, S7)

### DIFF
--- a/components/ambient-api-server/pkg/rbac/grpc_interceptor.go
+++ b/components/ambient-api-server/pkg/rbac/grpc_interceptor.go
@@ -42,11 +42,8 @@ func (m *DBAuthorizationMiddleware) populateGRPCContext(ctx context.Context) (co
 	if middleware.IsServiceCaller(ctx) {
 		username := auth.GetUsernameFromContext(ctx)
 		if username == "" {
-			glog.Warningf("legacy service token used — consider migrating to OIDC service account authentication")
-			return SetAuthResult(ctx, &AuthResult{
-				Username:      "service-token",
-				IsGlobalAdmin: true,
-			}), nil
+			glog.Warningf("gRPC service caller with empty username rejected — OIDC service account required")
+			return ctx, fmt.Errorf("service caller without OIDC username is not authorized")
 		}
 		m.autoProvisionServiceAccount(ctx, username)
 		enriched, err := m.PopulateAuthResult(ctx, username)

--- a/components/ambient-api-server/pkg/rbac/middleware.go
+++ b/components/ambient-api-server/pkg/rbac/middleware.go
@@ -67,12 +67,8 @@ func (m *DBAuthorizationMiddleware) AuthorizeApi(next http.Handler) http.Handler
 		if middleware.IsServiceCaller(ctx) {
 			username := auth.GetUsernameFromContext(ctx)
 			if username == "" {
-				glog.Warningf("legacy service token used — consider migrating to OIDC service account authentication")
-				ctx = SetAuthResult(ctx, &AuthResult{
-					Username:      "service-token",
-					IsGlobalAdmin: true,
-				})
-				next.ServeHTTP(w, r.WithContext(ctx))
+				glog.Warningf("service caller with empty username rejected — OIDC service account required")
+				http.Error(w, `{"kind":"Error","reason":"Unauthorized"}`, http.StatusUnauthorized)
 				return
 			}
 			m.autoProvisionServiceAccount(ctx, username)

--- a/components/ambient-api-server/pkg/rbac/middleware_test.go
+++ b/components/ambient-api-server/pkg/rbac/middleware_test.go
@@ -2,7 +2,10 @@ package rbac
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/ambient-code/platform/components/ambient-api-server/pkg/middleware"
 )
 
 func TestPathToResource(t *testing.T) {
@@ -80,7 +83,7 @@ func TestIsAuthExempt(t *testing.T) {
 		{http.MethodPost, "/api/ambient/v1/roles", false},
 		{http.MethodDelete, "/api/ambient/v1/roles/abc123", false},
 		{http.MethodGet, "/api/ambient/v1/roles/abc123/something", false},
-		{http.MethodPost, "/api/ambient/v1/role_bindings", true},
+		{http.MethodPost, "/api/ambient/v1/role_bindings", false},
 		{http.MethodPatch, "/api/ambient/v1/role_bindings/rb1", false},
 		{http.MethodDelete, "/api/ambient/v1/role_bindings/rb1", false},
 		{http.MethodGet, "/api/ambient/v1/role_bindings", false},
@@ -337,5 +340,32 @@ func TestSplitPath(t *testing.T) {
 				t.Errorf("splitPath(%q) len = %d, want %d; segments: %v", tt.path, len(got), tt.want, got)
 			}
 		})
+	}
+}
+
+func TestAuthorizeApi_RejectsEmptyUsernameServiceCaller(t *testing.T) {
+	mw := NewDBAuthorizationMiddleware(nil, true)
+
+	reached := false
+	handler := mw.AuthorizeApi(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		result := GetAuthResult(r.Context())
+		if result != nil && result.IsGlobalAdmin {
+			t.Error("empty-username service caller must not receive IsGlobalAdmin=true")
+		}
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/ambient/v1/sessions", nil)
+	ctx := middleware.WithCallerType(req.Context(), middleware.CallerTypeService)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if reached {
+		t.Error("next handler should not have been called for empty-username service caller")
 	}
 }

--- a/components/ambient-api-server/pkg/rbac/scope.go
+++ b/components/ambient-api-server/pkg/rbac/scope.go
@@ -115,8 +115,6 @@ func isAuthExempt(method, path string) bool {
 		return true
 	case method == http.MethodPost && normalized == "/api/ambient/v1/credentials":
 		return true
-	case method == http.MethodPost && normalized == "/api/ambient/v1/role_bindings":
-		return true
 	case method == http.MethodGet && normalized == "/api/ambient/v1/roles":
 		return true
 	case method == http.MethodGet && strings.HasPrefix(normalized, "/api/ambient/v1/roles/"):

--- a/components/ambient-control-plane/internal/tokenserver/sandbox_handler.go
+++ b/components/ambient-control-plane/internal/tokenserver/sandbox_handler.go
@@ -2,6 +2,7 @@ package tokenserver
 
 import (
 	"context"
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,13 +22,39 @@ type SandboxGateway interface {
 }
 
 type sandboxHandler struct {
-	gateway SandboxGateway
-	logger  zerolog.Logger
+	gateway    SandboxGateway
+	logger     zerolog.Logger
+	privateKey *rsa.PrivateKey
+}
+
+func (h *sandboxHandler) requireAuth(w http.ResponseWriter, r *http.Request) bool {
+	ciphertext, err := extractBearerToken(r)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	if h.privateKey != nil {
+		handler := &handler{privateKey: h.privateKey}
+		sessionID, decErr := handler.decryptSessionID(ciphertext)
+		if decErr != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return false
+		}
+		if !isValidSessionID(sessionID) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return false
+		}
+	}
+	return true
 }
 
 func (h *sandboxHandler) handlePolicy(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if !h.requireAuth(w, r) {
 		return
 	}
 
@@ -78,6 +105,10 @@ func (h *sandboxHandler) handlePolicy(w http.ResponseWriter, r *http.Request) {
 func (h *sandboxHandler) handleLogs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if !h.requireAuth(w, r) {
 		return
 	}
 

--- a/components/ambient-control-plane/internal/tokenserver/sandbox_handler_test.go
+++ b/components/ambient-control-plane/internal/tokenserver/sandbox_handler_test.go
@@ -52,6 +52,11 @@ func newTestSandboxHandler(gw SandboxGateway) *sandboxHandler {
 	}
 }
 
+func withTestAuth(r *http.Request) *http.Request {
+	r.Header.Set("Authorization", "Bearer test-sandbox-token")
+	return r
+}
+
 func makeSandboxResponse(id, name string) *pb.SandboxResponse {
 	return &pb.SandboxResponse{
 		Sandbox: &pb.Sandbox{
@@ -88,7 +93,7 @@ func TestHandleLogs_ResolvesNameToUUID(t *testing.T) {
 	}
 
 	h := newTestSandboxHandler(gw)
-	req := httptest.NewRequest(http.MethodGet, "/sandbox/"+sandboxName+"/logs?namespace=tenant-a", nil)
+	req := withTestAuth(httptest.NewRequest(http.MethodGet, "/sandbox/"+sandboxName+"/logs?namespace=tenant-a", nil))
 	rr := httptest.NewRecorder()
 
 	h.handleLogs(rr, req)
@@ -138,7 +143,7 @@ func TestHandleLogs_SSEFormat(t *testing.T) {
 	}
 
 	h := newTestSandboxHandler(gw)
-	req := httptest.NewRequest(http.MethodGet, "/sandbox/session-test/logs?namespace=ns", nil)
+	req := withTestAuth(httptest.NewRequest(http.MethodGet, "/sandbox/session-test/logs?namespace=ns", nil))
 	rr := httptest.NewRecorder()
 
 	h.handleLogs(rr, req)
@@ -196,7 +201,7 @@ func TestHandleLogs_GetSandboxNotFound(t *testing.T) {
 	}
 
 	h := newTestSandboxHandler(gw)
-	req := httptest.NewRequest(http.MethodGet, "/sandbox/nonexistent/logs?namespace=ns", nil)
+	req := withTestAuth(httptest.NewRequest(http.MethodGet, "/sandbox/nonexistent/logs?namespace=ns", nil))
 	rr := httptest.NewRecorder()
 
 	h.handleLogs(rr, req)
@@ -218,7 +223,7 @@ func TestHandleLogs_GetSandboxError(t *testing.T) {
 	}
 
 	h := newTestSandboxHandler(gw)
-	req := httptest.NewRequest(http.MethodGet, "/sandbox/session-x/logs?namespace=ns", nil)
+	req := withTestAuth(httptest.NewRequest(http.MethodGet, "/sandbox/session-x/logs?namespace=ns", nil))
 	rr := httptest.NewRecorder()
 
 	h.handleLogs(rr, req)
@@ -230,7 +235,7 @@ func TestHandleLogs_GetSandboxError(t *testing.T) {
 
 func TestHandleLogs_MissingNamespace(t *testing.T) {
 	h := newTestSandboxHandler(&mockSandboxGateway{})
-	req := httptest.NewRequest(http.MethodGet, "/sandbox/session-x/logs", nil)
+	req := withTestAuth(httptest.NewRequest(http.MethodGet, "/sandbox/session-x/logs", nil))
 	rr := httptest.NewRecorder()
 
 	h.handleLogs(rr, req)
@@ -260,7 +265,7 @@ func TestHandlePolicy_Success(t *testing.T) {
 	}
 
 	h := newTestSandboxHandler(gw)
-	req := httptest.NewRequest(http.MethodGet, "/sandbox/session-pol/policy?namespace=ns", nil)
+	req := withTestAuth(httptest.NewRequest(http.MethodGet, "/sandbox/session-pol/policy?namespace=ns", nil))
 	rr := httptest.NewRecorder()
 
 	h.handlePolicy(rr, req)
@@ -282,6 +287,44 @@ func TestHandlePolicy_Success(t *testing.T) {
 
 	if result["status"] != "active" {
 		t.Errorf("status: got %q, want %q", result["status"], "active")
+	}
+}
+
+func TestSandboxPolicy_RejectsUnauthenticated(t *testing.T) {
+	gw := &mockSandboxGateway{
+		getSandboxFn: func(context.Context, string, string) (*pb.SandboxResponse, error) {
+			t.Fatal("gateway should not be called without auth")
+			return nil, nil
+		},
+	}
+
+	h := newTestSandboxHandler(gw)
+	req := httptest.NewRequest(http.MethodGet, "/sandbox/session-x/policy?namespace=ns", nil)
+	rr := httptest.NewRecorder()
+
+	h.handlePolicy(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestSandboxLogs_RejectsUnauthenticated(t *testing.T) {
+	gw := &mockSandboxGateway{
+		getSandboxFn: func(context.Context, string, string) (*pb.SandboxResponse, error) {
+			t.Fatal("gateway should not be called without auth")
+			return nil, nil
+		},
+	}
+
+	h := newTestSandboxHandler(gw)
+	req := httptest.NewRequest(http.MethodGet, "/sandbox/session-x/logs?namespace=ns", nil)
+	rr := httptest.NewRecorder()
+
+	h.handleLogs(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusUnauthorized)
 	}
 }
 

--- a/components/ambient-control-plane/internal/tokenserver/server.go
+++ b/components/ambient-control-plane/internal/tokenserver/server.go
@@ -63,8 +63,9 @@ func New(
 
 	if cfg.gateway != nil {
 		sbx := &sandboxHandler{
-			gateway: cfg.gateway,
-			logger:  componentLogger,
+			gateway:    cfg.gateway,
+			logger:     componentLogger,
+			privateKey: privateKey,
 		}
 		mux.HandleFunc("/sandbox/", func(w http.ResponseWriter, r *http.Request) {
 			switch {

--- a/components/manifests/base/bootstrap-admin-job.yaml
+++ b/components/manifests/base/bootstrap-admin-job.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bootstrap-admin
+  labels:
+    app: ambient-api-server
+    component: bootstrap
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: ambient-api-server
+        component: bootstrap
+    spec:
+      serviceAccountName: ambient-api-server
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: seed-admin
+          image: quay.io/ambient_code/acp_api_server:latest
+          imagePullPolicy: Always
+          command:
+            - /usr/local/bin/ambient-api-server
+            - seed-admin
+            - --username=$(BOOTSTRAP_ADMIN_USERNAME)
+            - --db-host-file=/secrets/db/db.host
+            - --db-port-file=/secrets/db/db.port
+            - --db-user-file=/secrets/db/db.user
+            - --db-password-file=/secrets/db/db.password
+            - --db-name-file=/secrets/db/db.name
+            - --alsologtostderr
+            - -v=4
+          env:
+            - name: BOOTSTRAP_ADMIN_USERNAME
+              value: admin
+          volumeMounts:
+            - name: db-secrets
+              mountPath: /secrets/db
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      volumes:
+        - name: db-secrets
+          secret:
+            secretName: ambient-api-server-db

--- a/components/manifests/base/kustomization.yaml
+++ b/components/manifests/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - ambient-control-plane-service.yml
 - ambient-control-plane-token-svc.yaml
 - runner-networkpolicy.yaml
+- bootstrap-admin-job.yaml
 
 # Default images (can be overridden by overlays)
 images:


### PR DESCRIPTION
## Summary

Fixes three critical/high security findings from #431:

- **S1 — RBAC bypass on POST /role_bindings**: Removed `POST /role_bindings` from `isAuthExempt()`, which allowed any authenticated user to create arbitrary role bindings without RBAC evaluation. Added a `bootstrap-admin` Kubernetes Job (using the existing `seed-admin` CLI command) so the first admin can be provisioned at install time without the exemption.

- **S2 — Unauthenticated sandbox endpoints**: Added bearer token auth to `/sandbox/{name}/policy` and `/sandbox/{name}/logs` on the control plane token server. These endpoints were previously completely unauthenticated, exposing sandbox state to any network caller.

- **S7 — Empty JWT sub grants GlobalAdmin**: Replaced the legacy service token fallback in both HTTP (`AuthorizeApi`) and gRPC (`populateGRPCContext`) RBAC middleware. Previously, a service caller with an empty username was granted `IsGlobalAdmin: true` with a hardcoded `"service-token"` identity — now it returns 401/Unavailable.

## Test plan

All three fixes follow test-first methodology:

- [x] `TestIsAuthExempt` — updated to expect `POST /role_bindings` is NOT exempt; verified test fails before fix, passes after
- [x] `TestSandboxPolicy_RejectsUnauthenticated` — new test verifying 401 without bearer token
- [x] `TestSandboxLogs_RejectsUnauthenticated` — new test verifying 401 without bearer token
- [x] `TestAuthorizeApi_RejectsEmptyUsernameServiceCaller` — new test verifying empty-username service caller gets 401 instead of GlobalAdmin
- [x] All existing sandbox handler tests updated with auth headers — all 18 tokenserver tests pass
- [x] All 14 rbac unit tests pass
- [x] `go vet` clean on both components
- [x] `gofmt` clean on both components
- [x] Kustomize builds verified for base, kind, e2e overlays

🤖 Generated with [Claude Code](https://claude.ai/code)