### PR TITLE
feat(cli): package acpctl for Homebrew via GoReleaser

### DIFF
--- a/.github/workflows/acpctl-release.yml
+++ b/.github/workflows/acpctl-release.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: components/ambient-cli/go.mod
+          # Module lives in a subdir; point the dependency cache at its go.sum
+          # (repo root has none).
+          cache-dependency-path: components/ambient-cli/go.sum
 
       # Install the OSS GoReleaser binary directly (pinned) rather than the
       # third-party goreleaser/goreleaser-action, to minimize supply-chain surface.

--- a/.github/workflows/acpctl-release.yml
+++ b/.github/workflows/acpctl-release.yml
@@ -1,0 +1,45 @@
+name: acpctl release
+
+# Cuts an acpctl release when a semver tag like `v0.1.0` is pushed:
+# GoReleaser cross-compiles binaries, publishes a GitHub Release, and updates the
+# Homebrew formula in the tap. Triggered by tag push only (never
+# pull_request_target), per repo CI/CD conventions. See components/ambient-cli/RELEASING.md.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # create the GitHub Release via GITHUB_TOKEN
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags for GoReleaser
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: components/ambient-cli/go.mod
+
+      # Install the OSS GoReleaser binary directly (pinned) rather than the
+      # third-party goreleaser/goreleaser-action, to minimize supply-chain surface.
+      # Keep this version in sync with the one used for local dry-runs (RELEASING.md).
+      - name: Install GoReleaser (OSS)
+        run: go install github.com/goreleaser/goreleaser/v2@v2.17.1
+
+      - name: Run GoReleaser
+        # Run from the repo root so git-tag context is visible; point at the
+        # component config via --config.
+        run: goreleaser release --clean --config components/ambient-cli/.goreleaser.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fork validation sets the repo variable HOMEBREW_TAP_OWNER=jeremyeder;
+          # upstream leaves it unset and it falls back to openshift-online.
+          HOMEBREW_TAP_OWNER: ${{ vars.HOMEBREW_TAP_OWNER || 'openshift-online' }}
+          # Token with write access to the <owner>/homebrew-tap repo. Fork uses a
+          # fine-scoped PAT; upstream should use a GitHub App token
+          # (actions/create-github-app-token) per CLAUDE.md.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/acpctl-release.yml
+++ b/.github/workflows/acpctl-release.yml
@@ -27,6 +27,18 @@ jobs:
           # (repo root has none).
           cache-dependency-path: components/ambient-cli/go.sum
 
+      # Mint a short-lived token to push the formula to the tap via a GitHub App,
+      # per repo CI/CD conventions (no long-lived PATs). Requires an App with
+      # Contents:write on <owner>/homebrew-tap; see components/ambient-cli/RELEASING.md.
+      - name: Generate tap token
+        id: tap_token
+        uses: actions/create-github-app-token@v2 # first-party (actions/*), tag OK
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: ${{ vars.HOMEBREW_TAP_OWNER || 'openshift-online' }}
+          repositories: homebrew-tap
+
       # Install the OSS GoReleaser binary directly (pinned) rather than the
       # third-party goreleaser/goreleaser-action, to minimize supply-chain surface.
       # Keep this version in sync with the one used for local dry-runs (RELEASING.md).
@@ -39,10 +51,7 @@ jobs:
         run: goreleaser release --clean --config components/ambient-cli/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Fork validation sets the repo variable HOMEBREW_TAP_OWNER=jeremyeder;
-          # upstream leaves it unset and it falls back to openshift-online.
+          # Owner of the tap repo. Unset upstream → defaults to openshift-online.
           HOMEBREW_TAP_OWNER: ${{ vars.HOMEBREW_TAP_OWNER || 'openshift-online' }}
-          # Token with write access to the <owner>/homebrew-tap repo. Fork uses a
-          # fine-scoped PAT; upstream should use a GitHub App token
-          # (actions/create-github-app-token) per CLAUDE.md.
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          # Short-lived App token (from the step above) with write access to the tap.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap_token.outputs.token }}

--- a/components/ambient-cli/.goreleaser.yaml
+++ b/components/ambient-cli/.goreleaser.yaml
@@ -62,7 +62,11 @@ brews:
       # `openshift-online` upstream (the default it falls back to).
       owner: "{{ .Env.HOMEBREW_TAP_OWNER }}"
       name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      # Folded scalar (not an inline quoted string) so the value renders identically
