### PR TITLE
fix(rbac): standardize role_bindings.user_id on KSUID

### DIFF
--- a/components/ambient-api-server/pkg/rbac/evaluator.go
+++ b/components/ambient-api-server/pkg/rbac/evaluator.go
@@ -31,6 +31,10 @@ func NewEvaluator(sessionFactory *db.SessionFactory) *Evaluator {
 
 func (e *Evaluator) fetchBindings(g *gorm.DB, username string) ([]bindingRow, error) {
 	var rows []bindingRow
+	// TODO(2026-10-01): remove the OR rb.user_id = ? fallback once all
+	// role_bindings rows have been migrated from username to KSUID
+	// (migration 202607290001). After confirming migration is complete
+	// in all environments, simplify to: WHERE u.username = ?
 	err := g.Table("role_bindings rb").
 		Select("rb.role_id, r.name AS role_name, rb.scope, rb.user_id, rb.project_id, rb.agent_id, rb.session_id, rb.credential_id, r.permissions").
 		Joins("JOIN roles r ON r.id = rb.role_id").

--- a/components/ambient-api-server/pkg/rbac/evaluator.go
+++ b/components/ambient-api-server/pkg/rbac/evaluator.go
@@ -34,7 +34,8 @@ func (e *Evaluator) fetchBindings(g *gorm.DB, username string) ([]bindingRow, er
 	err := g.Table("role_bindings rb").
 		Select("rb.role_id, r.name AS role_name, rb.scope, rb.user_id, rb.project_id, rb.agent_id, rb.session_id, rb.credential_id, r.permissions").
 		Joins("JOIN roles r ON r.id = rb.role_id").
-		Where("rb.user_id = ? AND rb.deleted_at IS NULL AND r.deleted_at IS NULL", username).
+		Joins("LEFT JOIN users u ON u.id = rb.user_id AND u.deleted_at IS NULL").
+		Where("(u.username = ? OR rb.user_id = ?) AND rb.deleted_at IS NULL AND r.deleted_at IS NULL", username, username).
 		Scan(&rows).Error
 	return rows, err
 }

--- a/components/ambient-api-server/pkg/rbac/middleware.go
+++ b/components/ambient-api-server/pkg/rbac/middleware.go
@@ -357,11 +357,18 @@ func (m *DBAuthorizationMiddleware) autoProvisionServiceAccount(ctx context.Cont
 		return
 	}
 
+	// Resolve the user's KSUID for role_bindings.user_id.
+	userID, resolveErr := ResolveUserID(g, username)
+	if resolveErr != nil {
+		glog.Warningf("service account user ID resolution failed for %s: %v", username, resolveErr)
+		return
+	}
+
 	// Check whether a platform:admin binding already exists.
 	var count int64
 	err := g.Table("role_bindings").
 		Joins("JOIN roles ON roles.id = role_bindings.role_id").
-		Where("role_bindings.user_id = ? AND role_bindings.deleted_at IS NULL", username).
+		Where("role_bindings.user_id = ? AND role_bindings.deleted_at IS NULL", userID).
 		Where("roles.name = ? AND roles.deleted_at IS NULL", RolePlatformAdmin).
 		Count(&count).Error
 	if err != nil {
@@ -397,7 +404,7 @@ func (m *DBAuthorizationMiddleware) autoProvisionServiceAccount(ctx context.Cont
 		ID:        api.NewID(),
 		RoleID:    roleID,
 		Scope:     string(ScopeGlobal),
-		UserID:    username,
+		UserID:    userID,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}

--- a/components/ambient-api-server/pkg/rbac/user_resolve.go
+++ b/components/ambient-api-server/pkg/rbac/user_resolve.go
@@ -1,0 +1,24 @@
+package rbac
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// ResolveUserID looks up the KSUID primary key for a username.
+// All role_bindings.user_id values must store the users.id KSUID,
+// not the username string.
+func ResolveUserID(g *gorm.DB, username string) (string, error) {
+	var id string
+	err := g.Table("users").Select("id").
+		Where("username = ? AND deleted_at IS NULL", username).
+		Scan(&id).Error
+	if err != nil {
+		return "", fmt.Errorf("resolve user %q: %w", username, err)
+	}
+	if id == "" {
+		return "", fmt.Errorf("user %q not found", username)
+	}
+	return id, nil
+}

--- a/components/ambient-api-server/pkg/rbac/user_resolve.go
+++ b/components/ambient-api-server/pkg/rbac/user_resolve.go
@@ -1,10 +1,14 @@
 package rbac
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
 )
+
+// ErrUserNotFound is returned when the username has no matching row in users.
+var ErrUserNotFound = errors.New("user not found")
 
 // ResolveUserID looks up the KSUID primary key for a username.
 // All role_bindings.user_id values must store the users.id KSUID,
@@ -15,10 +19,10 @@ func ResolveUserID(g *gorm.DB, username string) (string, error) {
 		Where("username = ? AND deleted_at IS NULL", username).
 		Scan(&id).Error
 	if err != nil {
-		return "", fmt.Errorf("resolve user %q: %w", username, err)
+		return "", fmt.Errorf("resolve user ID: %w", err)
 	}
 	if id == "" {
-		return "", fmt.Errorf("user %q not found", username)
+		return "", ErrUserNotFound
 	}
 	return id, nil
 }

--- a/components/ambient-api-server/pkg/rbac/user_resolve_test.go
+++ b/components/ambient-api-server/pkg/rbac/user_resolve_test.go
@@ -1,0 +1,103 @@
+package rbac
+
+import (
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func newMockGorm(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { sqlDB.Close() })
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn:                 sqlDB,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	return gormDB, mock
+}
+
+func TestResolveUserID(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(sqlmock.Sqlmock)
+		wantID    string
+		wantErr   error
+		wantAnyErr bool
+	}{
+		{
+			name: "found",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT`).
+					WithArgs("alice").
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("ksuid_abc123"))
+			},
+			wantID: "ksuid_abc123",
+		},
+		{
+			name: "not found",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT`).
+					WithArgs("ghost").
+					WillReturnRows(sqlmock.NewRows([]string{"id"}))
+			},
+			wantErr: ErrUserNotFound,
+		},
+		{
+			name: "db error",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`SELECT`).
+					WithArgs("alice").
+					WillReturnError(errors.New("connection refused"))
+			},
+			wantAnyErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gormDB, mock := newMockGorm(t)
+			tt.setup(mock)
+
+			username := "alice"
+			if tt.wantErr == ErrUserNotFound {
+				username = "ghost"
+			}
+
+			id, err := ResolveUserID(gormDB, username)
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("got err %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if tt.wantAnyErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tt.wantID {
+				t.Errorf("got id %q, want %q", id, tt.wantID)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet sqlmock expectations: %v", err)
+			}
+		})
+	}
+}

