### PR TITLE
fix(acpctl): stop false token-expiry warning and honor insecure TLS on refresh

### DIFF
--- a/components/ambient-cli/cmd/acpctl/login/cmd.go
+++ b/components/ambient-cli/cmd/acpctl/login/cmd.go
@@ -3,6 +3,7 @@ package login
 
 import (
 	"fmt"
+	"io"
 	"net/url"
 	"time"
 
@@ -165,12 +166,31 @@ func run(cmd *cobra.Command, positional []string) error {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: TLS certificate verification is disabled (--insecure-skip-tls-verify)")
 	}
 
-	if exp, err := config.TokenExpiry(accessToken); err == nil && !exp.IsZero() {
-		if time.Until(exp) < 0 {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: token is already expired (at %s)\n", exp.Format(time.RFC3339))
-		} else if time.Until(exp) < 24*time.Hour {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: token expires soon (at %s)\n", exp.Format(time.RFC3339))
-		}
-	}
+	writeTokenExpiryNotice(cmd.OutOrStdout(), cmd.ErrOrStderr(), cfg.RefreshToken != "", accessToken, time.Now())
 	return nil
+}
+
+// writeTokenExpiryNotice reports on access-token lifetime after login.
+//
+// When a refresh token is stored, the short access-token lifespan is expected
+// and handled transparently (the CLI refreshes on demand), so we print a
+// reassuring informational line rather than a warning. Only when there is no
+// refresh token does a short lifespan genuinely mean the user must re-login,
+// in which case we warn.
+func writeTokenExpiryNotice(out, errOut io.Writer, hasRefreshToken bool, accessToken string, now time.Time) {
+	if hasRefreshToken {
+		fmt.Fprintln(out, "Access tokens are refreshed automatically using the stored refresh token.")
+		return
+	}
+
+	exp, err := config.TokenExpiry(accessToken)
+	if err != nil || exp.IsZero() {
+		return
+	}
+
+	if now.After(exp) {
+		fmt.Fprintf(errOut, "Warning: token is already expired (at %s)\n", exp.Format(time.RFC3339))
+	} else if exp.Sub(now) < 24*time.Hour {
+		fmt.Fprintf(errOut, "Warning: token expires soon (at %s)\n", exp.Format(time.RFC3339))
+	}
 }

--- a/components/ambient-cli/cmd/acpctl/login/expiry_notice_test.go
+++ b/components/ambient-cli/cmd/acpctl/login/expiry_notice_test.go
@@ -1,0 +1,95 @@
+package login
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// mintToken builds an unsigned JWT carrying the given exp claim. TokenExpiry
+// parses claims without verifying the signature, so an unsigned token is enough.
+func mintToken(t *testing.T, exp time.Time) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{"exp": exp.Unix()})
+	s, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	return s
+}
+
+func TestWriteTokenExpiryNotice(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		hasRefreshToken bool
+		accessToken     string
+		wantOut         string // substring expected on stdout ("" = expect empty)
+		wantErr         string // substring expected on stderr ("" = expect empty)
+	}{
+		{
+			name:            "refresh token present suppresses expiry warning",
+			hasRefreshToken: true,
+			accessToken:     "", // token irrelevant when a refresh token exists
+			wantOut:         "refreshed automatically",
+			wantErr:         "",
+		},
+		{
+			name:            "short-lived token without refresh token still warns",
+			hasRefreshToken: false,
+			accessToken:     "", // set per-case below
+			wantErr:         "expires soon",
+		},
+		{
+			name:            "expired token without refresh token warns expired",
+			hasRefreshToken: false,
+			accessToken:     "", // set per-case below
+			wantErr:         "already expired",
+		},
+		{
+			name:            "opaque non-JWT token stays silent",
+			hasRefreshToken: false,
+			accessToken:     "sha256~abc123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			token := tc.accessToken
+			switch {
+			case strings.Contains(tc.name, "short-lived"):
+				token = mintToken(t, now.Add(5*time.Minute))
+			case strings.Contains(tc.name, "expired token"):
+				token = mintToken(t, now.Add(-5*time.Minute))
+			}
+
+			var out, errOut bytes.Buffer
+			writeTokenExpiryNotice(&out, &errOut, tc.hasRefreshToken, token, now)
+
+			checkContains(t, "stdout", out.String(), tc.wantOut)
+			checkContains(t, "stderr", errOut.String(), tc.wantErr)
+
+			// The reassuring info line must never be a scary warning.
+			if tc.hasRefreshToken && strings.Contains(out.String()+errOut.String(), "Warning") {
+				t.Errorf("did not expect a warning when a refresh token is present, got out=%q err=%q", out.String(), errOut.String())
+			}
+		})
+	}
+}
+
+func checkContains(t *testing.T, stream, got, want string) {
+	t.Helper()
+	if want == "" {
+		if got != "" {
+			t.Errorf("expected empty %s, got %q", stream, got)
+		}
+		return
+	}
+	if !strings.Contains(got, want) {
+		t.Errorf("expected %s to contain %q, got %q", stream, want, got)
+	}
+}

--- a/components/ambient-cli/pkg/config/config.go
+++ b/components/ambient-cli/pkg/config/config.go
@@ -130,7 +130,7 @@ func (c *Config) GetTokenWithRefresh() (string, error) {
 		return c.AccessToken, nil
 	}
 
