### PR TITLE
fix(kind): deterministic OpenShell gateway port allocation

### DIFF
--- a/.github/component-paths.json
+++ b/.github/component-paths.json
@@ -44,7 +44,12 @@
     "label": "docs"
   },
   "scripts": {
-    "paths": [".github/scripts/**", "tests/test_model_discovery.py"],
+    "paths": [
+      ".github/scripts/**",
+      "scripts/**",
+      "Makefile",
+      "tests/unit/**"
+    ],
     "label": "scripts"
   }
 }

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -197,6 +197,9 @@ jobs:
       - name: Run tests
         run: python tests/unit/test_model_discovery.py -v
 
+      - name: Run gateway-ports unit tests
+        run: bash tests/unit/test_gateway_ports.sh
+
   summary:
     name: Unit Tests CI Gate
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,5 +198,6 @@ When both the self-review and the hook pass, apply the `ambient-code:self-review
 ## Testing
 
 - **Runner tests**: `cd components/runners/ambient-runner && python -m pytest tests/`
+- **Gateway port mapping**: `bash tests/unit/test_gateway_ports.sh`
 
 ## Convention Authority

--- a/Makefile
+++ b/Makefile
@@ -1176,16 +1176,19 @@ _kind-start-port-forward:
 	@kubectl port-forward -n $(NAMESPACE) svc/ambient-api-server $(KIND_FWD_BACKEND_PORT):8000 >$(KIND_PF_DIR)/kind-pf-backend.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-backend.pid
 	@kubectl port-forward -n $(NAMESPACE) svc/ambient-ui-service $(KIND_FWD_AMBIENT_UI_PORT):3000 >$(KIND_PF_DIR)/kind-pf-ambient-ui.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-ambient-ui.pid
 	@kubectl port-forward -n $(NAMESPACE) svc/keycloak-service $(KIND_FWD_KEYCLOAK_PORT):11880 >$(KIND_PF_DIR)/kind-pf-keycloak.log 2>&1 & echo $$! > $(KIND_PF_DIR)/kind-pf-keycloak.pid
-	@# Discover and port-forward openshell gateways on deterministic ports
-	@GW_NAMESPACES=$$(kubectl get pods --all-namespaces -l app.kubernetes.io/instance=openshell-gateway -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' 2>/dev/null | sort -u); \
-	OFFSET=0; \
-	for NS in $$GW_NAMESPACES; do \
-		PORT=$$(($(KIND_FWD_GATEWAY_BASE_PORT) + $$OFFSET)); \
+	@# Port-forward openshell gateways on deterministic, per-tenant ports.
+	@# Iterate the canonical tenant list (not "whatever pods exist right now")
+	@# so a tenant is never skipped or shifted onto another tenant's port.
+	@# Wait for each gateway StatefulSet to be Ready first to avoid racing pod startup.
+	@for NS in $(OPENSHELL_TENANTS); do \
+		kubectl get statefulset openshell-gateway -n "$$NS" >/dev/null 2>&1 || continue; \
+		PORT=$$(OPENSHELL_TENANTS="$(OPENSHELL_TENANTS)" KIND_FWD_GATEWAY_BASE_PORT=$(KIND_FWD_GATEWAY_BASE_PORT) ./scripts/lib/gateway-ports.sh port-for "$$NS"); \
+		kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=openshell-gateway -n "$$NS" --timeout=90s >/dev/null 2>&1 || \
+			echo "$(COLOR_YELLOW)⚠$(COLOR_RESET) openshell-gateway ($$NS) not ready after 90s; forwarding anyway"; \
 		kubectl port-forward -n "$$NS" statefulset/openshell-gateway $$PORT:8080 \
 			>"$(KIND_PF_DIR)/kind-pf-openshell-$$NS.log" 2>&1 & \
 		echo $$! > "$(KIND_PF_DIR)/kind-pf-openshell-$$NS.pid"; \
 		echo "$$PORT" > "$(KIND_PF_DIR)/kind-pf-openshell-$$NS.port"; \
-		OFFSET=$$(($$OFFSET + 1)); \
 	done
 	@sleep 1
 	@FAILED=0; \

--- a/Makefile
+++ b/Makefile
@@ -1493,12 +1493,11 @@ kind-status: check-kind ## Show all kind clusters and their port assignments
 	@if [ -n "$(KIND_HOST)" ]; then echo "  Host:     $(KIND_HOST) (remote)"; else echo "  Host:     localhost"; fi
 	@echo "  NodePort: $(KIND_HTTP_PORT) (HTTP) / $(KIND_HTTPS_PORT) (HTTPS)"
 	@echo "  Forward:  $(KIND_FWD_FRONTEND_PORT) (frontend) / $(KIND_FWD_BACKEND_PORT) (backend) / $(KIND_FWD_KEYCLOAK_PORT) (keycloak)"
-	@GW_LINE=""; OFFSET=0; \
+	@GW_LINE=""; \
 	for NS in $(OPENSHELL_TENANTS); do \
-		PORT=$$(($(KIND_FWD_GATEWAY_BASE_PORT) + $$OFFSET)); \
+		PORT=$$(OPENSHELL_TENANTS="$(OPENSHELL_TENANTS)" KIND_FWD_GATEWAY_BASE_PORT=$(KIND_FWD_GATEWAY_BASE_PORT) ./scripts/lib/gateway-ports.sh port-for "$$NS"); \
 		if [ -n "$$GW_LINE" ]; then GW_LINE="$$GW_LINE / "; fi; \
 		GW_LINE="$$GW_LINE$$PORT ($$NS)"; \
-		OFFSET=$$(($$OFFSET + 1)); \
 	done; \
 	if [ -n "$$GW_LINE" ]; then echo "  Gateways: $$GW_LINE"; fi
 	@echo ""

--- a/scripts/lib/gateway-ports.sh
+++ b/scripts/lib/gateway-ports.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# gateway-ports.sh — Single source of truth for the OpenShell gateway
+# tenant->local-port mapping used by kind port-forwarding, kind-status, and
+# setup-gateway-cli.sh.
+#
+# Formula: port(ns) = BASE + zero-based index of ns in OPENSHELL_TENANTS.
+#
+# Environment:
+#   OPENSHELL_TENANTS           space-separated tenant list
+#                               (default: tenant-a tenant-b tenant-c
+#                                vteam-product-swarm codebase-maintainers)
+#   KIND_FWD_GATEWAY_BASE_PORT  base port (preferred; default via GATEWAY_BASE_PORT/15080)
+#   GATEWAY_BASE_PORT           base port fallback (default: 15080)
+#
+# Sourceable:   gateway_port_for <ns>   -> echoes port, returns 0/1
+# Executable:   gateway-ports.sh port-for <ns>
+#               gateway-ports.sh list
+
+_gw_tenants() {
+  echo "${OPENSHELL_TENANTS:-tenant-a tenant-b tenant-c vteam-product-swarm codebase-maintainers}"
+}
+
+_gw_base_port() {
+  echo "${KIND_FWD_GATEWAY_BASE_PORT:-${GATEWAY_BASE_PORT:-15080}}"
+}
+
+# gateway_port_for <ns>: echo BASE+index; return 1 if ns not in the tenant list.
+gateway_port_for() {
+  local target="$1" base idx=0 ns
+  base="$(_gw_base_port)"
+  for ns in $(_gw_tenants); do
+    if [ "$ns" = "$target" ]; then
+      echo "$((base + idx))"
+      return 0
+    fi
+    idx=$((idx + 1))
+  done
+  echo "gateway-ports: unknown tenant '$target' (not in OPENSHELL_TENANTS)" >&2
+  return 1
+}
+
+# gateway_list: echo "<ns> <port>" for every tenant.
+gateway_list() {
+  local ns
+  for ns in $(_gw_tenants); do
+    echo "$ns $(gateway_port_for "$ns")"
+  done
+}
+
+# CLI dispatch only when executed directly (not sourced).
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  case "${1:-}" in
+    port-for) shift; gateway_port_for "${1:?usage: gateway-ports.sh port-for <ns>}" ;;
+    list)     gateway_list ;;
+    *) echo "usage: gateway-ports.sh {port-for <ns>|list}" >&2; exit 2 ;;
+  esac
+fi

--- a/scripts/setup-gateway-cli.sh
+++ b/scripts/setup-gateway-cli.sh
@@ -33,6 +33,10 @@ NAMESPACES=("${@:-tenant-a}")
 CERT_BASE="$HOME/.config/openshell/gateways"
 PF_DIR="${PF_DIR:-/tmp/ambient-code}"
 GATEWAY_BASE_PORT="${GATEWAY_BASE_PORT:-15080}"
+# Shared tenant->port mapping (keeps ports consistent with Makefile/kind-status).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/gateway-ports.sh
+. "$SCRIPT_DIR/lib/gateway-ports.sh"
 GW_PORTS=()
 NS_INDEX=0
 
@@ -70,8 +74,11 @@ for NS in "${NAMESPACES[@]}"; do
     rm -f "$PID_FILE" "$LOG_FILE"
   fi
 
-  # Assign a fixed local port: base + namespace index
-  PORT=$(( GATEWAY_BASE_PORT + NS_INDEX ))
+  # Canonical per-tenant port from the shared library; fall back to positional
+  # assignment for namespaces outside OPENSHELL_TENANTS (custom tenants).
+  if ! PORT=$(GATEWAY_BASE_PORT="$GATEWAY_BASE_PORT" gateway_port_for "$NS" 2>/dev/null); then
+    PORT=$(( GATEWAY_BASE_PORT + NS_INDEX ))
+  fi
   NS_INDEX=$(( NS_INDEX + 1 ))
 
   kubectl port-forward -n "$NS" statefulset/openshell-gateway "$PORT:8080" \

--- a/tests/unit/test_gateway_ports.sh
+++ b/tests/unit/test_gateway_ports.sh
@@ -19,12 +19,18 @@ fail() { echo -e "  ${RED}\xE2\x9C\x97${NC} $1"; FAILED=$((FAILED + 1)); }
 # assert_port <expected> <ns> [env assignments...]
 assert_port() {
   local expected="$1" ns="$2"; shift 2
-  local got
-  got=$(env "$@" bash "$LIB" port-for "$ns" 2>/dev/null)
-  if [ "$got" = "$expected" ]; then
+  local got stderr_file
+  stderr_file=$(mktemp)
+  got=$(env "$@" bash "$LIB" port-for "$ns" 2>"$stderr_file")
+  local stderr_content
+  stderr_content=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  if [ "$got" = "$expected" ] && [ -z "$stderr_content" ]; then
     pass "port-for $ns ($*) = $expected"
-  else
+  elif [ "$got" != "$expected" ]; then
     fail "port-for $ns ($*): expected '$expected', got '$got'"
+  else
+    fail "port-for $ns ($*): unexpected stderr: $stderr_content"
   fi
 }
 

--- a/tests/unit/test_gateway_ports.sh
+++ b/tests/unit/test_gateway_ports.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Unit tests for scripts/lib/gateway-ports.sh — deterministic tenant→port mapping.
+# Pure bash, no cluster required.
+#
+# Usage: bash tests/unit/test_gateway_ports.sh
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../../scripts/lib/gateway-ports.sh"
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; NC='\033[0m'
+PASSED=0; FAILED=0
+
+pass() { echo -e "  ${GREEN}\xE2\x9C\x93${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}\xE2\x9C\x97${NC} $1"; FAILED=$((FAILED + 1)); }
+
+# assert_port <expected> <ns> [env assignments...]
+assert_port() {
+  local expected="$1" ns="$2"; shift 2
+  local got
+  got=$(env "$@" bash "$LIB" port-for "$ns" 2>/dev/null)
+  if [ "$got" = "$expected" ]; then
+    pass "port-for $ns ($*) = $expected"
+  else
+    fail "port-for $ns ($*): expected '$expected', got '$got'"
+  fi
+}
+
+# assert_fails <ns> [env assignments...]
+assert_fails() {
+  local ns="$1"; shift
+  if env "$@" bash "$LIB" port-for "$ns" >/dev/null 2>&1; then
+    fail "port-for $ns ($*): expected non-zero exit, got success"
+  else
+    pass "port-for $ns ($*) fails as expected"
+  fi
+}
+
+echo "gateway-ports.sh unit tests"
+
+# Default list + default base
+assert_port 15080 tenant-a
+assert_port 15081 tenant-b
+assert_port 15082 tenant-c
+assert_port 15083 vteam-product-swarm
+assert_port 15084 codebase-maintainers
+
+# Base override via KIND_FWD_GATEWAY_BASE_PORT
+assert_port 20000 tenant-a KIND_FWD_GATEWAY_BASE_PORT=20000
+assert_port 20002 tenant-c KIND_FWD_GATEWAY_BASE_PORT=20000
+
+# Base override via GATEWAY_BASE_PORT (setup-gateway-cli.sh compatibility)
+assert_port 16081 tenant-b GATEWAY_BASE_PORT=16080
+
+# KIND_FWD_GATEWAY_BASE_PORT takes precedence over GATEWAY_BASE_PORT
+assert_port 20000 tenant-a KIND_FWD_GATEWAY_BASE_PORT=20000 GATEWAY_BASE_PORT=16080
+
+# Custom tenant list
+assert_port 15080 foo OPENSHELL_TENANTS="foo bar"
+assert_port 15081 bar OPENSHELL_TENANTS="foo bar"
+
+# Unknown tenant → failure, no port on stdout
+assert_fails not-a-tenant
+assert_fails tenant-a OPENSHELL_TENANTS="foo bar"
+
+echo ""
+echo "Passed: $PASSED  Failed: $FAILED"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Problem

OpenShell gateway local port-forwards were allocated non-deterministically, and three code paths disagreed on the tenant→port mapping:

- `kind-status` and `setup-gateway-cli.sh` used a **fixed** index (`tenant-a`=15080, `tenant-b`=15081, …).
- `_kind-start-port-forward` used a **positional** offset over *whichever gateway pods happened to exist* at that instant, sorted.

The SSO step (`Makefile:1037-1039`) restarts port-forwards as soon as **ambient-ui** is ready — it never waited for the gateway StatefulSets. So if a tenant's gateway pod wasn't up yet, that tenant was skipped and the others shifted down onto its port. Result: `tenant-b` squatted on 15080 (tenant-a's canonical port), and `setup-gateway-cli.sh tenant-a` then failed with **"port in use"**.

This was surfaced by a user's kind debug bundle: `tenant-b`/`tenant-c` port-forwards existed on 15080/15081, no `tenant-a`, and `setup-gateway-cli.sh tenant-a` errored on 15080.

## Fix

Single source of truth for the mapping, `port(ns) = BASE + index(ns in OPENSHELL_TENANTS)`, used by all consumers:

- **New `scripts/lib/gateway-ports.sh`** — sourceable (`gateway_port_for`) and executable (`port-for <ns>` / `list`). Honors `KIND_FWD_GATEWAY_BASE_PORT` → `GATEWAY_BASE_PORT` → `15080`.
- **`_kind-start-port-forward`** now iterates the canonical `OPENSHELL_TENANTS` list, skips tenants without an `openshell-gateway` StatefulSet, and `kubectl wait --for=condition=Ready`s the gateway pods (90s, non-fatal) **before** forwarding on the fixed port. No more skip-and-shift, no more race.
- **`kind-status`** derives its "Gateways:" line from the library (byte-identical output).
- **`setup-gateway-cli.sh`** uses the library for the canonical port, with a positional fallback for namespaces outside `OPENSHELL_TENANTS`.

Net effect: `tenant-a` is always 15080 everywhere; ports never shift; the "port in use" collision can't recur.

## Tests

- **New `tests/unit/test_gateway_ports.sh`** — pure-bash, 13 assertions (all default mappings, base-port precedence, custom tenant lists, unknown-tenant failure, stderr hygiene). No cluster required.
- **CI**: `.github/component-paths.json` now gates `scripts/**`, `Makefile`, and `tests/unit/**` (and drops a stale `tests/test_model_discovery.py` glob → the real file is `tests/unit/test_model_discovery.py`); `unit-tests.yml`'s `scripts` job runs the new test.

## Verification

- `bash tests/unit/test_gateway_ports.sh` → 13/13 pass.
- `./scripts/lib/gateway-ports.sh list` and `make kind-status` agree: `tenant-a`=15080 … `codebase-maintainers`=15084.
- `make -n kind-port-forward` / `make -n kind-status` parse cleanly.
- Whole-branch review (independent, most-capable model): **APPROVE — 0 Critical, 0 Important.**
- CodeRabbit local review was **rate-limited** (free-plan window); the `pr-review-gate` hook treats rate-limit as non-blocking. Re-run recommended once the window resets or via CI.

## Optional follow-ups (non-blocking Minors)

- `unit-tests.yml` `scripts` job label still reads "model-discovery" — cosmetic.
- Unit test exercises the executable `port-for` path; a sourced-function assertion would close a small gap.
- Redundant `GATEWAY_BASE_PORT=…` env prefix in `setup-gateway-cli.sh` (function already reads it).

🤖 Authored and reviewed via agent workflow (subagent-driven development + independent whole-branch review). No Go files touched.
