### PR TITLE
docs(deploy): document gateway-trusted-ca for OpenShift OIDC

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/gateway_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/gateway_reconciler.go
@@ -69,6 +69,7 @@ var networkPolicyGVR = schema.GroupVersionResource{
 	Resource: "networkpolicies",
 }
 
+// Cross-ref: docs/internal/deployment/OPENSHIFT_DEPLOY.md § "Gateway Trusted CA"
 const (
 	trustedCAConfigMapName = "gateway-trusted-ca"
 	trustedCAKey           = "ca-bundle.crt"

--- a/docs/internal/deployment/OPENSHIFT_DEPLOY.md
+++ b/docs/internal/deployment/OPENSHIFT_DEPLOY.md
@@ -110,6 +110,20 @@ oc logs -l app.kubernetes.io/name=openshell -n <tenant-namespace> | grep -i oidc
 > **Note:** If the cluster's ingress CA rotates, update the `gateway-trusted-ca`
 > ConfigMap and restart the gateway pods.
 
+### Sandbox SCC (Required on OpenShift)
+
+When a namespace that will host gateway sandboxes is created on OpenShift, the
+`openshell-sandbox` service account must be granted the `privileged` SCC. Without
+this, sandbox pods will fail to start due to insufficient permissions.
+
+```bash
+oc adm policy add-scc-to-user privileged -z openshell-sandbox -n <namespace>
+```
+
+Run this once per tenant namespace. See the
+[NVIDIA OpenShell docs](https://docs.nvidia.com/openshell/kubernetes/openshift#grant-the-privileged-scc-to-sandbox-pods)
+for details.
+
 ### Setting up API Keys
 After deployment, configure runner secrets through Settings → Runner Secrets in the UI. At minimum, provide `ANTHROPIC_API_KEY`.
 

--- a/docs/internal/deployment/OPENSHIFT_DEPLOY.md
+++ b/docs/internal/deployment/OPENSHIFT_DEPLOY.md
@@ -67,7 +67,8 @@ pods must trust the CA that signed the OIDC issuer's TLS certificate. On OpenShi
 Routes use certificates signed by the cluster's ingress CA, which is not present in
 the gateway's minimal container image.
 
-The control plane looks for a ConfigMap named `gateway-trusted-ca` in the
+The control plane looks for a ConfigMap named `gateway-trusted-ca` (defined in
+`components/ambient-control-plane/internal/reconciler/gateway_reconciler.go`) in the
 `ambient-code` namespace. If found, it automatically copies the CA bundle to each
 tenant namespace and mounts it into gateway pods via the `SSL_CERT_FILE` environment
 variable.
@@ -80,7 +81,10 @@ JWKS fetch failed: error sending request for url (https://<keycloak-route>/...ce
 
 **Create the ConfigMap:**
 ```bash
-# Extract the OpenShift ingress CA (signs *.apps.<cluster> Route certificates)
+# Extract the OpenShift ingress CA (signs *.apps.<cluster> Route certificates).
+# On ROSA with STS or other managed OCP variants, router-ca may not exist in
+# openshift-config-managed. Check `oc get configmap -n openshift-config-managed`
+# and use whichever ConfigMap holds the ingress CA for your variant.
 oc get configmap router-ca -n openshift-config-managed \
   -o jsonpath='{.data.ca-bundle\.crt}' > /tmp/ca-bundle.crt
 

--- a/docs/internal/deployment/OPENSHIFT_DEPLOY.md
+++ b/docs/internal/deployment/OPENSHIFT_DEPLOY.md
@@ -60,6 +60,56 @@ oc apply -k components/manifests/overlays/<your-overlay>
 ### Advanced Configuration
 Customize your deployment by editing overlay-specific patches and `kustomization.yaml` files under `components/manifests/overlays/<your-overlay>/`. See `components/manifests/env.example` for the list of configurable values.
 
+### Gateway Trusted CA (Required for OIDC)
+
+When gateways are configured with OIDC authentication (e.g., Keycloak), the gateway
+pods must trust the CA that signed the OIDC issuer's TLS certificate. On OpenShift,
+Routes use certificates signed by the cluster's ingress CA, which is not present in
+the gateway's minimal container image.
+
+The control plane looks for a ConfigMap named `gateway-trusted-ca` in the
+`ambient-code` namespace. If found, it automatically copies the CA bundle to each
+tenant namespace and mounts it into gateway pods via the `SSL_CERT_FILE` environment
+variable.
+
+**Without this ConfigMap, gateway OIDC will fail** with:
+```
+OIDC key refresh failed
+JWKS fetch failed: error sending request for url (https://<keycloak-route>/...certs)
+```
+
+**Create the ConfigMap:**
+```bash
+# Extract the OpenShift ingress CA (signs *.apps.<cluster> Route certificates)
+oc get configmap router-ca -n openshift-config-managed \
+  -o jsonpath='{.data.ca-bundle\.crt}' > /tmp/ca-bundle.crt
+
+# Create the ConfigMap the control plane expects
+oc create configmap gateway-trusted-ca \
+  --from-file=ca-bundle.crt=/tmp/ca-bundle.crt \
+  -n ambient-code
+```
+
+The next gateway reconcile cycle will pick up the ConfigMap and roll out updated
+gateway pods. To force an immediate update, delete the gateway pod in the tenant
+namespace:
+```bash
+oc delete pod -l app.kubernetes.io/name=openshell -n <tenant-namespace>
+```
+
+**Verify it worked:**
+```bash
+# Confirm the CA is mounted
+oc get pod -l app.kubernetes.io/name=openshell -n <tenant-namespace> -o json \
+  | jq '.items[0].spec.containers[0].env[] | select(.name == "SSL_CERT_FILE")'
+
+# Check gateway logs for successful OIDC
+oc logs -l app.kubernetes.io/name=openshell -n <tenant-namespace> | grep -i oidc
+```
+
+> **Note:** If the cluster's ingress CA rotates, update the `gateway-trusted-ca`
+> ConfigMap and restart the gateway pods.
+
 ### Setting up API Keys
 After deployment, configure runner secrets through Settings → Runner Secrets in the UI. At minimum, provide `ANTHROPIC_API_KEY`.
 
@@ -67,6 +117,16 @@ After deployment, configure runner secrets through Settings → Runner Secrets i
 For cluster login via OAuth proxy sidecar, see [OpenShift OAuth Setup](OPENSHIFT_OAUTH.md).
 
 For new deployments, SSO/OIDC via Keycloak is recommended instead. See `specs/security/sso-authentication.spec.md`.
+
+## Troubleshooting
+
+### Gateway OIDC: "OIDC key refresh failed"
+
+**Symptom:** Control plane logs show `provisioning failed` with `OIDC key refresh failed` for sessions using gateway mode.
+
+**Cause:** The gateway pod cannot verify the Keycloak Route's TLS certificate because the OpenShift ingress CA is not in the gateway container's trust store.
+
+**Fix:** Create the `gateway-trusted-ca` ConfigMap — see [Gateway Trusted CA](#gateway-trusted-ca-required-for-oidc) above.
 
 ## Cleanup
 

--- a/docs/internal/deployment/OPENSHIFT_DEPLOY.md
+++ b/docs/internal/deployment/OPENSHIFT_DEPLOY.md
@@ -120,7 +120,12 @@ this, sandbox pods will fail to start due to insufficient permissions.
 oc adm policy add-scc-to-user privileged -z openshell-sandbox -n <namespace>
 ```
 
-Run this once per tenant namespace. See the
+Run this once per tenant namespace. The ACP control plane automatically creates
+the required RoleBinding for the `openshell-sandbox` service account when a
+gateway is provisioned in a namespace, so manual intervention is only needed if
+you are pre-creating namespaces before gateway provisioning.
+
+See the
 [NVIDIA OpenShell docs](https://docs.nvidia.com/openshell/kubernetes/openshift#grant-the-privileged-scc-to-sandbox-pods)
 for details.
 

--- a/docs/internal/deployment/README.md
+++ b/docs/internal/deployment/README.md
@@ -10,6 +10,7 @@ Guides for deploying the Ambient Code Platform to various environments.
 - **SSO Migration** - Keycloak SSO/OIDC authentication (see `specs/security/sso-authentication.spec.md`)
 
 ### Configuration
+- **[Gateway Trusted CA](OPENSHIFT_DEPLOY.md#gateway-trusted-ca-required-for-oidc)** - Ingress CA for gateway OIDC on OpenShift
 - **[Git Authentication](git-authentication.md)** - Configure Git credentials for runners
 - **[GitHub App Setup](../GITHUB_APP_SETUP.md)** - GitHub App integration
 


### PR DESCRIPTION
## Summary
- Documents the required `gateway-trusted-ca` ConfigMap setup for OpenShift clusters using gateway OIDC (Keycloak)
- Adds troubleshooting entry for the "OIDC key refresh failed" / "JWKS fetch failed" error
- Documents the privileged SCC requirement for sandbox pods on OpenShift
- Updates deployment README index with links to the new sections

## Context

**gateway-trusted-ca (8c56a6c4)**

On OpenShift, the gateway container image (scratch/distroless) has no system CA bundle. When OIDC is configured against a Keycloak instance exposed via an OpenShift Route, the gateway cannot complete the TLS handshake to fetch JWKS keys — the ingress CA that signed the Route's certificate is not trusted.

The control plane already supports injecting a trusted CA via the `gateway-trusted-ca` ConfigMap (`SSL_CERT_FILE` + volume mount), but this prerequisite was undocumented.

**privileged SCC for sandbox pods (facf4638)**

On OpenShift, the `openshell-sandbox` service account needs the privileged SCC in each tenant namespace or sandbox pods fail to start. This requirement was undocumented.

## Test plan
- [ ] Verify the `oc get configmap router-ca` command works on a ROSA/OCP cluster
- [ ] Confirm the ConfigMap name (`gateway-trusted-ca`) and key (`ca-bundle.crt`) match the constants in `gateway_reconciler.go`
- [ ] Verify the `oc adm policy` command for the privileged SCC works on a ROSA/OCP cluster
- [ ] Verify links in the deployment README resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)