### PR TITLE
test(e2e): add README technical-content e2e test + CI

### DIFF
--- a/.github/workflows/readme-e2e.yml
+++ b/.github/workflows/readme-e2e.yml
@@ -1,0 +1,130 @@
+name: README E2E
+
+# Verifies the technical content of README.md so any user copy/pasting through
+# it succeeds. Two jobs:
+#   static  - every PR touching the README or referenced surfaces. No cluster;
+#             validates links, referenced files, badge workflows, make targets,
+#             and acpctl subcommands.
+#   live    - manual / scheduled. Brings up a Kind ACP environment via the
+#             documented path, then runs the README's live command flow against
+#             it. The script itself is environment-agnostic; this job just
+#             supplies an environment.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'Makefile'
+      - 'components/ambient-cli/**'
+      - 'tests/e2e/readme-e2e-test.sh'
+      - '.github/workflows/readme-e2e.yml'
+  workflow_dispatch:
+    inputs:
+      run_sandbox:
+        description: 'Exercise openshell sandbox create/list'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Weekly rot check against a fresh environment (Mondays 07:17 UTC).
+    - cron: '17 7 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: readme-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static:
+    # Static gate needs no cluster; live sections auto-skip when unreachable.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run README static gate
+        run: ./tests/e2e/readme-e2e-test.sh
+
+  live:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      KUBECTL_VERSION: v1.31.4
+      KIND_VERSION: v0.31.0
+      RUN_SANDBOX: ${{ inputs.run_sandbox || 'false' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Cleanup diskspace
+        if: (!cancelled())
+        run: |
+          docker system prune -f
+          df -h
+
+      - name: Cache kubectl and kind
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.1.2
+        with:
+          path: |
+            ~/k8s-tools/kubectl
+            ~/k8s-tools/kind
+          key: k8s-tools-${{ runner.os }}-kubectl-${{ env.KUBECTL_VERSION }}-kind-${{ env.KIND_VERSION }}
+
+      - name: Install kind and kubectl
+        run: |
+          mkdir -p ~/k8s-tools
+
+          if [[ ! -f ~/k8s-tools/kubectl ]]; then
+            curl -sLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            mv kubectl ~/k8s-tools/
+          fi
+          sudo cp ~/k8s-tools/kubectl /usr/local/bin/kubectl
+
+          if [[ ! -f ~/k8s-tools/kind ]]; then
+            curl -sLO "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+            chmod +x kind-linux-amd64
+            mv kind-linux-amd64 ~/k8s-tools/kind
+          fi
+          sudo cp ~/k8s-tools/kind /usr/local/bin/kind
+
+          kubectl version --client
+          kind version
+
+      - name: Add Keycloak host entry for OIDC gateway auth
+        run: echo "127.0.0.1 keycloak-service.ambient-code.svc.cluster.local" | sudo tee -a /etc/hosts
+
+      - name: Bring up ACP environment
+        run: |
+          make kind-up CONTAINER_ENGINE=docker CI_MODE=true OPENSHELL_USE_GATEWAY=true
+
+      - name: Configure acpctl (kind-login)
+        run: |
+          make kind-login CONTAINER_ENGINE=docker
+
+      - name: Run README live e2e
+        run: |
+          make test-readme
+
+      - name: Show deployment status
+        if: always()
+        run: |
+          echo "=== Kind clusters ==="
+          kind get clusters 2>&1 || true
+          echo ""
+          echo "=== ambient-code pods ==="
+          kubectl get pods -n ambient-code -o wide 2>&1 || true
+          echo ""
+          echo "=== Recent ambient-code events ==="
+          kubectl get events -n ambient-code --sort-by='.lastTimestamp' 2>&1 | tail -40 || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          make kind-down CONTAINER_ENGINE=docker 2>&1 || true

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .PHONY: local-test local-test-dev local-test-quick test-all local-troubleshoot local-port-forward local-stop-port-forward
 .PHONY: push-all registry-login setup-hooks remove-hooks lint check-minikube check-kind check-kubectl check-local-context dev-bootstrap kind-rebuild kind-reload-ambient-ui kind-reload-ambient-control-plane kind-reload-ambient-api-server kind-reload-runner-openshell kind-load-runner kind-status kind-login kind-sso-toggle kind-setup-vertex
 .PHONY: preflight-cluster preflight dev-env dev
-.PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift test-gateway-e2e test-vteam-catalog-lab
+.PHONY: e2e-test e2e-setup e2e-clean deploy-langfuse-openshift test-gateway-e2e test-vteam-catalog-lab test-readme
 .PHONY: crc-up crc-down crc-reload-component crc-reload-images
 .PHONY: unleash-port-forward unleash-status
 .PHONY: kind-port-forward kind-port-forward-stop _kind-start-port-forward _kind-print-access kind-acpctl-login kind-apply-examples
@@ -503,6 +503,10 @@ test-gateway-e2e: check-kubectl _kind-require-cluster ## Run full gateway e2e te
 test-vteam-catalog-lab: check-kubectl _kind-require-cluster ## Validate vTeam Catalog lab markdown copy/paste flow
 	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Running vTeam Catalog lab markdown e2e test..."
 	@./tests/e2e/vteam-catalog-lab-test.sh
+
+test-readme: ## E2E-test README.md technical content (static gate always; live flow if a cluster is reachable)
+	@echo "$(COLOR_BLUE)▶$(COLOR_RESET) Running README e2e test..."
+	@./tests/e2e/readme-e2e-test.sh
 
 local-test-quick: check-kubectl ## Quick smoke test of local environment
 	@echo "$(COLOR_BOLD)🧪 Quick Smoke Test$(COLOR_RESET)"

--- a/tests/e2e/readme-e2e-test.sh
+++ b/tests/e2e/readme-e2e-test.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+# End-to-end test for the technical content of README.md.
+#
+# Goal: any user who copy/pastes their way through the README should succeed.
+# This script is pointed at an ALREADY-RUNNING ACP environment (Kind, CRC, or a
+# real cluster) -- it does not provision anything. It runs in two phases:
+#
+#   1. Static gate  (no cluster needed): links, referenced files, badge
+#      workflows, `make` targets, and `acpctl` subcommands referenced by the
+#      README all resolve.
+#   2. Live flow    (needs a reachable cluster): the README's documented acpctl
+#      gateway/project commands are executed against the environment and
+#      asserted to succeed. Live sections skip cleanly when no cluster is
+#      reachable, so this doubles as a pure README linter.
+#
+# Environment overrides:
+#   README_DOC            Doc under test           (default: README.md)
+#   PROJECT               Throwaway project name   (default: readme-e2e-<rand>)
+#   GATEWAY_URL           Connect target URL       (default: auto-detect on Kind)
+#   CHECK_EXTERNAL_LINKS  Curl external http links (default: false)
+#   RUN_SANDBOX           Run openshell sandbox     (default: false)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+README_DOC="${README_DOC:-README.md}"
+PROJECT="${PROJECT:-readme-e2e-$RANDOM}"
+GATEWAY_URL="${GATEWAY_URL:-}"
+CHECK_EXTERNAL_LINKS="${CHECK_EXTERNAL_LINKS:-false}"
+RUN_SANDBOX="${RUN_SANDBOX:-false}"
+GATEWAY_READY_TIMEOUT="${GATEWAY_READY_TIMEOUT:-60}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+ORANGE='\033[38;5;214m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+pass() { echo -e "  ${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
+skip() { echo -e "  ${YELLOW}⊘${NC} $1${2:+ (skipped: $2)}"; SKIPPED=$((SKIPPED + 1)); }
+section() { echo ""; echo -e "${BOLD}$1${NC}"; }
+
+CMD_OUTPUT=""
+CMD_RC=0
+run_cmd() {
+  CMD_RC=0
+  echo ""
+  printf '  %b▶%b  %b$ %s%b\n' "${BOLD}" "${NC}" "${ORANGE}" "$*" "${NC}"
+  CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+  if [ -n "$CMD_OUTPUT" ]; then
+    echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  fi
+  echo ""
+}
+
+finish() {
+  echo ""
+  echo -e "${BOLD}Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}, ${YELLOW}${SKIPPED} skipped${NC}"
+  if [ "$FAILED" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+die() {
+  fail "$1"
+  exit 1
+}
+
+README_ABS="$REPO_ROOT/$README_DOC"
+
+# Throwaway project bookkeeping for teardown.
+CREATED_PROJECT=false
+ACPCTL=""
+
+cleanup() {
+  if [ "$CREATED_PROJECT" = true ] && [ -n "$ACPCTL" ]; then
+    echo ""
+    echo -e "${BOLD}Teardown${NC}"
+    # Local CLI registration cleanup (only meaningful if setup-cli ran).
+    "$ACPCTL" gateway remove-cli --project "$PROJECT" >/dev/null 2>&1 || true
+    # Best-effort gateway delete; project delete cascades owned resources.
+    "$ACPCTL" delete gateway --all --project "$PROJECT" --yes >/dev/null 2>&1 || true
+    # Deleting the throwaway project is the authoritative cleanup -- verify it,
+    # because a leaked project on the target environment is a real defect.
+    if "$ACPCTL" delete project "$PROJECT" --yes >/dev/null 2>&1; then
+      pass "Teardown: deleted project $PROJECT"
+    else
+      fail "Teardown: deleted project $PROJECT (manual cleanup may be required)"
+    fi
+  fi
+}
+on_exit() {
+  cleanup
+  finish
+}
+trap on_exit EXIT
+
+cd "$REPO_ROOT"
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+find_acpctl() {
+  if command -v acpctl >/dev/null 2>&1; then echo acpctl; return; fi
+  if [ -x "$REPO_ROOT/components/ambient-cli/acpctl" ]; then
+    echo "$REPO_ROOT/components/ambient-cli/acpctl"; return
+  fi
+  if [ -x "$REPO_ROOT/acpctl" ]; then echo "$REPO_ROOT/acpctl"; return; fi
+  echo ""
+}
+
+# Emit only the contents of ```bash fenced blocks, so command extraction never
+# picks up prose that merely mentions a command name. Fences may be indented
+# (README nests some blocks inside numbered lists).
+extract_bash_blocks() {
+  awk '
+    /^[[:space:]]*```bash[[:space:]]*$/ { in_block = 1; next }
+    /^[[:space:]]*```[[:space:]]*$/      { in_block = 0; next }
+    in_block                            { print }
+  ' "$README_ABS"
+}
+
+# GitHub-style heading slug (approximation sufficient for our anchors).
+to_slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9 _-]//g; s/^ +//; s/ +$//; s/ +/-/g'
+}
+
+# Newline-delimited set of heading anchors present in the README.
+readme_anchors() {
+  grep -E '^#{1,6} ' "$README_ABS" | sed -E 's/^#{1,6} +//' | while IFS= read -r h; do
+    to_slug "$h"; echo
+  done
+}
+
+# Extract markdown link/image targets: the "target" in ](target).
+extract_link_targets() {
+  grep -oE '\]\([^)]+\)' "$README_ABS" \
+    | sed -E 's/^\]\(//; s/\)$//' \
+    | sed -E 's/[[:space:]]+"[^"]*"$//' \
+    | sort -u
+}
+
+ANCHORS=""
+
+check_link() {
+  local target="$1"
+  case "$target" in
+    mailto:*|tel:*) return 0 ;;
+    http://*|https://*)
+      if [ "$CHECK_EXTERNAL_LINKS" = true ]; then
+        if curl -sfL --head --max-time 15 "$target" >/dev/null 2>&1; then
+          pass "External link: $target"
+        else
+          fail "External link: $target"
+        fi
+      else
+        skip "External link: $target" "CHECK_EXTERNAL_LINKS=false"
+      fi
+      ;;
+    \#*)
+      local anchor="${target#\#}"
+      if printf '%s\n' "$ANCHORS" | grep -Fxq "$anchor"; then
+        pass "In-page anchor: $target"
+      else
+        fail "In-page anchor: $target"
+      fi
+      ;;
+    *)
+      # Relative path, possibly with #anchor. Verify the file exists.
+      local path="${target%%#*}"
+      if [ -e "$REPO_ROOT/$path" ]; then
+        pass "Relative link: $target"
+      else
+        fail "Relative link: $target"
+      fi
+      ;;
+  esac
+}
+
+# ============================================================================
+# Section 1: README static quality gate (no cluster required)
+# ============================================================================
+
+section "1. README static quality gate"
+
+[ -f "$README_ABS" ] || die "README exists: $README_DOC"
+pass "README exists: $README_DOC"
+[ -s "$README_ABS" ] || die "README is non-empty"
+pass "README is non-empty"
+
+ANCHORS="$(readme_anchors)"
+
+# --- Links and referenced files ---
+section "1a. Links and referenced files"
+while IFS= read -r target; do
+  [ -n "$target" ] && check_link "$target"
+done < <(extract_link_targets)
+
+# --- Badge workflows ---
+section "1b. Badge workflows"
+for wf in lint.yml unit-tests.yml docs.yml; do
+  if [ -f "$REPO_ROOT/.github/workflows/$wf" ]; then
+    pass "Badge workflow exists: $wf"
+  else
+    fail "Badge workflow exists: $wf"
+  fi
+done
+
+# --- make targets ---
+section "1c. make targets referenced in README"
+while IFS= read -r target; do
+  [ -n "$target" ] || continue
+  if grep -qE "^${target}:" "$REPO_ROOT/Makefile"; then
+    pass "make target exists: $target"
+  else
+    fail "make target exists: $target"
+  fi
+done < <(extract_bash_blocks | grep -oE 'make [a-z][a-z0-9-]+' | awk '{print $2}' | sort -u)
+
+# --- acpctl subcommands ---
+section "1d. acpctl subcommands referenced in README"
+ACPCTL="$(find_acpctl)"
+if [ -z "$ACPCTL" ]; then
+  skip "acpctl subcommand validation" "acpctl not found on PATH or in repo"
+else
+  pass "acpctl found: $ACPCTL"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    group="$(echo "$line" | awk '{print $2}')"
+    sub="$(echo "$line" | awk '{print $3}')"
+    # Decouple the grep from acpctl's exit code: --help may exit non-zero on
+    # some builds while still printing the command surface we want to verify.
+    help_out="$("$ACPCTL" "$group" --help 2>&1)" || true
+    if printf '%s' "$help_out" | grep -qw "$sub"; then
+      pass "acpctl command exists: $group $sub"
+    else
+      fail "acpctl command exists: $group $sub"
+    fi
+  done < <(extract_bash_blocks | grep -oE 'acpctl [a-z][a-z0-9-]+ [a-z][a-z0-9-]+' | sort -u)
+fi
+
+# ============================================================================
+# Section 2: Prerequisites for the live flow
+# ============================================================================
+
+section "2. Live prerequisites"
+
+LIVE=true
+
+for tool in jq kubectl curl; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    pass "$tool is installed"
+  else
+    skip "$tool is installed" "required for live flow"
+    LIVE=false
+  fi
+done
+
+if [ -z "$ACPCTL" ]; then
+  skip "acpctl available for live flow" "acpctl not found"
+  LIVE=false
+fi
+
+if [ "$LIVE" = true ]; then
+  if kubectl cluster-info >/dev/null 2>&1; then
+    pass "Cluster is reachable"
+  else
+    skip "Cluster is reachable" "no reachable cluster; live sections skipped"
+    LIVE=false
+  fi
+fi
+
+if [ "$LIVE" != true ]; then
+  section "Live flow skipped"
+  skip "README live command flow" "no reachable ACP environment"
+  skip "CRC / OpenShift Local path" "not executable in this environment (validated statically only)"
+  exit 0
+fi
+
+# ============================================================================
+# Section 3: Live -- OpenShell as a Service (README: create project & gateway)
+# ============================================================================
+
+section "3. Live: create project and gateway"
+
+grep -qE 'acpctl create project' "$README_ABS" \
+  && pass "README documents: acpctl create project" \
+  || fail "README documents: acpctl create project"
+
+run_cmd "$ACPCTL" create project --name "$PROJECT"
+if [ "$CMD_RC" -eq 0 ]; then
+  CREATED_PROJECT=true
+  pass "Created project: $PROJECT"
+else
+  die "Created project: $PROJECT"
+fi
+
+GATEWAY_CREATED=false
+grep -qE 'acpctl create gateway' "$README_ABS" \
+  && pass "README documents: acpctl create gateway" \
+  || fail "README documents: acpctl create gateway"
+
+run_cmd "$ACPCTL" create gateway --project "$PROJECT"
+if [ "$CMD_RC" -ne 0 ]; then
+  fail "Requested gateway for project: $PROJECT"
+else
+  pass "Requested gateway for project: $PROJECT"
+
+  # Assert the gateway actually RECONCILES -- not merely that the API accepted
+  # the request or that `get` exits 0. The control plane exposes
+  # ambient.ai/reconcile-status; "Synced" is the signal a README reader depends
+  # on for the gateway to work. Fail (not skip) if it never reaches Synced.
+  GW_JSON=""
+  GW_STATUS=""
+  i=0
+  while [ "$i" -lt "$GATEWAY_READY_TIMEOUT" ]; do
+    GW_JSON="$("$ACPCTL" get gateway --project "$PROJECT" -o json 2>/dev/null || true)"
+    GW_STATUS="$(printf '%s' "$GW_JSON" | jq -r '.items[0].annotations | fromjson | ."ambient.ai/reconcile-status" // empty' 2>/dev/null || true)"
+    if [ "$GW_STATUS" = "Synced" ]; then
+      GATEWAY_CREATED=true
+      break
+    fi
+    sleep 5
+    i=$((i + 5))
+  done
+  if [ "$GATEWAY_CREATED" = true ]; then
+    pass "Gateway reconciled (status: Synced)"
+    # An external route address is only present on route-capable clusters.
+    # port-forward environments (kind) and cluster-DNS gateways expose none;
+    # there the README uses the --kubectl flow, so route steps skip below.
+    if [ -z "$GATEWAY_URL" ]; then
+      GATEWAY_URL="$(printf '%s' "$GW_JSON" | jq -r '.items[0].route // {} | tojson' 2>/dev/null | grep -oE 'https?://[^ "]+' | head -1 || true)"
+    fi
+  else
+    fail "Gateway reconciled within ${GATEWAY_READY_TIMEOUT}s (last status: ${GW_STATUS:-none})"
+  fi
+fi
+
+# ============================================================================
+# Section 4: Live -- connect and inspect (README: get gateway, setup-cli)
+# ============================================================================
+
+section "4. Live: connect and inspect"
+
+if [ "$GATEWAY_CREATED" = true ]; then
+  run_cmd "$ACPCTL" get gateway --project "$PROJECT"
+  if [ "$CMD_RC" -eq 0 ] && [ -n "$CMD_OUTPUT" ]; then
+    pass "get gateway returns records"
+  else
+    fail "get gateway returns records"
+  fi
+else
+  skip "get gateway returns records" "no gateway created"
+fi
+
+# README documents the connect commands.
+grep -qE 'acpctl gateway setup-cli' "$README_ABS" \
+  && pass "README documents: acpctl gateway setup-cli" \
+  || fail "README documents: acpctl gateway setup-cli"
+
+# Route-based connect (README's OpenShell-as-a-Service flow, validated on
+# OpenShift Local / real clusters). Requires a gateway route address; on
+# port-forward environments like kind there is none, so these steps skip
+# rather than fail. Set GATEWAY_URL to force the route-based path.
+if [ "$GATEWAY_CREATED" = true ] && [ -n "$GATEWAY_URL" ]; then
+  run_cmd "$ACPCTL" gateway setup-cli --project "$PROJECT" --print
+  [ "$CMD_RC" -eq 0 ] && pass "gateway setup-cli --print" || fail "gateway setup-cli --print"
+
+  run_cmd "$ACPCTL" gateway setup-cli --project "$PROJECT" --gateway-url "$GATEWAY_URL" --kubectl
+  [ "$CMD_RC" -eq 0 ] && pass "gateway setup-cli --gateway-url" || fail "gateway setup-cli --gateway-url"
+else
+  skip "gateway setup-cli --print" "gateway has no external route address (cluster-DNS/port-forward access); README uses the --kubectl flow here. Set GATEWAY_URL to test the route-based flow"
+  skip "gateway setup-cli --gateway-url" "no gateway URL resolved; set GATEWAY_URL to test the port-forward connect flow"
+fi
+
+# Optional sandbox lifecycle via the openshell CLI (README ~lines 75-78).
+if [ "$RUN_SANDBOX" = true ] && command -v openshell >/dev/null 2>&1; then
+  run_cmd openshell sandbox create
+  [ "$CMD_RC" -eq 0 ] && pass "openshell sandbox create" || fail "openshell sandbox create"
+  run_cmd openshell sandbox list
+  [ "$CMD_RC" -eq 0 ] && pass "openshell sandbox list" || fail "openshell sandbox list"
+else
+  skip "openshell sandbox create/list" "set RUN_SANDBOX=true with openshell installed"
+fi
+
+# CRC path is validated statically only (targets/links checked in Section 1).
+skip "CRC / OpenShift Local path" "not executable in CI (validated statically only)"
+
+# Teardown runs via the EXIT trap; finish() reports results there.