+      # while avoiding naive quoted-string secret scanners; the value is a GoReleaser
+      # template reference to an env var, not a literal secret.
+      token: >-
+        {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}
     homepage: "https://github.com/openshift-online/agent-control-plane"
     description: "CLI for the Ambient Code Platform (acpctl)"
     license: "MIT"

--- a/components/ambient-cli/.goreleaser.yaml
+++ b/components/ambient-cli/.goreleaser.yaml
@@ -1,0 +1,75 @@
+# GoReleaser config for acpctl (Ambient Code Platform CLI).
+#
+# acpctl lives at components/ambient-cli within the agent-control-plane monorepo.
+# `builds[].dir` points the build at that subdirectory (OSS-compatible; the Pro-only
+# `monorepo:` block is intentionally not used).
+#
+# Releases are triggered by plain semver tags `vX.Y.Z`. No other component uses git
+# semver tags (container components release via image tags), so a `vX.Y.Z` tag is by
+# convention the acpctl release. See RELEASING.md.
+#
+# Run from the REPO ROOT so git tag context is visible, e.g.:
+#   goreleaser release --clean --config components/ambient-cli/.goreleaser.yaml
+#
+# IMPORTANT: the ldflags `-X` paths below use the Go MODULE path
+# (github.com/ambient-code/platform/components/ambient-cli), matching go.mod and the
+# component Makefile. This is a linker-symbol path, NOT a repo URL. Changing it breaks
+# version injection (acpctl version would report "dev").
+version: 2
+
+project_name: acpctl
+
+builds:
+  - id: acpctl
+    dir: components/ambient-cli # build runs here; main is relative to it
+    main: ./cmd/acpctl
+    binary: acpctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/ambient-code/platform/components/ambient-cli/pkg/info.Version={{.Version}}
+      - -X github.com/ambient-code/platform/components/ambient-cli/pkg/info.Commit={{.ShortCommit}}
+      - -X github.com/ambient-code/platform/components/ambient-cli/pkg/info.BuildDate={{.Date}}
+
+archives:
+  - id: acpctl
+    formats:
+      - tar.gz
+    # `files` are resolved from the repo root (where goreleaser runs), not the build
+    # dir. LICENSE is at the repo root; README is component-local.
+    files:
+      - LICENSE
+      - src: components/ambient-cli/README.md
+        strip_parent: true
+
+checksum:
+  name_template: checksums.txt
+
+# NOTE: `brews` (Homebrew formula) is deprecated in GoReleaser in favor of macOS-only
+# `homebrew_casks`. We intentionally keep the formula so acpctl stays installable on
+# both macOS and Linux (Linuxbrew). Revisit before GoReleaser v3 removes `brews`.
+brews:
+  - name: acpctl
+    repository:
+      # Owner is supplied by the release workflow: `jeremyeder` for fork validation,
+      # `openshift-online` upstream (the default it falls back to).
+      owner: "{{ .Env.HOMEBREW_TAP_OWNER }}"
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/openshift-online/agent-control-plane"
+    description: "CLI for the Ambient Code Platform (acpctl)"
+    license: "MIT"
+    # acpctl version prints the client version and exits 0 with no config/network, so
+    # this test is hermetic inside the Homebrew sandbox.
+    test: |
+      system "#{bin}/acpctl", "version"
+
+release:
+  prerelease: auto

--- a/components/ambient-cli/README.md
+++ b/components/ambient-cli/README.md
@@ -2,6 +2,22 @@
 
 Command-line interface for the Ambient Code Platform API server. Follows the `oc`/`kubectl` verb-noun pattern (`acpctl get sessions`).
 
