### PR TITLE
fix(api-server): default DB secret paths to in-pod mount location

### DIFF
--- a/components/ambient-api-server/pkg/cmd/db_defaults.go
+++ b/components/ambient-api-server/pkg/cmd/db_defaults.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/openshift-online/rh-trex-ai/pkg/config"
+
+// setInPodDBDefaults overrides the upstream rh-trex-ai defaults to match the
+// volume mount paths used by the API server deployment (/secrets/db/).
+func setInPodDBDefaults(c *config.DatabaseConfig) {
+	c.HostFile = "/secrets/db/db.host"
+	c.PortFile = "/secrets/db/db.port"
+	c.NameFile = "/secrets/db/db.name"
+	c.UsernameFile = "/secrets/db/db.user"
+	c.PasswordFile = "/secrets/db/db.password"
+}

--- a/components/ambient-api-server/pkg/cmd/db_defaults_test.go
+++ b/components/ambient-api-server/pkg/cmd/db_defaults_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/openshift-online/rh-trex-ai/pkg/config"
+)
+
+func TestSetInPodDBDefaults(t *testing.T) {
+	tests := []struct {
+		name  string
+		field func(*config.DatabaseConfig) string
+		want  string
+	}{
+		{"HostFile", func(c *config.DatabaseConfig) string { return c.HostFile }, "/secrets/db/db.host"},
+		{"PortFile", func(c *config.DatabaseConfig) string { return c.PortFile }, "/secrets/db/db.port"},
+		{"NameFile", func(c *config.DatabaseConfig) string { return c.NameFile }, "/secrets/db/db.name"},
+		{"UsernameFile", func(c *config.DatabaseConfig) string { return c.UsernameFile }, "/secrets/db/db.user"},
+		{"PasswordFile", func(c *config.DatabaseConfig) string { return c.PasswordFile }, "/secrets/db/db.password"},
+	}
+
+	c := config.NewDatabaseConfig()
+	setInPodDBDefaults(c)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.field(c); got != tt.want {
+				t.Errorf("setInPodDBDefaults() %s = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/components/ambient-api-server/pkg/cmd/encrypt_credentials.go
+++ b/components/ambient-api-server/pkg/cmd/encrypt_credentials.go
@@ -25,6 +25,7 @@ func (credentialRow) TableName() string { return "credentials" }
 
 func NewEncryptCredentialsCommand() *cobra.Command {
 	dbConfig := config.NewDatabaseConfig()
+	setInPodDBDefaults(dbConfig)
 	var decrypt bool
 	var dryRun bool
 

--- a/components/ambient-api-server/pkg/cmd/seed_admin.go
+++ b/components/ambient-api-server/pkg/cmd/seed_admin.go
@@ -39,6 +39,7 @@ func (seedRoleBinding) TableName() string { return "role_bindings" }
 
 func NewSeedAdminCommand() *cobra.Command {
 	dbConfig := config.NewDatabaseConfig()
+	setInPodDBDefaults(dbConfig)
 	var username string
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
## Summary

- `seed-admin` and `encrypt-credentials` subcommands inherit upstream rh-trex-ai defaults (`secrets/db.host`) which don't match the API server pod's volume mount at `/secrets/db/db.host`, requiring every caller to pass explicit `--db-*-file` flags
- Extract a shared `setInPodDBDefaults` helper that overrides the defaults to `/secrets/db/db.*`
- Remove the now-redundant `--db-*-file` flags from the bootstrap-admin Job manifest

## Spec impact

None — no specs reference `seed-admin`, the bootstrap job, or DB secret paths.

## Test plan

- [ ] `kubectl exec` into API server pod and run `seed-admin --username test` without `--db-*-file` flags — should connect to DB successfully
- [ ] Verify bootstrap-admin Job still works on fresh deployment (no explicit DB path flags needed)
- [ ] `go build ./...` passes in `components/ambient-api-server/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)