### PR TITLE
fix(api-server): regenerate protobuf files after module rename

### DIFF
--- a/components/ambient-api-server/pkg/api/grpc/ambient/v1/common.pb.go
+++ b/components/ambient-api-server/pkg/api/grpc/ambient/v1/common.pb.go
@@ -323,7 +323,7 @@ const file_ambient_v1_common_proto_rawDesc = "" +
 	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12EVENT_TYPE_CREATED\x10\x01\x12\x16\n" +
 	"\x12EVENT_TYPE_UPDATED\x10\x02\x12\x16\n" +
-	"\x12EVENT_TYPE_DELETED\x10\x03BcZagithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
+	"\x12EVENT_TYPE_DELETED\x10\x03BrZpgithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
 
 var (
 	file_ambient_v1_common_proto_rawDescOnce sync.Once

--- a/components/ambient-api-server/pkg/api/grpc/ambient/v1/inbox.pb.go
+++ b/components/ambient-api-server/pkg/api/grpc/ambient/v1/inbox.pb.go
@@ -190,7 +190,7 @@ const file_ambient_v1_inbox_proto_rawDesc = "" +
 	"\x19WatchInboxMessagesRequest\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId2g\n" +
 	"\fInboxService\x12W\n" +
-	"\x12WatchInboxMessages\x12%.ambient.v1.WatchInboxMessagesRequest\x1a\x18.ambient.v1.InboxMessage0\x01BcZagithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
+	"\x12WatchInboxMessages\x12%.ambient.v1.WatchInboxMessagesRequest\x1a\x18.ambient.v1.InboxMessage0\x01BrZpgithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
 
 var (
 	file_ambient_v1_inbox_proto_rawDescOnce sync.Once

--- a/components/ambient-api-server/pkg/api/grpc/ambient/v1/project_settings.pb.go
+++ b/components/ambient-api-server/pkg/api/grpc/ambient/v1/project_settings.pb.go
@@ -594,7 +594,7 @@ const file_ambient_v1_project_settings_proto_rawDesc = "" +
 	"\x15UpdateProjectSettings\x12(.ambient.v1.UpdateProjectSettingsRequest\x1a\x1b.ambient.v1.ProjectSettings\x12l\n" +
 	"\x15DeleteProjectSettings\x12(.ambient.v1.DeleteProjectSettingsRequest\x1a).ambient.v1.DeleteProjectSettingsResponse\x12f\n" +
 	"\x13ListProjectSettings\x12&.ambient.v1.ListProjectSettingsRequest\x1a'.ambient.v1.ListProjectSettingsResponse\x12h\n" +
-	"\x14WatchProjectSettings\x12'.ambient.v1.WatchProjectSettingsRequest\x1a%.ambient.v1.ProjectSettingsWatchEvent0\x01BcZagithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
+	"\x14WatchProjectSettings\x12'.ambient.v1.WatchProjectSettingsRequest\x1a%.ambient.v1.ProjectSettingsWatchEvent0\x01BrZpgithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
 
 var (
 	file_ambient_v1_project_settings_proto_rawDescOnce sync.Once

--- a/components/ambient-api-server/pkg/api/grpc/ambient/v1/projects.pb.go
+++ b/components/ambient-api-server/pkg/api/grpc/ambient/v1/projects.pb.go
@@ -676,7 +676,7 @@ const file_ambient_v1_projects_proto_rawDesc = "" +
 	"\rUpdateProject\x12 .ambient.v1.UpdateProjectRequest\x1a\x13.ambient.v1.Project\x12T\n" +
 	"\rDeleteProject\x12 .ambient.v1.DeleteProjectRequest\x1a!.ambient.v1.DeleteProjectResponse\x12Q\n" +
 	"\fListProjects\x12\x1f.ambient.v1.ListProjectsRequest\x1a .ambient.v1.ListProjectsResponse\x12R\n" +
-	"\rWatchProjects\x12 .ambient.v1.WatchProjectsRequest\x1a\x1d.ambient.v1.ProjectWatchEvent0\x01BcZagithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
+	"\rWatchProjects\x12 .ambient.v1.WatchProjectsRequest\x1a\x1d.ambient.v1.ProjectWatchEvent0\x01BrZpgithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
 
 var (
 	file_ambient_v1_projects_proto_rawDescOnce sync.Once

--- a/components/ambient-api-server/pkg/api/grpc/ambient/v1/sessions.pb.go
+++ b/components/ambient-api-server/pkg/api/grpc/ambient/v1/sessions.pb.go
@@ -1823,7 +1823,7 @@ const file_ambient_v1_sessions_proto_rawDesc = "" +
 	"\x12PushSessionMessage\x12%.ambient.v1.PushSessionMessageRequest\x1a\x1a.ambient.v1.SessionMessage\x12]\n" +
 	"\x14WatchSessionMessages\x12'.ambient.v1.WatchSessionMessagesRequest\x1a\x1a.ambient.v1.SessionMessage0\x01\x12Q\n" +
 	"\x10PushSessionEvent\x12#.ambient.v1.PushSessionEventRequest\x1a\x18.ambient.v1.SessionEvent\x12W\n" +
-	"\x12WatchSessionEvents\x12%.ambient.v1.WatchSessionEventsRequest\x1a\x18.ambient.v1.SessionEvent0\x01BcZagithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
+	"\x12WatchSessionEvents\x12%.ambient.v1.WatchSessionEventsRequest\x1a\x18.ambient.v1.SessionEvent0\x01BrZpgithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
 
 var (
 	file_ambient_v1_sessions_proto_rawDescOnce sync.Once

--- a/components/ambient-api-server/pkg/api/grpc/ambient/v1/users.pb.go
+++ b/components/ambient-api-server/pkg/api/grpc/ambient/v1/users.pb.go
@@ -593,7 +593,7 @@ const file_ambient_v1_users_proto_rawDesc = "" +
 	"DeleteUser\x12\x1d.ambient.v1.DeleteUserRequest\x1a\x1e.ambient.v1.DeleteUserResponse\x12H\n" +
 	"\tListUsers\x12\x1c.ambient.v1.ListUsersRequest\x1a\x1d.ambient.v1.ListUsersResponse\x12I\n" +
 	"\n" +
-	"WatchUsers\x12\x1d.ambient.v1.WatchUsersRequest\x1a\x1a.ambient.v1.UserWatchEvent0\x01BcZagithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
+	"WatchUsers\x12\x1d.ambient.v1.WatchUsersRequest\x1a\x1a.ambient.v1.UserWatchEvent0\x01BrZpgithub.com/openshift-online/agent-control-plane/components/ambient-api-server/pkg/api/grpc/ambient/v1;ambient_v1b\x06proto3"
 
 var (
 	file_ambient_v1_users_proto_rawDescOnce sync.Once


### PR DESCRIPTION
## Summary

- Regenerates all `.pb.go` files in `ambient-api-server/pkg/api/grpc/ambient/v1/` after the module rename in #457
- The rename updated `go_package` in `.proto` files but did not regenerate the `.pb.go` files, leaving incorrect length bytes in the raw protobuf descriptors
- This causes a **panic on startup** of both the control plane and API server:
  ```
  panic: runtime error: slice bounds out of range [-5:]
  ```

## Test plan

- [x] Verify `go run ./cmd/ambient-control-plane/` no longer panics (exits with config error as expected)
- [x] Verify `go build ./...` passes for both api-server and control-plane

🤖 Generated with [Claude Code](https://claude.ai/code)