### PR DESCRIPTION
## What

Adds an end-to-end test for the **technical content of `README.md`**, so any user who copy/pastes their way through the README succeeds. Environment-agnostic — point it at any running ACP environment (Kind, CRC, or a real cluster); it provisions nothing.

## Deliverables

- `tests/e2e/readme-e2e-test.sh` — the test (mirrors the existing `tests/e2e/vteam-catalog-lab-test.sh` house style: `pass/fail/skip/section`, `acpctl` discovery).
- `.github/workflows/readme-e2e.yml` — `static` job on PRs (touching `README.md`, `Makefile`, `components/ambient-cli/**`, or the script); `live` job on `workflow_dispatch` + weekly `schedule`.
- `Makefile` — `make test-readme` target (no cluster prereq, so it doubles as a linter).

## How it works

**Static gate (always, no cluster):**
- Relative links / referenced files resolve; in-page anchors exist.
- Badge workflows exist (`lint.yml`, `unit-tests.yml`, `docs.yml`).
- Every `make <target>` in the README exists in the `Makefile`.
- Every `acpctl <group> <sub>` (extracted only from ```` ```bash ```` blocks, so prose mentions don't false-positive) resolves via `acpctl <group> --help`.

**Live flow (only when a cluster is reachable; skips cleanly otherwise):**
- Runs the README's documented `acpctl create project` / `create gateway` / `get gateway` / `gateway setup-cli` against the environment, using an isolated throwaway project that is torn down in an EXIT trap.
- Route-based `setup-cli --print` is skipped on port-forward/cluster-DNS gateways (per the README's OpenShift-Local scoping) rather than failing.
- CRC path is validated statically only (not executable in CI).

Exits non-zero on any failure so CI gates on it.

## Testing

- Static gate: 32 passed / 0 failed (cluster forced unreachable).
- Live flow: verified end-to-end against a live ACP env (project + gateway created, retrieved, and deleted; no leaked resources).
- `shellcheck -S warning` and `actionlint` clean.

## Notes

- No secrets in the workflow; pinned action SHAs; `permissions: contents: read`; user input passed via `env` only.
- The script does not `eval` README content — it greps for validation and runs explicit `acpctl` commands with regex-constrained tokens.