-	newAccess, newRefresh, refreshErr := RefreshAccessToken(c.IssuerURL, c.ClientID, c.RefreshToken)
+	newAccess, newRefresh, refreshErr := RefreshAccessToken(c.IssuerURL, c.ClientID, c.RefreshToken, c.InsecureTLSVerify)
 	if refreshErr != nil {
 		return c.AccessToken, nil
 	}

--- a/components/ambient-cli/pkg/config/token.go
+++ b/components/ambient-cli/pkg/config/token.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -52,7 +53,7 @@ func IsTokenExpired(tokenStr string) (bool, error) {
 	return time.Now().After(expiry), nil
 }
 
-func RefreshAccessToken(issuerURL, clientID, refreshToken string) (accessToken, newRefreshToken string, err error) {
+func RefreshAccessToken(issuerURL, clientID, refreshToken string, insecureTLSVerify bool) (accessToken, newRefreshToken string, err error) {
 	tokenURL := strings.TrimRight(issuerURL, "/") + "/protocol/openid-connect/token"
 
 	params := url.Values{
@@ -62,6 +63,14 @@ func RefreshAccessToken(issuerURL, clientID, refreshToken string) (accessToken, 
 	}
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
+	if insecureTLSVerify {
+		// Honor the same opt-in as the SDK client (--insecure-skip-tls-verify /
+		// insecure_tls_verify). Without this, token refresh fails against issuers
+		// with untrusted certs even though the user explicitly disabled verification.
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // G402: opt-in via insecure_tls_verify
+		}
+	}
 	resp, err := httpClient.PostForm(tokenURL, params)
 	if err != nil {
 		return "", "", fmt.Errorf("POST to token endpoint: %w", err)

--- a/components/ambient-cli/pkg/config/token_test.go
+++ b/components/ambient-cli/pkg/config/token_test.go
@@ -124,7 +124,7 @@ func TestRefreshAccessToken_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	access, refresh, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh-token")
+	access, refresh, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh-token", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestRefreshAccessToken_ErrorResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := RefreshAccessToken(srv.URL, "test-client", "bad-refresh")
+	_, _, err := RefreshAccessToken(srv.URL, "test-client", "bad-refresh", false)
 	if err == nil {
 		t.Fatal("expected error for expired refresh token")
 	}
@@ -157,9 +157,36 @@ func TestRefreshAccessToken_NoAccessToken(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh")
+	_, _, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh", false)
 	if err == nil {
 		t.Fatal("expected error for missing access_token")
+	}
+}
+
+func TestRefreshAccessToken_InsecureTLS(t *testing.T) {
+	newAccessToken := makeJWT(jwt.MapClaims{"exp": float64(time.Now().Add(1 * time.Hour).Unix())})
+	// TLS server with a self-signed cert the client does not trust by default.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":%q,"refresh_token":"new-refresh"}`, newAccessToken)
+	}))
+	defer srv.Close()
+
+	// Verification enabled: the untrusted cert must cause failure.
+	if _, _, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh", false); err == nil {
+		t.Fatal("expected TLS verification failure against self-signed cert")
+	}
+
+	// Verification disabled (opt-in): refresh must succeed.
+	access, refresh, err := RefreshAccessToken(srv.URL, "test-client", "my-refresh", true)
+	if err != nil {
+		t.Fatalf("unexpected error with insecure TLS: %v", err)
+	}
+	if access != newAccessToken {
+		t.Error("access token mismatch")
+	}
+	if refresh != "new-refresh" {
+		t.Errorf("expected new-refresh, got %q", refresh)
 	}
 }
 


### PR DESCRIPTION
## Problem
After `acpctl login --use-auth-code`, the CLI printed `Warning: token expires soon` on **every** login. The threshold is 24h (`login/cmd.go`), but OIDC access tokens are intentionally short-lived (~5 min) and auto-refreshed via the stored refresh token — so the warning was a false alarm that reads as "your login is about to break."

While investigating, found a latent bug in the refresh path: `RefreshAccessToken` built a plain `http.Client` that **ignored `insecure_tls_verify`**, so silent refresh fails against issuers with untrusted certs even when the user opted out of verification (e.g. self-hosted Keycloak on a cluster route). Both are in the CLI auth/token subsystem and ship together.

## Changes
- **Login message**: gate the expiry warning on there being **no** refresh token. When a refresh token is stored, print an informational line instead (`Access tokens are refreshed automatically using the stored refresh token.`). Extracted into a testable `writeTokenExpiryNotice` helper. `login/cmd.go` + new `expiry_notice_test.go`.
- **TLS on refresh**: `RefreshAccessToken` now takes `insecureTLSVerify bool` and builds the transport with `InsecureSkipVerify` when set, threaded from `cfg.InsecureTLSVerify` in `GetTokenWithRefresh`. `pkg/config/token.go` + `config.go`.

## Security note
The `InsecureSkipVerify` branch is **opt-in and off by default** — gated behind the pre-existing `insecure_tls_verify` config / `--insecure-skip-tls-verify` flag that the SDK client (`pkg/connection`) already honors via `WithInsecureSkipVerify()`. This change only makes the refresh path consistent with that existing, user-controlled behavior; it does not add a new capability or change defaults. `//nolint:gosec` is scoped to that line with justification.

## Testing
- `gofmt`, `go vet`, `golangci-lint run` (0 issues) on changed packages
- `go test ./pkg/config/... ./cmd/acpctl/login/...` — pass
- New tests: refresh-present / expires-soon / already-expired / opaque-token; insecure-TLS success vs verification failure against a self-signed `httptest.NewTLSServer`.