--- a/components/ambient-api-server/pkg/rbac/user_resolve_test.go
+++ b/components/ambient-api-server/pkg/rbac/user_resolve_test.go
@@ -29,10 +29,10 @@ func newMockGorm(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 
 func TestResolveUserID(t *testing.T) {
 	tests := []struct {
-		name      string
-		setup     func(sqlmock.Sqlmock)
-		wantID    string
-		wantErr   error
+		name       string
+		setup      func(sqlmock.Sqlmock)
+		wantID     string
+		wantErr    error
 		wantAnyErr bool
 	}{
 		{

--- a/components/ambient-api-server/plugins/credentials/service.go
+++ b/components/ambient-api-server/plugins/credentials/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/crypto"
+	pkgrbac "github.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/rbac"
 	"github.com/openshift-online/rh-trex-ai/pkg/api"
 	"github.com/openshift-online/rh-trex-ai/pkg/auth"
 	"github.com/openshift-online/rh-trex-ai/pkg/db"
@@ -173,6 +174,12 @@ func (s *sqlCredentialService) createOwnerBinding(ctx context.Context, credentia
 	}
 	g := (*s.sessionFactory).New(ctx)
 
+	userID, err := pkgrbac.ResolveUserID(g, username)
+	if err != nil {
+		glog.Warningf("failed to resolve user ID for credential owner binding %s: %v", credentialID, err)
+		return
+	}
+
 	var roleID string
 	if err := g.Table("roles").Select("id").
 		Where("name = ? AND deleted_at IS NULL", "credential:owner").
@@ -186,7 +193,7 @@ func (s *sqlCredentialService) createOwnerBinding(ctx context.Context, credentia
 		ID:           api.NewID(),
 		RoleId:       roleID,
 		Scope:        "credential",
-		UserId:       &username,
+		UserId:       &userID,
 		CredentialId: &credentialID,
 		CreatedAt:    now,
 		UpdatedAt:    now,

--- a/components/ambient-api-server/plugins/projects/handler.go
+++ b/components/ambient-api-server/plugins/projects/handler.go
@@ -209,12 +209,19 @@ func (h projectHandler) TransferOwnership(w http.ResponseWriter, r *http.Request
 	}
 
 	g := (*h.sessionFactory).New(ctx)
+
+	callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
+	if resolveErr != nil {
+		handlers.HandleError(ctx, w, errors.Forbidden("Forbidden"))
+		return
+	}
+
 	var callerRoleNames []string
 	if dbErr := g.Table("role_bindings rb").
 		Select("r.name").
 		Joins("JOIN roles r ON r.id = rb.role_id").
 		Where("rb.user_id = ? AND (rb.project_id = ? OR rb.scope = 'global') AND r.deleted_at IS NULL AND rb.deleted_at IS NULL",
-			username, projectID).
+			callerUserID, projectID).
 		Scan(&callerRoleNames).Error; dbErr != nil {
 		handlers.HandleError(ctx, w, errors.GeneralError("authorization check failed"))
 		return

--- a/components/ambient-api-server/plugins/projects/handler.go
+++ b/components/ambient-api-server/plugins/projects/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 
 	"github.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/openapi"
@@ -212,7 +213,8 @@ func (h projectHandler) TransferOwnership(w http.ResponseWriter, r *http.Request
 
 	callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
 	if resolveErr != nil {
-		handlers.HandleError(ctx, w, errors.Forbidden("Forbidden"))
+		glog.Errorf("ResolveUserID failed for ownership transfer: %v", resolveErr)
+		handlers.HandleError(ctx, w, errors.GeneralError("authorization check failed"))
 		return
 	}
 

--- a/components/ambient-api-server/plugins/projects/service.go
+++ b/components/ambient-api-server/plugins/projects/service.go
@@ -14,6 +14,8 @@ import (
 	"github.com/openshift-online/rh-trex-ai/pkg/logger"
 	"github.com/openshift-online/rh-trex-ai/pkg/services"
 	"gorm.io/gorm"
+
+	pkgrbac "github.com/ambient-code/platform/components/ambient-api-server/pkg/rbac"
 )
 
 // roleBindingRow is a local struct for creating role_bindings rows via GORM,
@@ -141,6 +143,12 @@ func (s *sqlProjectService) createOwnerBinding(ctx context.Context, projectID st
 	}
 	g := (*s.sessionFactory).New(ctx)
 
+	userID, err := pkgrbac.ResolveUserID(g, username)
+	if err != nil {
+		glog.Warningf("failed to resolve user ID for project owner binding %s: %v", projectID, err)
+		return
+	}
+
 	var roleID string
 	if err := g.Table("roles").Select("id").
 		Where("name = ? AND deleted_at IS NULL", "project:owner").
@@ -154,7 +162,7 @@ func (s *sqlProjectService) createOwnerBinding(ctx context.Context, projectID st
 		ID:        api.NewID(),
 		RoleId:    roleID,
 		Scope:     "project",
-		UserId:    &username,
+		UserId:    &userID,
 		ProjectId: &projectID,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -231,6 +239,12 @@ func (s *sqlProjectService) TransferOwnership(ctx context.Context, projectID, ca
 		return errors.GeneralError("failed to find project:editor role")
 	}
 
+	// Resolve caller username to KSUID for role_bindings queries.
+	callerUserID, resolveErr := pkgrbac.ResolveUserID(g, callerUsername)
+	if resolveErr != nil {
+		return errors.GeneralError("failed to resolve caller user ID")
+	}
+
 	// Verify target user exists.
 	var targetUserCount int64
 	if dbErr := g.Table("users").
@@ -278,7 +292,7 @@ func (s *sqlProjectService) TransferOwnership(ctx context.Context, projectID, ca
 		if !callerIsAdmin {
 			result := tx.Table("role_bindings").
 				Where("user_id = ? AND role_id = ? AND project_id = ? AND deleted_at IS NULL",
-					callerUsername, ownerRoleID, projectID).
+					callerUserID, ownerRoleID, projectID).
 				Updates(map[string]interface{}{
 					"role_id":    editorRoleID,
 					"updated_at": now,

--- a/components/ambient-api-server/plugins/projects/service.go
+++ b/components/ambient-api-server/plugins/projects/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift-online/rh-trex-ai/pkg/services"
 	"gorm.io/gorm"
 
-	pkgrbac "github.com/ambient-code/platform/components/ambient-api-server/pkg/rbac"
+	pkgrbac "github.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/rbac"
 )
 
 // roleBindingRow is a local struct for creating role_bindings rows via GORM,

--- a/components/ambient-api-server/plugins/roleBindings/handler.go
+++ b/components/ambient-api-server/plugins/roleBindings/handler.go
@@ -3,6 +3,7 @@ package roleBindings
 import (
 	"net/http"
 
+	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 
 	"github.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/openapi"
@@ -65,7 +66,8 @@ func (h roleBindingHandler) Create(w http.ResponseWriter, r *http.Request) {
 				username := auth.GetUsernameFromContext(ctx)
 				callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
 				if resolveErr != nil {
-					return nil, errors.Forbidden("Forbidden")
+					glog.Errorf("ResolveUserID failed for role binding operation: %v", resolveErr)
+					return nil, errors.GeneralError("authorization check failed")
 				}
 				var callerRoleNames []string
 				baseQuery := func(g *gorm.DB) *gorm.DB {
@@ -219,7 +221,8 @@ func (h roleBindingHandler) Patch(w http.ResponseWriter, r *http.Request) {
 
 				callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
 				if resolveErr != nil {
-					return nil, errors.Forbidden("Forbidden")
+					glog.Errorf("ResolveUserID failed for role binding operation: %v", resolveErr)
+					return nil, errors.GeneralError("authorization check failed")
 				}
 
 				// Fetch caller's roles scoped to the binding's project (+ global)
@@ -578,7 +581,8 @@ func (h roleBindingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 				username := auth.GetUsernameFromContext(ctx)
 				callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
 				if resolveErr != nil {
-					return nil, errors.Forbidden("Forbidden")
+					glog.Errorf("ResolveUserID failed for role binding operation: %v", resolveErr)
+					return nil, errors.GeneralError("authorization check failed")
 				}
 
 				if binding.Scope == "credential" {

--- a/components/ambient-api-server/plugins/roleBindings/handler.go
+++ b/components/ambient-api-server/plugins/roleBindings/handler.go
@@ -63,12 +63,16 @@ func (h roleBindingHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 				// b) Level hierarchy check — scoped to the target resource
 				username := auth.GetUsernameFromContext(ctx)
+				callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
+				if resolveErr != nil {
+					return nil, errors.Forbidden("Forbidden")
+				}
 				var callerRoleNames []string
 				baseQuery := func(g *gorm.DB) *gorm.DB {
 					return g.Table("role_bindings rb").
 						Select("r.name").
 						Joins("JOIN roles r ON r.id = rb.role_id").
-						Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", username)
+						Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", callerUserID)
 				}
 				var scanErr error
 				if roleBinding.Scope == "project" && roleBinding.ProjectId.IsSet() {
@@ -100,7 +104,7 @@ func (h roleBindingHandler) Create(w http.ResponseWriter, r *http.Request) {
 					var projCount int64
 					if dbErr := g.Table("role_bindings").
 						Where("user_id = ? AND (project_id = ? OR scope = 'global') AND deleted_at IS NULL",
-							username, *roleBinding.ProjectId.Get()).
+							callerUserID, *roleBinding.ProjectId.Get()).
 						Count(&projCount).Error; dbErr != nil {
 						return nil, errors.GeneralError("authorization check failed")
 					}
@@ -144,7 +148,7 @@ func (h roleBindingHandler) Create(w http.ResponseWriter, r *http.Request) {
 					if dbErr := g.Table("role_bindings").
 						Joins("JOIN roles ON roles.id = role_bindings.role_id").
 						Where("role_bindings.user_id = ? AND roles.name = ? AND role_bindings.credential_id = ? AND role_bindings.deleted_at IS NULL AND roles.deleted_at IS NULL",
-							username, pkgrbac.RoleCredentialOwner, *roleBinding.CredentialId.Get()).
+							callerUserID, pkgrbac.RoleCredentialOwner, *roleBinding.CredentialId.Get()).
 						Count(&credOwnerCount).Error; dbErr != nil {
 						return nil, errors.GeneralError("authorization check failed")
 					}
@@ -158,7 +162,7 @@ func (h roleBindingHandler) Create(w http.ResponseWriter, r *http.Request) {
 						if dbErr := g.Table("role_bindings").
 							Joins("JOIN roles ON roles.id = role_bindings.role_id").
 							Where("role_bindings.user_id = ? AND role_bindings.project_id = ? AND role_bindings.deleted_at IS NULL AND roles.deleted_at IS NULL",
-								username, *roleBinding.ProjectId.Get()).
+								callerUserID, *roleBinding.ProjectId.Get()).
 							Where("roles.name IN ?", []string{pkgrbac.RoleProjectOwner, pkgrbac.RoleProjectEditor}).
 							Count(&projEditorCount).Error; dbErr != nil {
 							return nil, errors.GeneralError("authorization check failed")
@@ -213,12 +217,17 @@ func (h roleBindingHandler) Patch(w http.ResponseWriter, r *http.Request) {
 			{
 				g := (*h.sessionFactory).New(ctx)
 
+				callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
+				if resolveErr != nil {
+					return nil, errors.Forbidden("Forbidden")
+				}
+
 				// Fetch caller's roles scoped to the binding's project (+ global)
 				// so the level check reflects project-scoped authority.
 				callerQuery := g.Table("role_bindings rb").
 					Select("r.name").
 					Joins("JOIN roles r ON r.id = rb.role_id").
-					Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", username)
+					Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", callerUserID)
 				if found.Scope == "project" && found.ProjectId != nil {
 					callerQuery = callerQuery.Where("rb.project_id = ? OR rb.scope = 'global'", *found.ProjectId)
 				}
@@ -230,7 +239,7 @@ func (h roleBindingHandler) Patch(w http.ResponseWriter, r *http.Request) {
 
 				// Authorization: allow if caller is admin, owns the binding,
 				// or has project:owner+ on the same project as the binding.
-				isOwner := found.UserId != nil && *found.UserId == username
+				isOwner := found.UserId != nil && *found.UserId == callerUserID
 				isProjectOwnerPlus := false
 				if found.Scope == "project" && found.ProjectId != nil && callerLevel <= 1 {
 					// callerLevel <= 1 means project:owner or platform:admin
@@ -349,6 +358,14 @@ func (h roleBindingHandler) List(w http.ResponseWriter, r *http.Request) {
 				if err != nil {
 					return nil, errors.Forbidden("invalid username")
 				}
+				if h.sessionFactory != nil {
+					g := (*h.sessionFactory).New(ctx)
+					if callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username); resolveErr == nil {
+						if ksuidFilter, filterErr := pkgrbac.TSLEqual("user_id", callerUserID); filterErr == nil {
+							userFilter = pkgrbac.TSLOr(ksuidFilter, userFilter)
+						}
+					}
+				}
 				scopeFilter := userFilter
 
 				if len(authResult.ProjectIDs) > 0 {
@@ -435,6 +452,14 @@ func (h roleBindingHandler) listByScope(w http.ResponseWriter, r *http.Request, 
 				userFilter, err := pkgrbac.TSLEqualUsername("user_id", username)
 				if err != nil {
 					return nil, errors.Forbidden("invalid username")
+				}
+				if h.sessionFactory != nil {
+					g := (*h.sessionFactory).New(ctx)
+					if callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username); resolveErr == nil {
+						if ksuidFilter, filterErr := pkgrbac.TSLEqual("user_id", callerUserID); filterErr == nil {
+							userFilter = pkgrbac.TSLOr(ksuidFilter, userFilter)
+						}
+					}
 				}
 				visibilityFilter := userFilter
 
@@ -551,6 +576,10 @@ func (h roleBindingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 				// --- Authorization check ---
 				username := auth.GetUsernameFromContext(ctx)
+				callerUserID, resolveErr := pkgrbac.ResolveUserID(g, username)
+				if resolveErr != nil {
+					return nil, errors.Forbidden("Forbidden")
+				}
 
 				if binding.Scope == "credential" {
 					// Asymmetric unbind: project:editor+ can remove credential bindings
@@ -560,7 +589,7 @@ func (h roleBindingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 					if dbErr := g.Table("role_bindings rb").
 						Select("r.name").
 						Joins("JOIN roles r ON r.id = rb.role_id").
-						Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", username).
+						Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", callerUserID).
 						Scan(&callerAllRoles).Error; dbErr != nil {
 						return nil, errors.GeneralError("authorization check failed")
 					}
@@ -573,7 +602,7 @@ func (h roleBindingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 						if dbErr := g.Table("role_bindings").
 							Joins("JOIN roles ON roles.id = role_bindings.role_id").
 							Where("role_bindings.user_id = ? AND role_bindings.project_id = ? AND role_bindings.deleted_at IS NULL AND roles.deleted_at IS NULL",
-								username, *binding.ProjectId).
+								callerUserID, *binding.ProjectId).
 							Where("roles.name IN ?", []string{pkgrbac.RoleProjectOwner, pkgrbac.RoleProjectEditor}).
 							Count(&projEditorCount).Error; dbErr != nil {
 							return nil, errors.GeneralError("authorization check failed")
@@ -592,7 +621,7 @@ func (h roleBindingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 					baseQuery := g.Table("role_bindings rb").
 						Select("r.name").
 						Joins("JOIN roles r ON r.id = rb.role_id").
-						Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", username)
+						Where("rb.user_id = ? AND r.deleted_at IS NULL AND rb.deleted_at IS NULL", callerUserID)
 					if binding.Scope == "project" && binding.ProjectId != nil {
 						baseQuery = baseQuery.Where("rb.project_id = ? OR rb.scope = 'global'", *binding.ProjectId)
 					}

--- a/components/ambient-api-server/plugins/roleBindings/migration.go
+++ b/components/ambient-api-server/plugins/roleBindings/migration.go
@@ -1,6 +1,8 @@
 package roleBindings
 
 import (
+	"fmt"
+
 	"gorm.io/gorm"
 
 	"github.com/go-gormigrate/gormigrate/v2"
@@ -96,21 +98,38 @@ func typedFKMigration() *gormigrate.Migration {
 func userIDKSUIDMigration() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "202607290001",
-		Migrate: func(tx *gorm.DB) error {
-			return tx.Exec(`UPDATE role_bindings
-				SET user_id = u.id, updated_at = NOW()
-				FROM users u
-				WHERE role_bindings.user_id = u.username
-				  AND role_bindings.deleted_at IS NULL
-				  AND u.deleted_at IS NULL`).Error
+		Migrate: func(g *gorm.DB) error {
+			return g.Transaction(func(tx *gorm.DB) error {
+				// Guard: abort if duplicate usernames exist — the JOIN
+				// would non-deterministically pick one id per username.
+				var dupeCount int64
+				if err := tx.Raw(`SELECT COUNT(*) FROM (
+					SELECT username FROM users
+					WHERE deleted_at IS NULL
+					GROUP BY username HAVING COUNT(*) > 1
+				) dupes`).Scan(&dupeCount).Error; err != nil {
+					return err
+				}
+				if dupeCount > 0 {
+					return fmt.Errorf("cannot migrate: %d duplicate username(s) in users table", dupeCount)
+				}
+				return tx.Exec(`UPDATE role_bindings
+					SET user_id = u.id, updated_at = NOW()
+					FROM users u
+					WHERE role_bindings.user_id = u.username
+					  AND role_bindings.deleted_at IS NULL
+					  AND u.deleted_at IS NULL`).Error
+			})
 		},
-		Rollback: func(tx *gorm.DB) error {
-			return tx.Exec(`UPDATE role_bindings
-				SET user_id = u.username, updated_at = NOW()
-				FROM users u
-				WHERE role_bindings.user_id = u.id
-				  AND role_bindings.deleted_at IS NULL
-				  AND u.deleted_at IS NULL`).Error
+		Rollback: func(g *gorm.DB) error {
+			return g.Transaction(func(tx *gorm.DB) error {
+				return tx.Exec(`UPDATE role_bindings
+					SET user_id = u.username, updated_at = NOW()
+					FROM users u
+					WHERE role_bindings.user_id = u.id
+					  AND role_bindings.deleted_at IS NULL
+					  AND u.deleted_at IS NULL`).Error
+			})
 		},
 	}
 }

--- a/components/ambient-api-server/plugins/roleBindings/migration.go
+++ b/components/ambient-api-server/plugins/roleBindings/migration.go
@@ -93,6 +93,28 @@ func typedFKMigration() *gormigrate.Migration {
 	}
 }
 
+func userIDKSUIDMigration() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202607290001",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.Exec(`UPDATE role_bindings
+				SET user_id = u.id, updated_at = NOW()
+				FROM users u
+				WHERE role_bindings.user_id = u.username
+				  AND role_bindings.deleted_at IS NULL
+				  AND u.deleted_at IS NULL`).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Exec(`UPDATE role_bindings
+				SET user_id = u.username, updated_at = NOW()
+				FROM users u
+				WHERE role_bindings.user_id = u.id
+				  AND role_bindings.deleted_at IS NULL
+				  AND u.deleted_at IS NULL`).Error
+		},
+	}
+}
+
 func uniqueBindingMigration() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "202606050010",

--- a/components/ambient-api-server/plugins/roleBindings/plugin.go
+++ b/components/ambient-api-server/plugins/roleBindings/plugin.go
@@ -105,5 +105,6 @@ func init() {
 
 	db.RegisterMigration(migration())
 	db.RegisterMigration(typedFKMigration())
+	db.RegisterMigration(userIDKSUIDMigration())
 	db.RegisterMigration(uniqueBindingMigration())
 }

--- a/specs/platform/data-model.spec.md
+++ b/specs/platform/data-model.spec.md
@@ -1670,14 +1670,14 @@ When a runner fetches a credential, the response payload shape is consistent acr
 | `session` | `session_id` | Role applies to a specific session run |
 | `credential` | `credential_id` | Role governs access to a specific credential |
 
-`user_id` is a **separate, independently nullable FK** — it identifies the user who holds the binding when the grant is user-specific. It is null when the grant is project-level (not tied to a specific human):
+`user_id` is a **separate, independently nullable FK** referencing `users.id` (a KSUID primary key, **not** the username string). It identifies the user who holds the binding when the grant is user-specific. It is null when the grant is project-level (not tied to a specific human):
 
 | Use case | `user_id` | scope FK | Meaning |
 |---|---|---|---|
-| User A owns Credential Y | `user_id=A` | `credential_id=Y` | A can CRUD credential Y |
+| User A owns Credential Y | `user_id=<A's KSUID>` | `credential_id=Y` | A can CRUD credential Y |
 | Credential Y bound to Project X | `user_id=NULL` | `credential_id=Y` + `project_id=X` | Project X can access credential Y |
-| User A is project:owner of Project X | `user_id=A` | `project_id=X` | A owns project X |
-| Global platform:admin grant | `user_id=A` | _(none)_ | A has platform-wide admin |
+| User A is project:owner of Project X | `user_id=<A's KSUID>` | `project_id=X` | A owns project X |
+| Global platform:admin grant | `user_id=<A's KSUID>` | _(none)_ | A has platform-wide admin |
 
 For credential→project bindings, both `credential_id` and `project_id` are non-null. This is the one exception to the "single FK per row" pattern — a credential binding names both the credential (the resource) and the project (the recipient). `user_id` is null because the grant is not user-specific; it applies to the entire project.
 

--- a/specs/security/rbac-enforcement.spec.md
+++ b/specs/security/rbac-enforcement.spec.md
@@ -259,7 +259,7 @@ admins can be granted access through the API by existing admins.
 
 - GIVEN a fresh deployment with no role bindings
 - WHEN an operator runs the admin seeding CLI command with a username
-- THEN a RoleBinding is created: `role=platform:admin`, `scope=global`, `user_id=<username>`
+- THEN a RoleBinding is created: `role=platform:admin`, `scope=global`, `user_id=<user KSUID>` (resolved from `users.id`)
 - AND the admin can now manage all platform resources via the API
 
 #### Scenario: Existing admin grants new admin


### PR DESCRIPTION
## Summary

`role_bindings.user_id` stored two incompatible formats depending on the code path:
- **Username strings** (e.g. `"brandon"`) — written by API middleware, project/credential owner binding creation, and roleBindings handler authorization queries
- **KSUIDs** (e.g. `"3HBj0p9axFCf7z03P6GgpVFCb7n"`) — written by `seed-admin` CLI and `TransferOwnership`

The RBAC evaluator queried `WHERE rb.user_id = ? [username]`, so KSUID-stored bindings were invisible to authorization checks. This caused **403 errors for users whose admin bindings were created via seed-admin**.

### Changes

- **Evaluator** (`pkg/rbac/evaluator.go`): `fetchBindings` now LEFT JOINs through `users` table with `OR` fallback for legacy username entries
- **New helper** (`pkg/rbac/user_resolve.go`): shared `ResolveUserID(g, username)` function used by all write paths
- **All write paths** resolve username → KSUID before storing in `user_id`:
  - `pkg/rbac/middleware.go` — `autoProvisionServiceAccount`
  - `plugins/projects/service.go` — `createOwnerBinding`, `TransferOwnership`
  - `plugins/projects/handler.go` — `TransferOwnership` authorization query
  - `plugins/credentials/service.go` — `createOwnerBinding`
  - `plugins/roleBindings/handler.go` — Create, Patch, Delete authorization queries
- **List handlers** (`roleBindings/handler.go`): filter by both KSUID and username for migration safety
- **Data migration** (`plugins/roleBindings/migration.go`): converts existing username-stored `user_id` values to KSUIDs (idempotent — rows already storing KSUIDs are unaffected)
- **Spec updates**:
  - `specs/security/rbac-enforcement.spec.md`: seed-admin scenario now shows `user_id=<user KSUID>`
  - `specs/platform/data-model.spec.md`: clarifies `user_id` references `users.id` (KSUID), not the username string

## Test plan

- [ ] `cd components/ambient-api-server && go build ./...` passes
- [ ] Run `seed-admin --username <user>` and verify the created admin can perform gateway operations (no 403)
- [ ] Create a new project and verify the auto-created owner binding stores a KSUID in `user_id`
- [ ] Run `acpctl get rolebindings` and verify all bindings show KSUID user_ids after migration
- [ ] Verify existing bindings continue to work during migration transition (evaluator OR fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)