### PR TITLE
ENGPROD-10220 - fix pre-commit hook golangci-lint to work on macOS

### DIFF
--- a/scripts/pre-commit/golangci-lint.sh
+++ b/scripts/pre-commit/golangci-lint.sh
@@ -20,21 +20,28 @@ GO_MODULES=(
 )
 
 # Determine which modules are affected by the staged files
-declare -A affected_modules=()
+affected_modules=""
 for file in "$@"; do
     for mod in "${GO_MODULES[@]}"; do
         if [[ "$file" == "$mod/"* || "$file" == "$REPO_ROOT/$mod/"* ]]; then
-            affected_modules["$mod"]=1
+            case "$affected_modules" in
+                *"|$mod|"*) ;;
+                *) affected_modules="${affected_modules}|${mod}|" ;;
+            esac
         fi
     done
 done
 
-if [ ${#affected_modules[@]} -eq 0 ]; then
+if [ -z "$affected_modules" ]; then
     exit 0
 fi
 
 exit_code=0
-for mod in "${!affected_modules[@]}"; do
+for mod in "${GO_MODULES[@]}"; do
+    case "$affected_modules" in
+        *"|$mod|"*) ;;
+        *) continue ;;
+    esac
     mod_dir="$REPO_ROOT/$mod"
     if [ -f "$mod_dir/go.mod" ]; then
         echo "golangci-lint: $mod"


### PR DESCRIPTION
## Summary

  - Replace `declare -A` associative array with a delimited-string pattern for tracking affected Go modules
  - `declare -A` is a bash 4+ feature; macOS ships bash 3.2 by default, causing the hook to fail on every commit
  for Mac developers

  ## Test plan

  - [ ] Run `git commit` touching a Go file on macOS — hook runs and lints only the affected module
  - [ ] Run `git commit` touching a Go file on Linux — no regression
  - [ ] Run `git commit` with no Go files — hook exits 0 (skips)