### PR TITLE
fix(rbac): register applications resource in RBAC middleware

### DIFF
--- a/components/ambient-api-server/pkg/rbac/permissions.go
+++ b/components/ambient-api-server/pkg/rbac/permissions.go
@@ -17,6 +17,7 @@ const (
 	ResourceProvider        Resource = "provider"
 	ResourceGateway         Resource = "gateway"
 	ResourceCluster         Resource = "cluster"
+	ResourceApplication     Resource = "application"
 )
 
 type Action string
@@ -132,4 +133,10 @@ var (
 	PermClusterUpdate = Permission{ResourceCluster, ActionUpdate}
 	PermClusterDelete = Permission{ResourceCluster, ActionDelete}
 	PermClusterList   = Permission{ResourceCluster, ActionList}
+
+	PermApplicationCreate = Permission{ResourceApplication, ActionCreate}
+	PermApplicationRead   = Permission{ResourceApplication, ActionRead}
+	PermApplicationUpdate = Permission{ResourceApplication, ActionUpdate}
+	PermApplicationDelete = Permission{ResourceApplication, ActionDelete}
+	PermApplicationList   = Permission{ResourceApplication, ActionList}
 )

--- a/components/ambient-api-server/pkg/rbac/scope.go
+++ b/components/ambient-api-server/pkg/rbac/scope.go
@@ -137,7 +137,7 @@ func isListEndpoint(method, path string) bool {
 	switch last {
 	case "projects", "agents", "sessions", "credentials", "roles", "role_bindings",
 		"users", "inbox", "session_messages", "scheduled-sessions", "messages",
-		"providers", "gateways", "clusters", "policies":
+		"providers", "gateways", "clusters", "policies", "applications":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

The application-reconciler was logging 404 errors when listing applications:

```
{"level":"error","component":"application-reconciler","error":"list applications page 1: ambient API error 404: http_error — HTTP 404: unexpected status","message":"failed to list applications"}
```

**Root cause:** The applications plugin (PRs #247/#253) registered routes and a reconciler but never updated the RBAC middleware. `isListEndpoint()` in `pkg/rbac/scope.go` has a hardcoded allowlist of recognized list endpoints, and `"applications"` was missing. This caused the middleware to misclassify `GET /api/ambient/v1/applications` as a singleton GET request, which returns HTTP 404 when authorization hasn't resolved — making it appear as if the route didn't exist.

**Changes:**
- **`pkg/rbac/scope.go`** — Add `"applications"` to the `isListEndpoint()` switch case
- **`pkg/rbac/permissions.go`** — Add `ResourceApplication` constant and CRUD+List permission variables for fine-grained application RBAC

## Test plan

- [ ] Verify `go vet ./pkg/rbac/...` passes (confirmed locally)
- [ ] Deploy to dev cluster and confirm the `application-reconciler` no longer logs 404 errors
- [ ] Verify application list endpoint returns 200 for authenticated control plane service account
- [ ] Verify RBAC enforcement still blocks unauthorized users from listing applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)