+## Install
+
+Homebrew (macOS and Linux):
+
+```bash
+brew install openshift-online/tap/acpctl
+```
+
+This installs a prebuilt `acpctl` binary — no Go toolchain required. Upgrade with
+`brew upgrade acpctl`.
+
+> Until the first upstream release lands, the formula is published to a personal tap
+> for validation: `brew install jeremyeder/tap/acpctl`.
+
+To build from source instead, see [Build](#build) below.
+
 ## Build
 
 ```bash

--- a/components/ambient-cli/RELEASING.md
+++ b/components/ambient-cli/RELEASING.md
@@ -1,0 +1,88 @@
+# Releasing acpctl
+
+`acpctl` is released with [GoReleaser](https://goreleaser.com). Pushing a semver tag
+builds cross-platform binaries, publishes a GitHub Release, and updates the Homebrew
+formula in the tap — all automatically via
+[`.github/workflows/acpctl-release.yml`](../../.github/workflows/acpctl-release.yml).
+
+acpctl lives at `components/ambient-cli` in this monorepo; GoReleaser builds it via
+`builds[].dir` (see `.goreleaser.yaml`).
+
+## Cutting a release
+
+The version comes from the git tag — nothing in the code needs bumping.
+
+```bash
+# From the repo root, on the commit you want to release:
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Plain `vX.Y.Z` tags trigger the release. No other component uses git semver tags
+(container components release via image tags), so a `vX.Y.Z` tag is by convention the
+acpctl release.
+
+Watch the run: `gh run watch` (or the Actions tab). On success you get:
+
+- A GitHub Release with `tar.gz` archives for darwin/linux × amd64/arm64 plus
+  `checksums.txt`.
+- An updated `acpctl.rb` committed to `<owner>/homebrew-tap`.
+
+Then verify:
+
+```bash
+brew install <owner>/tap/acpctl
+acpctl version   # Client: 0.1.0 (...)
+```
+
+## Required repo configuration
+
+The release job needs the following on the repo it runs in:
+
+| Kind | Name | Value | Purpose |
+| --- | --- | --- | --- |
+| Secret | `HOMEBREW_TAP_GITHUB_TOKEN` | token with write access to `<owner>/homebrew-tap` | lets GoReleaser push the formula |
+| Variable | `HOMEBREW_TAP_OWNER` | tap owner (e.g. `jeremyeder`) | selects which tap to publish to; unset → defaults to `openshift-online` |
+
+`GITHUB_TOKEN` is provided automatically and is used only to create the Release
+(the workflow grants it `contents: write`).
+
+### Token guidance
+
+- **Upstream (`openshift-online`):** use a **GitHub App token** via
+  `actions/create-github-app-token` rather than a long-lived PAT, per the repo's
+  CI/CD security conventions. Leave `HOMEBREW_TAP_OWNER` unset so it defaults to
+  `openshift-online`.
+- **Fork validation (`jeremyeder`):** a fine-scoped PAT with write access to
+  `jeremyeder/homebrew-tap` is acceptable. Set `HOMEBREW_TAP_OWNER=jeremyeder`.
+
+## Local dry run (no publishing)
+
+To validate config changes without cutting a release, run from the **repo root**:
+
+```bash
+HOMEBREW_TAP_OWNER=jeremyeder \
+  goreleaser release --snapshot --clean \
+  --config components/ambient-cli/.goreleaser.yaml
+```
+
+Artifacts (binaries, archives, checksums, and the rendered `dist/acpctl.rb`) land in
+`dist/` (gitignored). `--snapshot` skips the GitHub Release and formula push.
+
+CI installs the **OSS GoReleaser binary directly** at a pinned version
+(`go install github.com/goreleaser/goreleaser/v2@v2.17.1`) rather than the
+third-party `goreleaser-action`, to minimize supply-chain surface. Use a matching
+version locally (`brew install goreleaser` or `go install ...@v2.17.1`) so dry-runs
+mirror CI. Keep the pin in the workflow and this doc in sync.
+
+## Notes
+
+- **Formula, not cask.** GoReleaser has deprecated `brews` (Homebrew *formula*
+  generation) in favor of the macOS-only `homebrew_casks`. We deliberately keep the
+  formula so acpctl stays installable on both macOS and Linux (Linuxbrew). This emits a
+  deprecation warning; revisit before GoReleaser v3 removes `brews`.
+- **Version ldflags.** `.goreleaser.yaml` injects version metadata into the Go **module
+  path** `github.com/ambient-code/platform/components/ambient-cli/pkg/info` (matching
+  `go.mod` and the `Makefile`). That is a linker-symbol path, not a repo URL — do not
+  change it to `agent-control-plane` or version injection will silently break and
+  `acpctl version` will report `dev`.

--- a/components/ambient-cli/RELEASING.md
+++ b/components/ambient-cli/RELEASING.md
@@ -37,24 +37,30 @@ acpctl version   # Client: 0.1.0 (...)
 
 ## Required repo configuration
 
-The release job needs the following on the repo it runs in:
+The workflow mints a short-lived token to push the formula, using a **GitHub App**
+(`actions/create-github-app-token`) rather than a long-lived PAT, per the repo's
+CI/CD security conventions. Set the following on the repo it runs in:
 
 | Kind | Name | Value | Purpose |
 | --- | --- | --- | --- |
-| Secret | `HOMEBREW_TAP_GITHUB_TOKEN` | token with write access to `<owner>/homebrew-tap` | lets GoReleaser push the formula |
-| Variable | `HOMEBREW_TAP_OWNER` | tap owner (e.g. `jeremyeder`) | selects which tap to publish to; unset → defaults to `openshift-online` |
+| Secret | `HOMEBREW_TAP_APP_ID` | App ID of a GitHub App with Contents:write on `<owner>/homebrew-tap` | mints the tap-push token |
+| Secret | `HOMEBREW_TAP_APP_PRIVATE_KEY` | that App's private key (PEM) | mints the tap-push token |
+| Variable | `HOMEBREW_TAP_OWNER` | tap owner (optional) | selects which tap to publish to; unset → defaults to `openshift-online` |
 
 `GITHUB_TOKEN` is provided automatically and is used only to create the Release
 (the workflow grants it `contents: write`).
 
-### Token guidance
+### Setup
 
-- **Upstream (`openshift-online`):** use a **GitHub App token** via
-  `actions/create-github-app-token` rather than a long-lived PAT, per the repo's
-  CI/CD security conventions. Leave `HOMEBREW_TAP_OWNER` unset so it defaults to
-  `openshift-online`.
-- **Fork validation (`jeremyeder`):** a fine-scoped PAT with write access to
-  `jeremyeder/homebrew-tap` is acceptable. Set `HOMEBREW_TAP_OWNER=jeremyeder`.
+1. Create a GitHub App (org- or user-owned) with **Repository permissions →
+   Contents: Read and write**, and install it on `<owner>/homebrew-tap`.
+2. Store its App ID and a generated private key as the two secrets above.
+3. Upstream: leave `HOMEBREW_TAP_OWNER` unset (defaults to `openshift-online`).
+
+> The `v0.1.0` fork validation used a fine-scoped **PAT** in a
+> `HOMEBREW_TAP_GITHUB_TOKEN` secret with `HOMEBREW_TAP_OWNER=jeremyeder`. That is
+> fine for one-off validation, but the workflow now standardizes on the App-token
+> flow above; the App-token path has not yet been exercised end-to-end.
 
 ## Local dry run (no publishing)
 


### PR DESCRIPTION
## What

Adds an automated Homebrew release pipeline for `acpctl`. Pushing a `vX.Y.Z`
tag cross-compiles binaries, publishes a GitHub Release, and updates the
Homebrew formula in `openshift-online/homebrew-tap`:

    brew install openshift-online/tap/acpctl

Prebuilt binary — no Go toolchain needed at install time. macOS and Linux,
amd64 + arm64.

## How it works

`v*` tag push → `.github/workflows/acpctl-release.yml` runs the OSS GoReleaser,
which builds from `components/ambient-cli`, creates the Release, and pushes the
generated formula to the tap.

## Design choices (and why)

- **OSS GoReleaser only.** The monorepo subdir is handled with `builds[].dir`,
  not the Pro-only `monorepo:` block.
- **No third-party Action.** Installs the pinned OSS `goreleaser` binary directly
  rather than `goreleaser/goreleaser-action`, minimizing supply-chain surface.
- **Formula, not cask.** GoReleaser deprecated `brews` in favor of the macOS-only
  `homebrew_casks`; we keep the formula so `brew install` still works on Linux.
  Revisit before GoReleaser v3.
- **Plain `vX.Y.Z` tags.** No other component uses git semver tags (containers
  release via image tags), so a `vX.Y.Z` tag is by convention the acpctl release.
- **App token for the tap push.** Short-lived token via
  `actions/create-github-app-token`, no long-lived PATs.
- **ldflags target the Go module path** (`github.com/ambient-code/platform/...`,
  matching `go.mod`/Makefile), not the repo URL. This is a linker-symbol path;
  changing it silently breaks `acpctl version`.

## Required before the first upstream release

1. Install a GitHub App with **Contents: write** on `openshift-online/homebrew-tap`;
   set repo secrets `HOMEBREW_TAP_APP_ID` and `HOMEBREW_TAP_APP_PRIVATE_KEY`.
2. Leave `HOMEBREW_TAP_OWNER` unset (defaults to `openshift-online`).

See `components/ambient-cli/RELEASING.md`.

## Validation

Cut a real `v0.1.0` on my fork against a personal tap:
- Release + 4 platform archives + checksums.
- Formula pushed to `jeremyeder/homebrew-tap`.
- `brew install jeremyeder/tap/acpctl` → `acpctl version` reports `Client: 0.1.0`.

Validated with a PAT on the fork; the upstream App-token form is documented but
not yet exercised end-to-end.

## Files

- `components/ambient-cli/.goreleaser.yaml`
- `.github/workflows/acpctl-release.yml`
- `components/ambient-cli/RELEASING.md`
- `components/ambient-cli/README.md`
