### PR TITLE
fix(security): relax bootstrap-admin Job securityContext for Kind

### DIFF
--- a/components/manifests/base/bootstrap-admin-job.yaml
+++ b/components/manifests/base/bootstrap-admin-job.yaml
@@ -21,7 +21,6 @@ spec:
       serviceAccountName: ambient-api-server
       restartPolicy: OnFailure
       securityContext:
-        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -48,7 +47,7 @@ spec:
               readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## Summary

- Remove `runAsNonRoot: true` from bootstrap-admin Job pod securityContext — the API server image (`ubi9/ubi-minimal`) has no `USER` directive and runs as root
- Change `readOnlyRootFilesystem` from `true` to `false` to match the existing migration init container pattern

Fixes the `test-local-dev-simulation` CI failure from PR #432 where the Job pod failed with `container has runAsNonRoot and image will run as root`.

## Test plan

- [x] Kustomize build validates for base, kind, and e2e overlays
- [ ] `test-local-dev-simulation` CI passes

Closes #431

🤖 Generated with [Claude Code](https://claude.ai/code)