### PR TITLE
fix: get test-local-dev-simulation CI green

### DIFF
--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -247,8 +247,9 @@ jobs:
           sleep 5
         done
 
-        # Wait for gateway StatefulSet pod to be ready (not the certgen Job pod)
-        kubectl wait --for=condition=ready pod/openshell-gateway-0 \
+        # Wait for gateway pod to be ready (Deployment, not the certgen Job pod)
+        kubectl wait --for=condition=ready pod \
+          -l app.kubernetes.io/name=openshell,app.kubernetes.io/component=gateway \
           -n tenant-a --timeout=120s || echo "Warning: gateway pod not ready after 120s"
 
         PF_DIR=/tmp/ambient-code ./scripts/setup-gateway-cli.sh tenant-a

--- a/.github/workflows/test-local-dev.yml
+++ b/.github/workflows/test-local-dev.yml
@@ -60,6 +60,8 @@ jobs:
     env:
       KUBECTL_VERSION: v1.31.4
       KIND_VERSION: v0.31.0
+      IMAGE_TAG: ${{ inputs.image-tag || 'latest' }}
+      BUILT_IMAGES: ${{ inputs.built-images || '[]' }}
 
     steps:
     - name: Checkout code

--- a/components/ambient-api-server/pkg/middleware/auth_header_sanitize.go
+++ b/components/ambient-api-server/pkg/middleware/auth_header_sanitize.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	pkgserver "github.com/openshift-online/rh-trex-ai/pkg/server"
+)
+
+func init() {
+	pkgserver.RegisterPreAuthMiddleware(sanitizeAuthHeaders)
+}
+
+func sanitizeAuthHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		fwd := r.Header.Get(forwardedAccessTokenHeader)
+		if auth == "" && fwd == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		h := r.Header.Clone()
+		if auth != "" {
+			if token, ok := strings.CutPrefix(auth, "Bearer "); ok {
+				h.Set("Authorization", fmt.Sprintf("Bearer [REDACTED:len=%d]", len(token)))
+			} else {
+				h.Set("Authorization", fmt.Sprintf("[REDACTED:len=%d]", len(auth)))
+			}
+		}
+		if fwd != "" {
+			h.Set(forwardedAccessTokenHeader, fmt.Sprintf("[REDACTED:len=%d]", len(fwd)))
+		}
+
+		r2 := r.WithContext(r.Context())
+		r2.Header = h
+		next.ServeHTTP(w, r2)
+	})
+}

--- a/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
+++ b/components/ambient-api-server/pkg/middleware/bearer_token_grpc.go
@@ -11,6 +11,14 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// staticTokenUsername is the identity assigned to callers authenticating with
+// the shared static bearer token (e.g. the control plane, bootstrap jobs).
+// autoProvisionServiceAccount in pkg/rbac grants this identity a global
+// platform:admin RoleBinding — the same mechanism used for OIDC service
+// accounts. Access is scoped to the API server's RBAC evaluator; it does
+// NOT grant K8s cluster privileges.
+const staticTokenUsername = "static-service-token"
+
 var grpcBypassMethods = map[string]bool{
 	"/grpc.health.v1.Health/Check":                                   true,
 	"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo": true,
@@ -26,7 +34,9 @@ func bearerTokenGRPCUnaryInterceptor(expectedToken, serviceAccountUsername strin
 			if authHeader := md.Get("authorization"); len(authHeader) > 0 {
 				if token, err := extractBearerToken(authHeader[0]); err == nil {
 					if subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
-						return handler(WithCallerType(ctx, CallerTypeService), req)
+						ctx = WithCallerType(ctx, CallerTypeService)
+						ctx = auth.SetUsernameContext(ctx, staticTokenUsername)
+						return handler(ctx, req)
 					}
 					if username := usernameFromJWT(token); username != "" {
 						if isServiceAccount(username, serviceAccountUsername) {
@@ -52,7 +62,9 @@ func bearerTokenGRPCStreamInterceptor(expectedToken, serviceAccountUsername stri
 			if authHeader := md.Get("authorization"); len(authHeader) > 0 {
 				if token, err := extractBearerToken(authHeader[0]); err == nil {
 					if subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
-						return handler(srv, &serviceCallerStream{ServerStream: ss, ctx: WithCallerType(ss.Context(), CallerTypeService)})
+						ctx := WithCallerType(ss.Context(), CallerTypeService)
+						ctx = auth.SetUsernameContext(ctx, staticTokenUsername)
+						return handler(srv, &serviceCallerStream{ServerStream: ss, ctx: ctx})
 					}
 					if username := usernameFromJWT(token); username != "" {
 						ctx := auth.SetUsernameContext(ss.Context(), username)

--- a/components/ambient-api-server/plugins/gateways/handler.go
+++ b/components/ambient-api-server/plugins/gateways/handler.go
@@ -30,12 +30,6 @@ func gatewayImageFromEnv() string {
 	return "ghcr.io/nvidia/openshell/gateway:0.0.92"
 }
 
-var DefaultOIDCIssuerURL = oidcIssuerURLFromEnv()
-
-func oidcIssuerURLFromEnv() string {
-	return os.Getenv("OIDC_ISSUER_URL")
-}
-
 func applyGatewayDefaults(gw *Gateway, projectID string) {
 	if gw.Name == "" {
 		gw.Name = "openshell-gateway"
@@ -50,18 +44,10 @@ func applyGatewayDefaults(gw *Gateway, projectID string) {
 		s := string(raw)
 		gw.ServerDnsNames = &s
 	}
-	if gw.Oidc == nil && DefaultOIDCIssuerURL != "" {
-		oidcDefaults := map[string]interface{}{
-			"issuer":      DefaultOIDCIssuerURL,
-			"audience":    "openshell-cli",
-			"roles_claim": "realm_access.roles",
-			"admin_role":  "openshell-admin",
-			"user_role":   "openshell-user",
-		}
-		raw, _ := json.Marshal(oidcDefaults)
-		s := string(raw)
-		gw.Oidc = &s
-	}
+	// OIDC is opt-in: only gateways whose manifests explicitly include an
+	// oidc block should have OIDC enabled.  Auto-injecting OIDC based on
+	// the global OIDC_ISSUER_URL caused non-OIDC tenants to reject both
+	// authenticated and unauthenticated control-plane calls.
 	if gw.Route == nil {
 		routeDefault := map[string]interface{}{}
 		raw, _ := json.Marshal(routeDefault)

--- a/components/ambient-api-server/plugins/inbox/testmain_test.go
+++ b/components/ambient-api-server/plugins/inbox/testmain_test.go
@@ -1,36 +1,15 @@
 package inbox_test
 
 import (
-	"flag"
 	"os"
-	"runtime"
 	"testing"
-
-	"github.com/golang/glog"
-
-	"github.com/openshift-online/agent-control-plane/components/ambient-api-server/test"
-
-	// Ensure all plugin migrations run in this test binary
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/agents"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/credentials"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/inbox"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/projectSettings"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/projects"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/roleBindings"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/roles"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/scheduledSessions"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/sessions"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/users"
-	_ "github.com/openshift-online/agent-control-plane/components/ambient-api-server/plugins/version"
-	_ "github.com/openshift-online/rh-trex-ai/plugins/events"
-	_ "github.com/openshift-online/rh-trex-ai/plugins/generic"
 )
 
+// All inbox integration tests are currently skipped (pending nested route
+// client update). Skipping the full test infrastructure avoids a race
+// between the gRPC Serve goroutine and GracefulStop during teardown that
+// causes os.Exit(1) via rh-trex-ai's Check(). Re-add the server setup
+// when the integration tests are re-enabled.
 func TestMain(m *testing.M) {
-	flag.Parse()
-	glog.Infof("Starting inbox integration test using go version %s", runtime.Version())
-	helper := test.NewHelper(&testing.T{})
-	exitCode := m.Run()
-	helper.Teardown()
-	os.Exit(exitCode)
+	os.Exit(m.Run())
 }

--- a/components/ambient-api-server/plugins/roles/migration.go
+++ b/components/ambient-api-server/plugins/roles/migration.go
@@ -297,6 +297,36 @@ func providerGatewayPermissionsMigration() *gormigrate.Migration {
 	}
 }
 
+func editorRoleBindingCreateMigration() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "202607310001",
+		Migrate: func(tx *gorm.DB) error {
+			var perms string
+			if err := tx.Raw(`SELECT permissions FROM roles WHERE name = 'project:editor' AND deleted_at IS NULL`).Scan(&perms).Error; err != nil {
+				return err
+			}
+			var permList []string
+			if err := json.Unmarshal([]byte(perms), &permList); err != nil {
+				return err
+			}
+			for _, p := range permList {
+				if p == "role_binding:create" {
+					return nil
+				}
+			}
+			permList = append(permList, "role_binding:create")
+			updated, err := json.Marshal(permList)
+			if err != nil {
+				return err
+			}
+			return tx.Exec(`UPDATE roles SET permissions = ?, updated_at = NOW() WHERE name = 'project:editor' AND deleted_at IS NULL`, string(updated)).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}
+
 func policyPermissionsMigration() *gormigrate.Migration {
 	type rolePerms struct {
 		roleName    string

--- a/components/ambient-api-server/plugins/roles/plugin.go
+++ b/components/ambient-api-server/plugins/roles/plugin.go
@@ -83,6 +83,7 @@ func init() {
 	db.RegisterMigration(migration())
 	db.RegisterMigration(viewerRoleBindingReadMigration())
 	db.RegisterMigration(editorCredentialUnbindMigration())
+	db.RegisterMigration(editorRoleBindingCreateMigration())
 	db.RegisterMigration(providerGatewayPermissionsMigration())
 	db.RegisterMigration(clusterRolesMigration())
 	db.RegisterMigration(policyPermissionsMigration())

--- a/components/ambient-control-plane/cmd/ambient-control-plane/main.go
+++ b/components/ambient-control-plane/cmd/ambient-control-plane/main.go
@@ -217,25 +217,6 @@ func runKubeMode(ctx context.Context, cfg *config.ControlPlaneConfig) error {
 	inf.RegisterHandler("projects", projectReconciler.Reconcile)
 	inf.RegisterHandler("project_settings", projectSettingsReconciler.Reconcile)
 
-	gatewayErrCh := make(chan error, 1)
-	kubeCfg, kubeErr := buildKubeConfig(cfg.Kubeconfig)
-	if kubeErr != nil {
-		return fmt.Errorf("build kubeconfig for gateway reconciler: %w", kubeErr)
-	}
-	gwClientset, csErr := kubernetes.NewForConfig(kubeCfg)
-	if csErr != nil {
-		return fmt.Errorf("create kubernetes clientset for gateway reconciler: %w", csErr)
-	}
-	gwDynamic, dynErr := dynamic.NewForConfig(kubeCfg)
-	if dynErr != nil {
-		return fmt.Errorf("create dynamic client for gateway reconciler: %w", dynErr)
-	}
-	gwReconciler := reconciler.NewGatewayReconciler(factory, gwDynamic, gwClientset, provisioner, log.Logger)
-	go func() {
-		gatewayErrCh <- gwReconciler.Run(ctx)
-	}()
-	log.Info().Msg("gateway reconciler enabled")
-
 	var resolveCred openshell.CredentialResolver
 	if cfg.OpenShellGatewayTLSEnabled {
 		tlsResolver := openshell.NewTLSResolver(provisionerKube, cfg.OpenShellGatewayClientTLSSecret, cfg.OpenShellGatewayTLSServerName, log.Logger)
@@ -251,6 +232,26 @@ func runKubeMode(ctx context.Context, cfg *config.ControlPlaneConfig) error {
 			log.Warn().Err(err).Msg("failed to close gateway client")
 		}
 	}()
+
+	gatewayErrCh := make(chan error, 1)
+	kubeCfg, kubeErr := buildKubeConfig(cfg.Kubeconfig)
+	if kubeErr != nil {
+		return fmt.Errorf("build kubeconfig for gateway reconciler: %w", kubeErr)
+	}
+	gwClientset, csErr := kubernetes.NewForConfig(kubeCfg)
+	if csErr != nil {
+		return fmt.Errorf("create kubernetes clientset for gateway reconciler: %w", csErr)
+	}
+	gwDynamic, dynErr := dynamic.NewForConfig(kubeCfg)
+	if dynErr != nil {
+		return fmt.Errorf("create dynamic client for gateway reconciler: %w", dynErr)
+	}
+	gwReconciler := reconciler.NewGatewayReconciler(factory, gwDynamic, gwClientset, provisioner, log.Logger,
+		reconciler.WithAuthModeCallback(gateway.SetNamespaceAuthMode))
+	go func() {
+		gatewayErrCh <- gwReconciler.Run(ctx)
+	}()
+	log.Info().Msg("gateway reconciler enabled")
 
 	sessionReconcilers := createSessionReconcilers(cfg.Reconcilers, factory, kube, projectKube, provisioner, gateway, kubeReconcilerCfg, log.Logger, inf)
 	for _, sessionRec := range sessionReconcilers {

--- a/components/ambient-control-plane/internal/gateway/reconciler.go
+++ b/components/ambient-control-plane/internal/gateway/reconciler.go
@@ -604,7 +604,7 @@ func buildGatewayDeployment(nsConfig NamespaceConfig, defaultImage string, opts 
 						},
 						"volumes": []interface{}{
 							map[string]interface{}{"name": "gateway-config", "configMap": map[string]interface{}{"name": "openshell-gateway-config"}},
-							map[string]interface{}{"name": "sandbox-jwt", "secret": map[string]interface{}{"secretName": "openshell-gateway-jwt-keys", "defaultMode": int64(256)}},
+							map[string]interface{}{"name": "sandbox-jwt", "secret": map[string]interface{}{"secretName": "openshell-gateway-jwt-keys", "defaultMode": int64(0440)}},
 							map[string]interface{}{"name": "tls-cert", "secret": map[string]interface{}{"secretName": "openshell-server-tls"}},
 							map[string]interface{}{"name": "tls-client-ca", "secret": map[string]interface{}{"secretName": "openshell-server-tls", "items": []interface{}{map[string]interface{}{"key": "ca.crt", "path": "ca.crt"}}}},
 							map[string]interface{}{"name": "tmp", "emptyDir": map[string]interface{}{}},

--- a/components/ambient-control-plane/internal/openshell/gateway_client.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
 
@@ -73,30 +72,25 @@ func (g *GatewayClient) authContext(ctx context.Context, namespace string) conte
 		}
 		return ctx
 	}
-	// Namespace not yet registered — fall back to legacy behavior
-	if g.tokenProvider != nil {
-		token, err := g.tokenProvider.Token(ctx)
-		if err != nil {
-			g.logger.Warn().Err(err).Msg("failed to obtain OIDC token for gateway auth")
-			return ctx
-		}
-		if token != "" {
-			return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+token))
-		}
+	// Namespace not yet registered — optimistically try OIDC. If the
+	// gateway rejects the token ("unknown signing key"), the caller
+	// retries without auth and registers the namespace as non-OIDC.
+	return g.oidcAuthContext(ctx)
+}
+
+func (g *GatewayClient) stripAuthContext(ctx context.Context) context.Context {
+	return metadata.NewOutgoingContext(ctx, metadata.MD{})
+}
+
+func (g *GatewayClient) isUnauthSigningKeyErr(err error) bool {
+	if err == nil {
+		return false
 	}
-	if g.saTokenPath == "" {
-		return ctx
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
 	}
-	raw, err := os.ReadFile(g.saTokenPath)
-	if err != nil {
-		g.logger.Warn().Err(err).Str("path", g.saTokenPath).Msg("failed to read SA token file")
-		return ctx
-	}
-	token := strings.TrimSpace(string(raw))
-	if token == "" {
-		return ctx
-	}
-	return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+token))
+	return st.Code() == codes.Unauthenticated && strings.Contains(st.Message(), "unknown signing key")
 }
 
 func (g *GatewayClient) oidcAuthContext(ctx context.Context) context.Context {
@@ -177,12 +171,18 @@ func (g *GatewayClient) shouldEvict(err error) bool {
 }
 
 func (g *GatewayClient) CreateSandbox(ctx context.Context, namespace string, req *pb.CreateSandboxRequest) (*pb.SandboxResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.CreateSandbox(ctx, req)
+	resp, err := client.CreateSandbox(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.CreateSandbox(noAuthCtx, req)
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -190,12 +190,18 @@ func (g *GatewayClient) CreateSandbox(ctx context.Context, namespace string, req
 }
 
 func (g *GatewayClient) GetSandbox(ctx context.Context, namespace string, name string) (*pb.SandboxResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetSandbox(ctx, &pb.GetSandboxRequest{Name: name})
+	resp, err := client.GetSandbox(authCtx, &pb.GetSandboxRequest{Name: name})
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.GetSandbox(noAuthCtx, &pb.GetSandboxRequest{Name: name})
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -203,12 +209,18 @@ func (g *GatewayClient) GetSandbox(ctx context.Context, namespace string, name s
 }
 
 func (g *GatewayClient) DeleteSandbox(ctx context.Context, namespace string, name string) error {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return err
 	}
-	_, err = client.DeleteSandbox(ctx, &pb.DeleteSandboxRequest{Name: name})
+	_, err = client.DeleteSandbox(authCtx, &pb.DeleteSandboxRequest{Name: name})
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		_, err = client.DeleteSandbox(noAuthCtx, &pb.DeleteSandboxRequest{Name: name})
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -216,12 +228,18 @@ func (g *GatewayClient) DeleteSandbox(ctx context.Context, namespace string, nam
 }
 
 func (g *GatewayClient) CreateProvider(ctx context.Context, namespace string, req *pb.CreateProviderRequest) (*pb.ProviderResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.CreateProvider(ctx, req)
+	resp, err := client.CreateProvider(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.CreateProvider(noAuthCtx, req)
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -229,12 +247,18 @@ func (g *GatewayClient) CreateProvider(ctx context.Context, namespace string, re
 }
 
 func (g *GatewayClient) UpdateProvider(ctx context.Context, namespace string, req *pb.UpdateProviderRequest) (*pb.ProviderResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.UpdateProvider(ctx, req)
+	resp, err := client.UpdateProvider(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.UpdateProvider(noAuthCtx, req)
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -242,12 +266,18 @@ func (g *GatewayClient) UpdateProvider(ctx context.Context, namespace string, re
 }
 
 func (g *GatewayClient) GetProvider(ctx context.Context, namespace string, name string) (*pb.ProviderResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetProvider(ctx, &pb.GetProviderRequest{Name: name})
+	resp, err := client.GetProvider(authCtx, &pb.GetProviderRequest{Name: name})
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.GetProvider(noAuthCtx, &pb.GetProviderRequest{Name: name})
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -261,12 +291,18 @@ type ExecResult struct {
 }
 
 func (g *GatewayClient) ExecSandbox(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (*ExecResult, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	stream, err := client.ExecSandbox(ctx, req)
+	stream, err := client.ExecSandbox(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		stream, err = client.ExecSandbox(noAuthCtx, req)
+	}
 	if err != nil {
 		if g.shouldEvict(err) {
 			g.evictConn(namespace)
@@ -304,12 +340,18 @@ func (g *GatewayClient) inferenceClientForNamespace(ctx context.Context, namespa
 }
 
 func (g *GatewayClient) SetInferenceRoute(ctx context.Context, namespace string, req *inferencepb.SetInferenceRouteRequest) (*inferencepb.SetInferenceRouteResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.inferenceClientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.inferenceClientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.SetInferenceRoute(ctx, req)
+	resp, err := client.SetInferenceRoute(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.SetInferenceRoute(noAuthCtx, req)
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -317,12 +359,18 @@ func (g *GatewayClient) SetInferenceRoute(ctx context.Context, namespace string,
 }
 
 func (g *GatewayClient) ConfigureProviderRefresh(ctx context.Context, namespace string, req *pb.ConfigureProviderRefreshRequest) (*pb.ConfigureProviderRefreshResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ConfigureProviderRefresh(ctx, req)
+	resp, err := client.ConfigureProviderRefresh(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.ConfigureProviderRefresh(noAuthCtx, req)
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -330,12 +378,18 @@ func (g *GatewayClient) ConfigureProviderRefresh(ctx context.Context, namespace 
 }
 
 func (g *GatewayClient) RotateProviderCredential(ctx context.Context, namespace string, req *pb.RotateProviderCredentialRequest) (*pb.RotateProviderCredentialResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.RotateProviderCredential(ctx, req)
+	resp, err := client.RotateProviderCredential(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.RotateProviderCredential(noAuthCtx, req)
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -353,12 +407,18 @@ func (e *ExecExitError) Error() string {
 const maxLogChunkSize = 512
 
 func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) error {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return err
 	}
-	stream, err := client.ExecSandbox(ctx, req)
+	stream, err := client.ExecSandbox(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		stream, err = client.ExecSandbox(noAuthCtx, req)
+	}
 	if err != nil {
 		if g.shouldEvict(err) {
 			g.evictConn(namespace)
@@ -400,12 +460,18 @@ func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace stri
 }
 
 func (g *GatewayClient) UpdateConfig(ctx context.Context, namespace string, req *pb.UpdateConfigRequest) (*pb.UpdateConfigResponse, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.UpdateConfig(ctx, req)
+	resp, err := client.UpdateConfig(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		resp, err = client.UpdateConfig(noAuthCtx, req)
+	}
 	if err != nil && g.shouldEvict(err) {
 		g.evictConn(namespace)
 	}
@@ -413,12 +479,18 @@ func (g *GatewayClient) UpdateConfig(ctx context.Context, namespace string, req 
 }
 
 func (g *GatewayClient) WatchSandbox(ctx context.Context, namespace string, req *pb.WatchSandboxRequest) (pb.OpenShell_WatchSandboxClient, error) {
-	ctx = g.authContext(ctx, namespace)
-	client, err := g.clientForNamespace(ctx, namespace)
+	authCtx := g.authContext(ctx, namespace)
+	client, err := g.clientForNamespace(authCtx, namespace)
 	if err != nil {
 		return nil, err
 	}
-	stream, err := client.WatchSandbox(ctx, req)
+	stream, err := client.WatchSandbox(authCtx, req)
+	if g.isUnauthSigningKeyErr(err) {
+		g.logger.Info().Str("namespace", namespace).Msg("OIDC token rejected, retrying without auth")
+		g.SetNamespaceAuthMode(namespace, false)
+		noAuthCtx := g.stripAuthContext(ctx)
+		stream, err = client.WatchSandbox(noAuthCtx, req)
+	}
 	if err != nil {
 		if g.shouldEvict(err) {
 			g.evictConn(namespace)

--- a/components/ambient-control-plane/internal/openshell/gateway_client.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client.go
@@ -25,14 +25,15 @@ type TokenProvider interface {
 }
 
 type GatewayClient struct {
-	mu            sync.RWMutex
-	conns         map[string]*grpc.ClientConn
-	serviceName   string
-	grpcPort      int
-	resolveCred   CredentialResolver
-	saTokenPath   string
-	tokenProvider TokenProvider
-	logger        zerolog.Logger
+	mu             sync.RWMutex
+	conns          map[string]*grpc.ClientConn
+	oidcNamespaces sync.Map // namespace → bool (true = OIDC enabled)
+	serviceName    string
+	grpcPort       int
+	resolveCred    CredentialResolver
+	saTokenPath    string
+	tokenProvider  TokenProvider
+	logger         zerolog.Logger
 }
 
 type GatewayClientOption func(*GatewayClient)
@@ -58,7 +59,21 @@ func NewGatewayClient(serviceName string, grpcPort int, resolveCred CredentialRe
 	return g
 }
 
-func (g *GatewayClient) authContext(ctx context.Context) context.Context {
+// SetNamespaceAuthMode records whether a namespace's gateway requires OIDC auth.
+// Called by the gateway reconciler after it processes each gateway's config.
+func (g *GatewayClient) SetNamespaceAuthMode(namespace string, hasOIDC bool) {
+	g.oidcNamespaces.Store(namespace, hasOIDC)
+	g.logger.Debug().Str("namespace", namespace).Bool("oidc", hasOIDC).Msg("gateway auth mode registered")
+}
+
+func (g *GatewayClient) authContext(ctx context.Context, namespace string) context.Context {
+	if mode, ok := g.oidcNamespaces.Load(namespace); ok {
+		if mode.(bool) {
+			return g.oidcAuthContext(ctx)
+		}
+		return ctx
+	}
+	// Namespace not yet registered — fall back to legacy behavior
 	if g.tokenProvider != nil {
 		token, err := g.tokenProvider.Token(ctx)
 		if err != nil {
@@ -82,6 +97,21 @@ func (g *GatewayClient) authContext(ctx context.Context) context.Context {
 		return ctx
 	}
 	return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+token))
+}
+
+func (g *GatewayClient) oidcAuthContext(ctx context.Context) context.Context {
+	if g.tokenProvider == nil {
+		return ctx
+	}
+	token, err := g.tokenProvider.Token(ctx)
+	if err != nil {
+		g.logger.Warn().Err(err).Msg("failed to obtain OIDC token for gateway auth")
+		return ctx
+	}
+	if token != "" {
+		return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+token))
+	}
+	return ctx
 }
 
 func (g *GatewayClient) clientForNamespace(ctx context.Context, namespace string) (pb.OpenShellClient, error) {
@@ -147,7 +177,7 @@ func (g *GatewayClient) shouldEvict(err error) bool {
 }
 
 func (g *GatewayClient) CreateSandbox(ctx context.Context, namespace string, req *pb.CreateSandboxRequest) (*pb.SandboxResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -160,7 +190,7 @@ func (g *GatewayClient) CreateSandbox(ctx context.Context, namespace string, req
 }
 
 func (g *GatewayClient) GetSandbox(ctx context.Context, namespace string, name string) (*pb.SandboxResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -173,7 +203,7 @@ func (g *GatewayClient) GetSandbox(ctx context.Context, namespace string, name s
 }
 
 func (g *GatewayClient) DeleteSandbox(ctx context.Context, namespace string, name string) error {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return err
@@ -186,7 +216,7 @@ func (g *GatewayClient) DeleteSandbox(ctx context.Context, namespace string, nam
 }
 
 func (g *GatewayClient) CreateProvider(ctx context.Context, namespace string, req *pb.CreateProviderRequest) (*pb.ProviderResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -199,7 +229,7 @@ func (g *GatewayClient) CreateProvider(ctx context.Context, namespace string, re
 }
 
 func (g *GatewayClient) UpdateProvider(ctx context.Context, namespace string, req *pb.UpdateProviderRequest) (*pb.ProviderResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -212,7 +242,7 @@ func (g *GatewayClient) UpdateProvider(ctx context.Context, namespace string, re
 }
 
 func (g *GatewayClient) GetProvider(ctx context.Context, namespace string, name string) (*pb.ProviderResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -231,7 +261,7 @@ type ExecResult struct {
 }
 
 func (g *GatewayClient) ExecSandbox(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) (*ExecResult, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -274,7 +304,7 @@ func (g *GatewayClient) inferenceClientForNamespace(ctx context.Context, namespa
 }
 
 func (g *GatewayClient) SetInferenceRoute(ctx context.Context, namespace string, req *inferencepb.SetInferenceRouteRequest) (*inferencepb.SetInferenceRouteResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.inferenceClientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -287,7 +317,7 @@ func (g *GatewayClient) SetInferenceRoute(ctx context.Context, namespace string,
 }
 
 func (g *GatewayClient) ConfigureProviderRefresh(ctx context.Context, namespace string, req *pb.ConfigureProviderRefreshRequest) (*pb.ConfigureProviderRefreshResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -300,7 +330,7 @@ func (g *GatewayClient) ConfigureProviderRefresh(ctx context.Context, namespace 
 }
 
 func (g *GatewayClient) RotateProviderCredential(ctx context.Context, namespace string, req *pb.RotateProviderCredentialRequest) (*pb.RotateProviderCredentialResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -323,7 +353,7 @@ func (e *ExecExitError) Error() string {
 const maxLogChunkSize = 512
 
 func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace string, req *pb.ExecSandboxRequest) error {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return err
@@ -370,7 +400,7 @@ func (g *GatewayClient) ExecSandboxStreaming(ctx context.Context, namespace stri
 }
 
 func (g *GatewayClient) UpdateConfig(ctx context.Context, namespace string, req *pb.UpdateConfigRequest) (*pb.UpdateConfigResponse, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -383,7 +413,7 @@ func (g *GatewayClient) UpdateConfig(ctx context.Context, namespace string, req 
 }
 
 func (g *GatewayClient) WatchSandbox(ctx context.Context, namespace string, req *pb.WatchSandboxRequest) (pb.OpenShell_WatchSandboxClient, error) {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return nil, err

--- a/components/ambient-control-plane/internal/openshell/gateway_client_test.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client_test.go
@@ -224,7 +224,7 @@ func TestClose(t *testing.T) {
 
 func TestAuthContext_NoPath(t *testing.T) {
 	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop())
-	ctx := g.authContext(context.Background())
+	ctx := g.authContext(context.Background(), "test-ns")
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if ok && len(md.Get("authorization")) > 0 {
 		t.Error("expected no authorization metadata when saTokenPath is empty")
@@ -238,7 +238,7 @@ func TestAuthContext_ValidToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	g := NewGatewayClient("gw", 8443, nil, tokenFile, zerolog.Nop())
-	ctx := g.authContext(context.Background())
+	ctx := g.authContext(context.Background(), "test-ns")
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		t.Fatal("expected outgoing metadata")
@@ -279,9 +279,68 @@ func TestExecExitError(t *testing.T) {
 
 func TestAuthContext_MissingFile(t *testing.T) {
 	g := NewGatewayClient("gw", 8443, nil, "/nonexistent/path/token", zerolog.Nop())
-	ctx := g.authContext(context.Background())
+	ctx := g.authContext(context.Background(), "test-ns")
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if ok && len(md.Get("authorization")) > 0 {
 		t.Error("expected no authorization metadata when token file is missing")
 	}
+}
+
+func TestAuthContext_NonOIDCNamespace(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("sa-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	g := NewGatewayClient("gw", 8443, nil, tokenFile, zerolog.Nop())
+	g.SetNamespaceAuthMode("tenant-a", false)
+
+	ctx := g.authContext(context.Background(), "tenant-a")
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if ok && len(md.Get("authorization")) > 0 {
+		t.Error("non-OIDC namespace should not send any auth token")
+	}
+}
+
+func TestAuthContext_OIDCNamespace(t *testing.T) {
+	tp := &staticToken{token: "oidc-token"}
+	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop(), WithTokenProvider(tp))
+	g.SetNamespaceAuthMode("tenant-c", true)
+
+	ctx := g.authContext(context.Background(), "tenant-c")
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("expected outgoing metadata for OIDC namespace")
+	}
+	vals := md.Get("authorization")
+	if len(vals) != 1 || vals[0] != "Bearer oidc-token" {
+		t.Errorf("authorization = %v, want [Bearer oidc-token]", vals)
+	}
+}
+
+func TestAuthContext_UnregisteredNamespaceFallback(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("sa-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	g := NewGatewayClient("gw", 8443, nil, tokenFile, zerolog.Nop())
+	// Don't register any namespace — should fall back to legacy SA token behavior
+	ctx := g.authContext(context.Background(), "unknown-ns")
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("expected outgoing metadata for unregistered namespace with SA token")
+	}
+	vals := md.Get("authorization")
+	if len(vals) != 1 || vals[0] != "Bearer sa-token" {
+		t.Errorf("authorization = %v, want [Bearer sa-token]", vals)
+	}
+}
+
+type staticToken struct {
+	token string
+}
+
+func (s *staticToken) Token(_ context.Context) (string, error) {
+	return s.token, nil
 }

--- a/components/ambient-control-plane/internal/openshell/gateway_client_test.go
+++ b/components/ambient-control-plane/internal/openshell/gateway_client_test.go
@@ -231,24 +231,6 @@ func TestAuthContext_NoPath(t *testing.T) {
 	}
 }
 
-func TestAuthContext_ValidToken(t *testing.T) {
-	dir := t.TempDir()
-	tokenFile := filepath.Join(dir, "token")
-	if err := os.WriteFile(tokenFile, []byte("test-sa-token\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	g := NewGatewayClient("gw", 8443, nil, tokenFile, zerolog.Nop())
-	ctx := g.authContext(context.Background(), "test-ns")
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		t.Fatal("expected outgoing metadata")
-	}
-	vals := md.Get("authorization")
-	if len(vals) != 1 || vals[0] != "Bearer test-sa-token" {
-		t.Errorf("authorization = %v, want [Bearer test-sa-token]", vals)
-	}
-}
-
 func TestExecExitError(t *testing.T) {
 	t.Run("implements error interface", func(t *testing.T) {
 		var err error = &ExecExitError{Code: 42}
@@ -275,15 +257,6 @@ func TestExecExitError(t *testing.T) {
 			t.Fatal("errors.As should return false for non-ExecExitError")
 		}
 	})
-}
-
-func TestAuthContext_MissingFile(t *testing.T) {
-	g := NewGatewayClient("gw", 8443, nil, "/nonexistent/path/token", zerolog.Nop())
-	ctx := g.authContext(context.Background(), "test-ns")
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if ok && len(md.Get("authorization")) > 0 {
-		t.Error("expected no authorization metadata when token file is missing")
-	}
 }
 
 func TestAuthContext_NonOIDCNamespace(t *testing.T) {
@@ -318,22 +291,52 @@ func TestAuthContext_OIDCNamespace(t *testing.T) {
 	}
 }
 
-func TestAuthContext_UnregisteredNamespaceFallback(t *testing.T) {
-	dir := t.TempDir()
-	tokenFile := filepath.Join(dir, "token")
-	if err := os.WriteFile(tokenFile, []byte("sa-token"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	g := NewGatewayClient("gw", 8443, nil, tokenFile, zerolog.Nop())
-	// Don't register any namespace — should fall back to legacy SA token behavior
+func TestAuthContext_UnregisteredNamespaceTriesOIDC(t *testing.T) {
+	tp := &staticToken{token: "oidc-token"}
+	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop(), WithTokenProvider(tp))
+	// Unregistered namespace should optimistically try OIDC; the caller
+	// retries without auth if the gateway rejects it.
 	ctx := g.authContext(context.Background(), "unknown-ns")
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
-		t.Fatal("expected outgoing metadata for unregistered namespace with SA token")
+		t.Fatal("expected outgoing metadata for unregistered namespace with OIDC provider")
 	}
 	vals := md.Get("authorization")
-	if len(vals) != 1 || vals[0] != "Bearer sa-token" {
-		t.Errorf("authorization = %v, want [Bearer sa-token]", vals)
+	if len(vals) != 1 || vals[0] != "Bearer oidc-token" {
+		t.Errorf("authorization = %v, want [Bearer oidc-token]", vals)
+	}
+}
+
+func TestIsUnauthSigningKeyErr(t *testing.T) {
+	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop())
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"non-status error", fmt.Errorf("plain"), false},
+		{"Unauthenticated with signing key", status.Error(codes.Unauthenticated, "invalid token: unknown signing key"), true},
+		{"Unauthenticated without signing key", status.Error(codes.Unauthenticated, "missing token"), false},
+		{"PermissionDenied with signing key", status.Error(codes.PermissionDenied, "unknown signing key"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := g.isUnauthSigningKeyErr(tt.err)
+			if got != tt.want {
+				t.Errorf("isUnauthSigningKeyErr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripAuthContext(t *testing.T) {
+	g := NewGatewayClient("gw", 8443, nil, "", zerolog.Nop())
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", "Bearer token"))
+	stripped := g.stripAuthContext(ctx)
+	md, ok := metadata.FromOutgoingContext(stripped)
+	if ok && len(md.Get("authorization")) > 0 {
+		t.Error("stripAuthContext should remove authorization metadata")
 	}
 }
 

--- a/components/ambient-control-plane/internal/openshell/ssh_upload.go
+++ b/components/ambient-control-plane/internal/openshell/ssh_upload.go
@@ -35,7 +35,7 @@ type Payload struct {
 }
 
 func (g *GatewayClient) UploadPayloads(ctx context.Context, namespace string, sandboxID string, payloads []Payload) error {
-	ctx = g.authContext(ctx)
+	ctx = g.authContext(ctx, namespace)
 	client, err := g.clientForNamespace(ctx, namespace)
 	if err != nil {
 		return fmt.Errorf("get gateway client: %w", err)

--- a/components/ambient-control-plane/internal/reconciler/gateway_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/gateway_reconciler.go
@@ -1389,6 +1389,16 @@ func (r *GatewayReconciler) reconcileSandboxNetworkPolicy(ctx context.Context, n
 									},
 								},
 							},
+							map[string]interface{}{
+								"podSelector": map[string]interface{}{
+									"matchExpressions": []interface{}{
+										map[string]interface{}{
+											"key":      "agents.x-k8s.io/sandbox-name-hash",
+											"operator": "Exists",
+										},
+									},
+								},
+							},
 						},
 						"ports": []interface{}{
 							map[string]interface{}{

--- a/components/ambient-control-plane/internal/reconciler/gateway_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/gateway_reconciler.go
@@ -74,6 +74,16 @@ const (
 	trustedCAKey           = "ca-bundle.crt"
 )
 
+type GatewayReconcilerOption func(*GatewayReconciler)
+
+// WithAuthModeCallback registers a function called after each gateway is
+// reconciled, informing consumers whether the namespace uses OIDC auth.
+func WithAuthModeCallback(fn func(namespace string, hasOIDC bool)) GatewayReconcilerOption {
+	return func(r *GatewayReconciler) {
+		r.onNamespaceAuthMode = fn
+	}
+}
+
 type GatewayReconciler struct {
 	factory                    *SDKClientFactory
 	dynamicClient              dynamic.Interface
@@ -90,6 +100,7 @@ type GatewayReconciler struct {
 	gatewayAPIGatewayNamespace string
 	baseDomain                 string
 	nlbRouteDomain             string
+	onNamespaceAuthMode        func(namespace string, hasOIDC bool)
 }
 
 func NewGatewayReconciler(
@@ -98,6 +109,7 @@ func NewGatewayReconciler(
 	clientset *kubernetes.Clientset,
 	provisioner kubeclient.NamespaceProvisioner,
 	logger zerolog.Logger,
+	opts ...GatewayReconcilerOption,
 ) *GatewayReconciler {
 	defaultImage := os.Getenv("OPENSHELL_GATEWAY_IMAGE")
 	if defaultImage == "" {
@@ -118,7 +130,7 @@ func NewGatewayReconciler(
 	if gwAPINamespace == "" {
 		gwAPINamespace = "openshift-ingress"
 	}
-	return &GatewayReconciler{
+	r := &GatewayReconciler{
 		factory:                    factory,
 		dynamicClient:              dynamicClient,
 		clientset:                  clientset,
@@ -129,6 +141,10 @@ func NewGatewayReconciler(
 		gatewayAPIGatewayName:      gwAPIName,
 		gatewayAPIGatewayNamespace: gwAPINamespace,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 func (r *GatewayReconciler) Run(ctx context.Context) error {
@@ -373,6 +389,11 @@ func (r *GatewayReconciler) reconcileGateway(ctx context.Context, projectClient 
 		Str("image", resolveGatewayImage(gwConfig.Image, r.defaultGatewayImage)).
 		Int("dns_names", len(gw.ServerDnsNames)).
 		Msg("gateway reconciled")
+
+	if r.onNamespaceAuthMode != nil {
+		hasOIDC := gw.Oidc != nil && gw.Oidc.Issuer != ""
+		r.onNamespaceAuthMode(namespace, hasOIDC)
+	}
 
 	r.updateGatewayAnnotation(ctx, projectClient, gw, "ambient.ai/reconcile-status", "Synced")
 	return nil

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -583,6 +583,11 @@ func (r *SimpleKubeReconciler) injectACPInternalPolicy(ctx context.Context, name
 }
 
 // Workaround for https://github.com/NVIDIA/OpenShell/issues/2053
+// The Sandbox CRD supports spec.podTemplate.spec.dnsConfig. This patch sets
+// ndots:1 on the CR so that newly created pods inherit the correct value.
+// However, the controller does NOT update existing pod specs, so pods created
+// before this patch still have ndots:5. verifyAndFixDNSConfig() handles that
+// case by deleting the pod for recreation from the already-patched CR.
 func (r *SimpleKubeReconciler) patchSandboxDNSConfig(ctx context.Context, namespace, sandboxName string) error {
 	sandboxGVR := schema.GroupVersionResource{
 		Group:    "agents.x-k8s.io",
@@ -629,10 +634,14 @@ func (r *SimpleKubeReconciler) patchSandboxDNSConfig(ctx context.Context, namesp
 }
 
 // verifyAndFixDNSConfig checks the sandbox pod's /etc/resolv.conf for the
-// incorrect ndots:5 value. If found, the pod is deleted so the agent-sandbox
-// controller recreates it from the already-patched CR (which has ndots:1).
-// Returns (true, nil) when DNS config is correct, (false, nil) when the pod
-// was deleted and needs recreation, or (false, err) on failure.
+// incorrect ndots:5 value. If found, the pod is gracefully deleted so the
+// agent-sandbox controller recreates it from the already-patched CR (which
+// has ndots:1). Returns (true, nil) when DNS config is correct, (false, nil)
+// when the pod was deleted and needs recreation, or (false, err) on failure.
+//
+// Race safety: if the pod is replaced between the cat check and the delete,
+// DeletePod returns NotFound which is swallowed. The caller's poll loop will
+// re-verify DNS on the next READY transition.
 func (r *SimpleKubeReconciler) verifyAndFixDNSConfig(ctx context.Context, namespace, sandboxID, sbxName string) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler_test.go
@@ -927,9 +927,10 @@ func TestVerifyAndFixDNSConfig(t *testing.T) {
 				},
 			}
 
+			crName := openshell.SandboxCRName("test-sandbox")
 			var objects []runtime.Object
 			if tt.podExists {
-				objects = append(objects, makeNamedPod("test-ns", "test-sandbox"))
+				objects = append(objects, makeNamedPod("test-ns", crName))
 			}
 			kube := newFakeKubeClientWithPods(objects...)
 			logger := zerolog.Nop()
@@ -950,13 +951,13 @@ func TestVerifyAndFixDNSConfig(t *testing.T) {
 			}
 
 			if tt.wantDeleted {
-				_, getErr := kube.DynamicClient().Resource(kubeclient.PodGVR).Namespace("test-ns").Get(context.Background(), "test-sandbox", metav1.GetOptions{})
+				_, getErr := kube.DynamicClient().Resource(kubeclient.PodGVR).Namespace("test-ns").Get(context.Background(), crName, metav1.GetOptions{})
 				if !k8serrors.IsNotFound(getErr) {
 					t.Errorf("expected pod to be deleted, but got err: %v", getErr)
 				}
 			}
 			if !tt.wantDeleted && tt.podExists && err == nil {
-				_, getErr := kube.DynamicClient().Resource(kubeclient.PodGVR).Namespace("test-ns").Get(context.Background(), "test-sandbox", metav1.GetOptions{})
+				_, getErr := kube.DynamicClient().Resource(kubeclient.PodGVR).Namespace("test-ns").Get(context.Background(), crName, metav1.GetOptions{})
 				if getErr != nil {
 					t.Errorf("expected pod to still exist, but got err: %v", getErr)
 				}

--- a/components/ambient-control-plane/internal/reconciler/project_reconciler_test.go
+++ b/components/ambient-control-plane/internal/reconciler/project_reconciler_test.go
@@ -46,6 +46,9 @@ func newTestProjectReconciler(kube *kubeclient.KubeClient, platformMode string) 
 	}
 }
 
+// Rule counts: standard=7 (core, pods, rbac, apps, batch, networking, route),
+// mpp=9 (standard + build.openshift.io, image.openshift.io).
+// Expanded from 3/6 by PR #430 (gateway passthrough Route, RBAC expansion).
 func TestControlPlaneRBACRules_StandardMode(t *testing.T) {
 	r := newTestProjectReconciler(nil, "standard")
 	rules := r.controlPlaneRBACRules()
@@ -69,8 +72,8 @@ func TestControlPlaneRBACRules_StandardMode(t *testing.T) {
 		}
 	}
 
-	if len(rules) != 3 {
-		t.Errorf("expected 3 rule entries in standard mode, got %d", len(rules))
+	if len(rules) != 7 {
+		t.Errorf("expected 7 rule entries in standard mode, got %d", len(rules))
 	}
 }
 
@@ -100,8 +103,8 @@ func TestControlPlaneRBACRules_MPPMode(t *testing.T) {
 		}
 	}
 
-	if len(rules) != 6 {
-		t.Errorf("expected 6 rule entries in mpp mode, got %d", len(rules))
+	if len(rules) != 9 {
+		t.Errorf("expected 9 rule entries in mpp mode, got %d", len(rules))
 	}
 }
 
@@ -159,8 +162,8 @@ func TestEnsureControlPlaneRBAC_CreatesRoleAndBinding(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("expected rules in created Role: found=%v err=%v", found, err)
 	}
-	if len(rules) != 3 {
-		t.Errorf("expected 3 rules in created Role (standard mode), got %d", len(rules))
+	if len(rules) != 7 {
+		t.Errorf("expected 7 rules in created Role (standard mode), got %d", len(rules))
 	}
 }
 
@@ -201,7 +204,7 @@ func TestEnsureControlPlaneRBAC_UpdatesExistingRole(t *testing.T) {
 	if err != nil || !found {
 		t.Fatalf("expected rules in updated Role: found=%v err=%v", found, err)
 	}
-	if len(rules) != 6 {
-		t.Errorf("expected 6 rules after update in mpp mode (was 1), got %d", len(rules))
+	if len(rules) != 9 {
+		t.Errorf("expected 9 rules after update in mpp mode (was 1), got %d", len(rules))
 	}
 }

--- a/components/ambient-control-plane/manifests/gateway/statefulset.yaml
+++ b/components/ambient-control-plane/manifests/gateway/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
         - name: sandbox-jwt
           secret:
             secretName: openshell-gateway-jwt-keys
-            defaultMode: 256
+            defaultMode: 288
         - name: tls-cert
           secret:
             secretName: openshell-server-tls

--- a/components/manifests/overlays/kind-local/kustomization.yaml
+++ b/components/manifests/overlays/kind-local/kustomization.yaml
@@ -39,6 +39,19 @@ patches:
     version: v1
     kind: Deployment
     name: ambient-control-plane
+- path: image-pull-policy-patch.yaml
+  target:
+    group: batch
+    version: v1
+    kind: Job
+    name: bootstrap-admin
+# DEV-ONLY: relax security context for locally-built bootstrap-admin image
+- path: security-context-patch.yaml
+  target:
+    group: batch
+    version: v1
+    kind: Job
+    name: bootstrap-admin
 
 # Remap images from Quay.io to locally-built names
 # Podman tags images with localhost/ prefix, which kind preserves when loading

--- a/components/manifests/overlays/kind-local/security-context-patch.yaml
+++ b/components/manifests/overlays/kind-local/security-context-patch.yaml
@@ -1,0 +1,13 @@
+# DEV-ONLY: Relaxes security constraints for the bootstrap-admin Job when
+# running locally-built images in Kind. Required because local images run as
+# root and write to the filesystem during bootstrap. This overlay is scoped
+# to overlays/kind-local/ which is only applied by `make kind-up` — it is
+# never referenced by production, staging, or CI overlays.
+#
+# DO NOT apply this patch outside of local Kind development.
+- op: replace
+  path: /spec/template/spec/securityContext/runAsNonRoot
+  value: false
+- op: replace
+  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
+  value: false

--- a/components/manifests/overlays/kind/control-plane-env-patch.yaml
+++ b/components/manifests/overlays/kind/control-plane-env-patch.yaml
@@ -24,6 +24,8 @@ spec:
               value: "http://ambient-api-server.ambient-code.svc.cluster.local:8000"
             - name: AMBIENT_GRPC_USE_TLS
               value: "false"
+            - name: OPENSHELL_GATEWAY_SA_TOKEN_PATH
+              value: ""
             - name: LOCAL_IMAGES
               value: "true"
             - name: USE_VERTEX

--- a/components/pr-test/e2e-openshell.sh
+++ b/components/pr-test/e2e-openshell.sh
@@ -288,7 +288,7 @@ for item in data.get('items',[]):
     to = item.get('spec',{}).get('to',{})
     name = item.get('metadata',{}).get('name','')
     # Look for passthrough routes to openshell-gateway service
-    if (tls.get('termination') == 'passthrough' and 
+    if (tls.get('termination') == 'passthrough' and
         to.get('name') == gateway_name and
         ('grpc' in name or 'gateway' in name)):
         candidates.append(item['spec']['host'])

--- a/examples/overlays/tenant-a/gateway.yaml
+++ b/examples/overlays/tenant-a/gateway.yaml
@@ -5,6 +5,7 @@ server_dns_names:
   - openshell-gateway.tenant-a.svc.cluster.local
 database:
   type: postgres
+  image: postgres:16
 labels:
   purpose: openshell
   env: dev

--- a/examples/overlays/tenant-b/gateway.yaml
+++ b/examples/overlays/tenant-b/gateway.yaml
@@ -3,6 +3,8 @@ name: openshell-gateway
 image: ghcr.io/nvidia/openshell/gateway:0.0.92
 server_dns_names:
   - openshell-gateway.tenant-b.svc.cluster.local
+database:
+  image: postgres:16
 labels:
   purpose: openshell
   env: staging

--- a/examples/overlays/tenant-c/gateway.yaml
+++ b/examples/overlays/tenant-c/gateway.yaml
@@ -9,6 +9,8 @@ oidc:
   roles_claim: realm_access.roles
   admin_role: openshell-admin
   user_role: openshell-user
+database:
+  image: postgres:16
 labels:
   purpose: openshell
   env: dev

--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -21,12 +21,42 @@ AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v0.5.1}"
 # Space-separated list of tenant namespaces to provision
 IFS=' ' read -ra TENANTS <<< "${OPENSHELL_TENANTS:-tenant-a tenant-b vteam-product-swarm codebase-maintainers}"
 
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-$(command -v podman >/dev/null 2>&1 && echo podman || echo docker)}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-ambient-dev}"
+
+OPENSHELL_GATEWAY_IMAGE="${OPENSHELL_GATEWAY_IMAGE:-ghcr.io/nvidia/openshell/gateway:0.0.92}"
+OPENSHELL_PG_IMAGE="${OPENSHELL_PG_IMAGE:-registry.redhat.io/rhel9/postgresql-16:latest}"
+
 echo "Setting up OpenShell gateway prerequisites (tenants: ${TENANTS[*]})..."
 
-# 0. Suppress IPv6 (AAAA) DNS for all external domains in CoreDNS.
-#    Kind on Podman has no IPv6 connectivity. The OpenShell supervisor's DNS
-#    resolver tries IPv6 first and fails without falling back to IPv4, causing
-#    503 on inference calls (Vertex AI) and DENIED on api.anthropic.com, github.com, etc.
+# 0a. Load gateway and database images into Kind (idempotent).
+#     The control plane reconciler creates gateway Deployments that reference
+#     these images; they must be present inside the Kind node's containerd.
+_load_image() {
+  local img="$1"
+  if $CONTAINER_ENGINE exec "${KIND_CLUSTER_NAME}-control-plane" \
+      crictl inspecti "$img" >/dev/null 2>&1; then
+    echo "  Image '$img' already present in Kind"
+    return 0
+  fi
+  echo "  Pulling '$img'..."
+  if ! $CONTAINER_ENGINE pull "$img" 2>/dev/null; then
+    echo "  Warning: could not pull '$img' — skipping (registry auth may be required)"
+    return 1
+  fi
+  echo "  Loading '$img' into Kind..."
+  $CONTAINER_ENGINE save "$img" | \
+    $CONTAINER_ENGINE exec -i "${KIND_CLUSTER_NAME}-control-plane" \
+    ctr --namespace=k8s.io images import - >/dev/null 2>&1
+}
+
+_load_image "$OPENSHELL_GATEWAY_IMAGE" || true
+_load_image "$OPENSHELL_PG_IMAGE" || true
+
+# 0b. Suppress IPv6 (AAAA) DNS for all external domains in CoreDNS.
+#     Kind on Podman has no IPv6 connectivity. The OpenShell supervisor's DNS
+#     resolver tries IPv6 first and fails without falling back to IPv4, causing
+#     503 on inference calls (Vertex AI) and DENIED on api.anthropic.com, github.com, etc.
 echo "  Patching CoreDNS to suppress AAAA records (IPv4-only)..."
 COREFILE=$(kubectl get configmap coredns -n kube-system -o jsonpath='{.data.Corefile}')
 if echo "$COREFILE" | grep -q "template IN AAAA"; then

--- a/scripts/setup-kind-openshell.sh
+++ b/scripts/setup-kind-openshell.sh
@@ -25,7 +25,7 @@ CONTAINER_ENGINE="${CONTAINER_ENGINE:-$(command -v podman >/dev/null 2>&1 && ech
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-ambient-dev}"
 
 OPENSHELL_GATEWAY_IMAGE="${OPENSHELL_GATEWAY_IMAGE:-ghcr.io/nvidia/openshell/gateway:0.0.92}"
-OPENSHELL_PG_IMAGE="${OPENSHELL_PG_IMAGE:-registry.redhat.io/rhel9/postgresql-16:latest}"
+OPENSHELL_PG_IMAGE="${OPENSHELL_PG_IMAGE:-postgres:16}"
 
 echo "Setting up OpenShell gateway prerequisites (tenants: ${TENANTS[*]})..."
 

--- a/specs/platform/e2e-test-tooling.spec.md
+++ b/specs/platform/e2e-test-tooling.spec.md
@@ -453,6 +453,77 @@ Scripts SHALL NOT use `run_cmd` for internal helper functions (e.g., the `api()`
 - AND `CMD_RC` SHALL contain the exit code
 - AND the test SHALL use these variables for pass/fail assertions
 
+### Requirement: Wait Loop Progress Indicators
+
+Every wait loop in an e2e test script SHALL provide visual progress feedback using the `wait_for` helper function. Silent wait loops — loops that block for seconds or minutes without any terminal output — are prohibited. They make CI logs unreadable and leave operators guessing whether the test is stuck or working.
+
+Scripts SHALL define and use the following `wait_for` helper:
+
+```bash
+WAIT_RESULT=""
+wait_for() {
+  local msg="$1" max="$2" interval="$3"
+  shift 3
+  printf '  %b⏳ %s' "${DIM}" "$msg"
+  local _wf_i
+  for _wf_i in $(seq 1 "$max"); do
+    if "$@"; then
+      printf '%b\n' "${NC}"
+      return 0
+    fi
+    printf '.'
+    sleep "$interval"
+  done
+  printf '%b\n' "${NC}"
+  return 1
+}
+```
+
+The helper takes a human-readable message, a maximum attempt count, a sleep interval in seconds, and a check function with optional arguments. The message and dots are printed in dim text (`${DIM}`) and the color is reset (`${NC}`) only when the loop finishes, so the entire progress line renders as a single muted visual block.
+
+Check functions SHALL set the `WAIT_RESULT` global variable when callers need to inspect the last-checked value (e.g., for error messages). Common reusable check functions include:
+
+```bash
+_pod_phase_running() {
+  WAIT_RESULT=$(kubectl get pod "$1" -n "$2" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  [ "$WAIT_RESULT" = "Running" ]
+}
+
+_session_phase_active() {
+  WAIT_RESULT=$(api GET "/api/ambient/v1/sessions/$1" 2>/dev/null \
+    | jq -r '.phase // empty' 2>/dev/null || echo "")
+  [ "$WAIT_RESULT" = "Running" ] || [ "$WAIT_RESULT" = "Succeeded" ] || [ "$WAIT_RESULT" = "Failed" ]
+}
+```
+
+For loops that do not fit the `wait_for` pattern (inverted conditions like stability checks, or loops that call `run_cmd` internally), scripts SHALL add inline progress using the same dim-text-with-dots style:
+
+```bash
+printf '  %b⏳ Verifying session remains Running for 120s...' "${DIM}"
+for i in $(seq 1 12); do
+  sleep 10
+  printf '.'
+  # ... check logic ...
+done
+printf '%b\n' "${NC}"
+```
+
+Scripts SHALL NOT leave any wait loop without progress output, regardless of the loop pattern.
+
+#### Scenario: Wait loops show progress
+
+- GIVEN an e2e test script with a wait loop polling for a Kubernetes resource
+- WHEN the loop is executing
+- THEN the terminal SHALL display a `⏳` prefixed message followed by dots accumulating at the polling interval
+- AND the dots SHALL render in dim text, matching the message color
+
+#### Scenario: New wait loops use wait_for
+
+- GIVEN a developer adds a new wait loop to an e2e test
+- WHEN the loop polls a condition with sleep intervals
+- THEN the loop SHALL use the `wait_for` helper or inline progress indicators
+- AND the progress output SHALL follow the dim-text-with-dots convention
+
 ### Requirement: Section Structure
 
 Each e2e test script SHALL organize its assertions into numbered sections using banner comments and the `section()` helper. Sections SHALL use full-width separator comments in the source:

--- a/tests/e2e/fixtures/gateway-apply/gateway.yaml
+++ b/tests/e2e/fixtures/gateway-apply/gateway.yaml
@@ -2,3 +2,5 @@ kind: Gateway
 name: openshell-gateway
 server_dns_names:
   - openshell-gateway.e2e-gateway-apply.svc.cluster.local
+database:
+  image: postgres:16

--- a/tests/e2e/fixtures/openshell-cli-test/gateway.yaml
+++ b/tests/e2e/fixtures/openshell-cli-test/gateway.yaml
@@ -9,6 +9,8 @@ oidc:
   roles_claim: realm_access.roles
   admin_role: openshell-admin
   user_role: openshell-user
+database:
+  image: postgres:16
 labels:
   purpose: openshell
   env: test

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -95,7 +95,7 @@ _ensure_gateway_port_forward() {
   # Start a port-forward to the gateway gRPC port
   local gw_log
   gw_log=$(mktemp)
-  kubectl port-forward -n "${TENANT}" statefulset/openshell-gateway ":8080" \
+  kubectl port-forward -n "${TENANT}" svc/openshell-gateway ":8080" \
     >"$gw_log" 2>&1 &
   GW_PF_PID=$!
 
@@ -357,23 +357,24 @@ fi
 
 if [ "$E2E_GW_CLEANUP" = "true" ]; then
   # The gateway reconciler runs on a 30s interval. Wait up to 120s for the
-  # StatefulSet to appear, checking every 5s.
+  # gateway workload (Deployment or StatefulSet) to appear, checking every 5s.
   GW_DEPLOYED=false
   for i in $(seq 1 24); do
-    run_cmd kubectl get statefulset openshell-gateway -n "$E2E_GW_PROJECT" \
-      -o jsonpath='{.metadata.name}'
-    GW_STS="${CMD_OUTPUT:-}"
-    if [ "$GW_STS" = "openshell-gateway" ]; then
-      GW_DEPLOYED=true
-      break
-    fi
+    for _kind in deployment statefulset; do
+      _name=$(kubectl get "$_kind" openshell-gateway -n "$E2E_GW_PROJECT" \
+        -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+      if [ "$_name" = "openshell-gateway" ]; then
+        GW_DEPLOYED=true
+        break 2
+      fi
+    done
     sleep 5
   done
 
   if [ "$GW_DEPLOYED" = "true" ]; then
-    pass "Gateway StatefulSet created in namespace '${E2E_GW_PROJECT}'"
+    pass "Gateway workload created in namespace '${E2E_GW_PROJECT}'"
   else
-    fail "Gateway StatefulSet not found in namespace '${E2E_GW_PROJECT}' after 120s"
+    fail "Gateway workload not found in namespace '${E2E_GW_PROJECT}' after 120s"
     echo "  Control plane may be using gateway name as namespace instead of project namespace"
   fi
 
@@ -502,14 +503,21 @@ fi
 
 section "8. OpenShell gateway healthy"
 
-run_cmd kubectl get statefulset openshell-gateway -n "$TENANT" \
-  -o jsonpath='{.status.readyReplicas}'
-GW_READY="${CMD_OUTPUT:-0}"
+GW_READY=""
+for _kind in deployment statefulset; do
+  _val=$(kubectl get "$_kind" openshell-gateway -n "$TENANT" \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "")
+  if [ -n "$_val" ]; then
+    GW_READY="$_val"
+    GW_WORKLOAD_KIND="$_kind"
+    break
+  fi
+done
 
-if [ "${GW_READY}" -ge 1 ]; then
-  pass "openshell-gateway in ${TENANT} ready (replicas: ${GW_READY})"
+if [ "${GW_READY:-0}" -ge 1 ] 2>/dev/null; then
+  pass "openshell-gateway in ${TENANT} ready (${GW_WORKLOAD_KIND}, replicas: ${GW_READY})"
 else
-  fail "openshell-gateway in ${TENANT} not ready (readyReplicas=${GW_READY})"
+  fail "openshell-gateway in ${TENANT} not ready (readyReplicas=${GW_READY:-not found})"
 fi
 
 run_cmd kubectl get deployment agent-sandbox-controller \
@@ -1017,16 +1025,20 @@ if ! _ensure_gateway_port_forward; then
 fi
 
 # Wait for gateway pod to be fully ready — the reconciler may have restarted
-# the StatefulSet during sections 9-11 (DNS or config change detection).
+# the workload during sections 9-11 (DNS or config change detection).
 GW_READY_FOR_NET=false
 for _i in $(seq 1 30); do
-  _gw_phase=$(kubectl get pod openshell-gateway-0 -n "$TENANT" \
-    -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-  _gw_ready=$(kubectl get pod openshell-gateway-0 -n "$TENANT" \
-    -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo "")
-  if [ "$_gw_phase" = "Running" ] && [ "$_gw_ready" = "true" ]; then
-    GW_READY_FOR_NET=true
-    break
+  _gw_pod=$(kubectl get pod -n "$TENANT" -l app.kubernetes.io/name=openshell,app.kubernetes.io/component=gateway \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+  if [ -n "$_gw_pod" ]; then
+    _gw_phase=$(kubectl get pod "$_gw_pod" -n "$TENANT" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    _gw_ready=$(kubectl get pod "$_gw_pod" -n "$TENANT" \
+      -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo "")
+    if [ "$_gw_phase" = "Running" ] && [ "$_gw_ready" = "true" ]; then
+      GW_READY_FOR_NET=true
+      break
+    fi
   fi
   sleep 2
 done
@@ -1137,9 +1149,13 @@ fi
 
 # Brief gateway readiness check — cleanup may coincide with a reconciler restart
 for _i in $(seq 1 15); do
-  _gw_ready=$(kubectl get pod openshell-gateway-0 -n "$TENANT" \
-    -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo "")
-  [ "$_gw_ready" = "true" ] && break
+  _gw_pod=$(kubectl get pod -n "$TENANT" -l app.kubernetes.io/name=openshell,app.kubernetes.io/component=gateway \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+  if [ -n "$_gw_pod" ]; then
+    _gw_ready=$(kubectl get pod "$_gw_pod" -n "$TENANT" \
+      -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo "")
+    [ "$_gw_ready" = "true" ] && break
+  fi
   sleep 2
 done
 # Re-check CLI connectivity after potential gateway restart

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -797,9 +797,18 @@ if [ -n "$CREATED_SESSION_ID" ]; then
 
   else
     fail "Sandbox configuration verification — sandbox pod not ready (phase: ${WAIT_RESULT:-unknown})"
+    echo "--- DIAGNOSTIC: sandbox pod describe ---"
+    kubectl describe pod "${SBX_NAME}" -n "${TENANT}" 2>&1 | tail -30 || true
+    echo "--- DIAGNOSTIC: control plane log (last 50 lines) ---"
+    kubectl logs -n "${NAMESPACE}" -l app=ambient-control-plane --tail=50 2>&1 || true
+    echo "--- END DIAGNOSTICS ---"
+    results
+    exit 1
   fi
 else
   fail "Sandbox configuration verification — session not created"
+  results
+  exit 1
 fi
 
 # ============================================================================

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -162,6 +162,7 @@ NC='\033[0m'
 
 PASSED=0
 FAILED=0
+FAILED_TESTS=()
 CREATED_SESSION_ID=""
 CREATED_SESSIONS=()
 CMD_OUTPUT=""
@@ -169,7 +170,7 @@ CMD_RC=0
 
 sep()     { printf '%b%s%b\n' "${DIM}" "──────────────────────────────────────────────────" "${NC}"; }
 pass()    { echo -e "  ${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
-fail()    { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
+fail()    { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); FAILED_TESTS+=("$1"); }
 skip()    { echo -e "  ${YELLOW}⊘${NC} $1 (skipped: $2)"; }
 
 run_cmd() {
@@ -181,6 +182,12 @@ run_cmd() {
     echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
   fi
   echo ""
+}
+
+# Strip kubectl's "Defaulted container ..." stderr line from CMD_OUTPUT.
+# Use after run_cmd for commands whose output is compared by value.
+strip_kubectl_noise() {
+  CMD_OUTPUT=$(echo "${CMD_OUTPUT:-}" | grep -v '^Defaulted container ".*" out of:')
 }
 
 run_cmd_redact() {
@@ -207,6 +214,11 @@ results() {
   sep
   if [ "$FAILED" -gt 0 ]; then
     printf '%b  %d passed, %d failed%b\n' "${RED}" "$PASSED" "$FAILED" "${NC}"
+    echo ""
+    echo -e "  ${RED}Failed tests:${NC}"
+    for _ft in "${FAILED_TESTS[@]}"; do
+      echo -e "    ${RED}✗${NC} ${_ft}"
+    done
   else
     printf '%b  %d passed ✓%b\n' "${GREEN}" "$PASSED" "${NC}"
   fi
@@ -679,6 +691,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     # 10b. Agent environment variable passed through to sandbox
     run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       printenv CLAUDE_CODE_ATTRIBUTION_HEADER
+    strip_kubectl_noise
     ENV_VAL="${CMD_OUTPUT:-}"
     if [ "$ENV_VAL" = "0" ]; then
       pass "Agent env var CLAUDE_CODE_ATTRIBUTION_HEADER passed through to sandbox"
@@ -707,6 +720,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     # 10d. Claude settings baked into image match source
     run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       cat /sandbox/.claude/settings.json
+    strip_kubectl_noise
     SETTINGS_ACTUAL="${CMD_OUTPUT:-}"
     SETTINGS_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/claude-settings.json" 2>/dev/null || echo "")
     if [ -n "$SETTINGS_ACTUAL" ] && [ "$SETTINGS_ACTUAL" = "$SETTINGS_EXPECTED" ]; then
@@ -720,6 +734,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     # 10e. Claude settings.local.json baked into image matches source
     run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       cat /sandbox/.claude/settings.local.json
+    strip_kubectl_noise
     SETTINGS_LOCAL_ACTUAL="${CMD_OUTPUT:-}"
     SETTINGS_LOCAL_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/claude-settings-local.json" 2>/dev/null || echo "")
     if [ -n "$SETTINGS_LOCAL_ACTUAL" ] && [ "$SETTINGS_LOCAL_ACTUAL" = "$SETTINGS_LOCAL_EXPECTED" ]; then
@@ -733,6 +748,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     # 10f. Sandbox network policy present at /etc/openshell/policy.yaml
     run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       cat /etc/openshell/policy.yaml
+    strip_kubectl_noise
     POLICY_ACTUAL="${CMD_OUTPUT:-}"
     POLICY_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/policy.yaml" 2>/dev/null || echo "")
     if [ -n "$POLICY_ACTUAL" ] && [ "$POLICY_ACTUAL" = "$POLICY_EXPECTED" ]; then

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -139,6 +139,18 @@ _ensure_gateway_port_forward() {
   openshell sandbox list --gateway "${TENANT}" &>/dev/null
 }
 
+# Derives the sandbox name from a session ID, mirroring the Go
+# openshell.SandboxName() function (first 11 chars, lowercased).
+sandbox_name() {
+  echo "session-$(echo "${1:0:11}" | tr '[:upper:]' '[:lower:]')"
+}
+
+# Derives the pod name from a session ID, mirroring the Go
+# openshell.SandboxCRName(SandboxName(id)) convention.
+sandbox_pod_name() {
+  echo "default--$(sandbox_name "$1")"
+}
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -214,7 +226,7 @@ _delete_session() {
   if [ "$SKIP_CLEANUP" = "true" ]; then return 0; fi
   api DELETE "/api/ambient/v1/sessions/${sid}" >/dev/null 2>&1 && \
     echo "  Deleted session ${sid}" || true
-  local pod="session-$(echo "${sid:0:40}" | tr '[:upper:]' '[:lower:]')"
+  local pod="$(sandbox_pod_name "$sid")"
   for _i in $(seq 1 15); do
     kubectl get pod "$pod" -n "$TENANT" &>/dev/null || break
     sleep 2
@@ -237,7 +249,7 @@ cleanup() {
     for (( _i=${#CREATED_SESSIONS[@]}-1; _i>=0; _i-- )); do
       local _sid="${CREATED_SESSIONS[$_i]}"
       [ -z "$_sid" ] && continue
-      _pod="session-$(echo "${_sid:0:40}" | tr '[:upper:]' '[:lower:]')"
+      _pod="$(sandbox_pod_name "$_sid")"
       _phase=$(kubectl get pod "$_pod" -n "$TENANT" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
       if [ -n "$_phase" ]; then
         echo -e "  Retained session ${_sid}  pod=${_pod}  phase=${_phase}"
@@ -609,8 +621,7 @@ fi
 section "11. Sandbox configuration verification"
 
 if [ -n "$CREATED_SESSION_ID" ]; then
-  # Derive sandbox pod name: "session-" + lowercased session ID (first 40 chars)
-  SBX_NAME="session-$(echo "${CREATED_SESSION_ID:0:40}" | tr '[:upper:]' '[:lower:]')"
+  SBX_NAME="$(sandbox_pod_name "$CREATED_SESSION_ID")"
 
   # Wait for the sandbox pod to be running (up to 60s)
   POD_READY=false
@@ -646,7 +657,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
       # Poll briefly for the file to appear.
       PAYLOAD_READY=false
       for j in $(seq 1 10); do
-        run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- cat /sandbox/CLAUDE.md
+        run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- cat /sandbox/CLAUDE.md
         PAYLOAD_CONTENT="${CMD_OUTPUT:-}"
         if echo "$PAYLOAD_CONTENT" | grep -q "mock LLM"; then
           PAYLOAD_READY=true
@@ -666,7 +677,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10b. Agent environment variable passed through to sandbox
-    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       printenv CLAUDE_CODE_ATTRIBUTION_HEADER
     ENV_VAL="${CMD_OUTPUT:-}"
     if [ "$ENV_VAL" = "0" ]; then
@@ -676,7 +687,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10c. MCP config env var patterns preserved (not auto-expanded)
-    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       cat /sandbox/.mcp.json
     MCP_CONTENT="${CMD_OUTPUT:-}"
     if [ -n "$MCP_CONTENT" ]; then
@@ -694,7 +705,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10d. Claude settings baked into image match source
-    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       cat /sandbox/.claude/settings.json
     SETTINGS_ACTUAL="${CMD_OUTPUT:-}"
     SETTINGS_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/claude-settings.json" 2>/dev/null || echo "")
@@ -707,7 +718,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10e. Claude settings.local.json baked into image matches source
-    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       cat /sandbox/.claude/settings.local.json
     SETTINGS_LOCAL_ACTUAL="${CMD_OUTPUT:-}"
     SETTINGS_LOCAL_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/claude-settings-local.json" 2>/dev/null || echo "")
@@ -720,7 +731,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
     # 10f. Sandbox network policy present at /etc/openshell/policy.yaml
-    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -- \
+    run_cmd kubectl exec -n "$TENANT" "$SBX_NAME" -c agent -- \
       cat /etc/openshell/policy.yaml
     POLICY_ACTUAL="${CMD_OUTPUT:-}"
     POLICY_EXPECTED=$(cat "$REPO_ROOT/components/runners/ambient-runner/policy.yaml" 2>/dev/null || echo "")
@@ -774,9 +785,9 @@ if [ -n "$CREATED_SESSION_ID" ] && [ "${SESSION_RUNNING:-false}" = "true" ]; the
     echo "--- DIAGNOSTIC: sandbox pod status ---"
     kubectl get pod "${SBX_NAME}" -n "${TENANT}" -o wide 2>&1 || true
     echo "--- DIAGNOSTIC: sandbox ANTHROPIC_BASE_URL ---"
-    kubectl exec -n "${TENANT}" "${SBX_NAME}" -- printenv ANTHROPIC_BASE_URL 2>&1 || echo "(not set or pod gone)"
+    kubectl exec -n "${TENANT}" "${SBX_NAME}" -c agent -- printenv ANTHROPIC_BASE_URL 2>&1 || echo "(not set or pod gone)"
     echo "--- DIAGNOSTIC: runner log (last 80 lines) ---"
-    kubectl exec -n "${TENANT}" "${SBX_NAME}" -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
+    kubectl exec -n "${TENANT}" "${SBX_NAME}" -c agent -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
     echo "--- DIAGNOSTIC: sandbox supervisor log (last 40 lines) ---"
     kubectl logs -n "${TENANT}" "${SBX_NAME}" -c agent --tail=40 2>&1 || true
     echo "--- DIAGNOSTIC: control plane log for session (last 20 matches) ---"
@@ -808,7 +819,7 @@ if [ -n "$CREATED_SESSION_ID" ] && [ "${SESSION_RUNNING:-false}" = "true" ]; the
     echo "--- DIAGNOSTIC: sandbox pod events ---"
     kubectl describe pod "${SBX_NAME}" -n "${TENANT}" 2>&1 | grep -A 20 "^Events:" || true
     echo "--- DIAGNOSTIC: runner log (last 80 lines) ---"
-    kubectl exec -n "${TENANT}" "${SBX_NAME}" -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
+    kubectl exec -n "${TENANT}" "${SBX_NAME}" -c agent -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
     echo "--- DIAGNOSTIC: sandbox supervisor log (last 80 lines) ---"
     kubectl logs -n "${TENANT}" "${SBX_NAME}" -c agent --tail=80 2>&1 || true
     echo "--- DIAGNOSTIC: control plane log (last 100 lines) ---"
@@ -862,7 +873,7 @@ if [ -n "$CREATED_SESSION_ID" ] && [ "${SESSION_RUNNING:-false}" = "true" ]; the
     echo "--- DIAGNOSTIC: sandbox pod status ---"
     kubectl get pod "${SBX_NAME}" -n "${TENANT}" -o wide 2>&1 || true
     echo "--- DIAGNOSTIC: runner log (last 80 lines) ---"
-    kubectl exec -n "${TENANT}" "${SBX_NAME}" -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
+    kubectl exec -n "${TENANT}" "${SBX_NAME}" -c agent -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
     echo "--- DIAGNOSTIC: sandbox supervisor log (last 80 lines) ---"
     kubectl logs -n "${TENANT}" "${SBX_NAME}" -c agent --tail=80 2>&1 || true
     echo "--- DIAGNOSTIC: control plane log (last 100 lines) ---"
@@ -915,7 +926,7 @@ if [ -n "$SHORT_SESSION_ID" ]; then
     fail "stop_on_run_finished not set on session (got: '${SHORT_FLAG}')"
   fi
 
-  SHORT_SBX_NAME="session-$(echo "${SHORT_SESSION_ID:0:40}" | tr '[:upper:]' '[:lower:]')"
+  SHORT_SBX_NAME="$(sandbox_pod_name "$SHORT_SESSION_ID")"
 
   # Wait for LLM response (same polling as long-running)
   SHORT_LLM_FOUND=0
@@ -940,7 +951,7 @@ if [ -n "$SHORT_SESSION_ID" ]; then
     echo "--- DIAGNOSTIC: sandbox pod ---"
     kubectl get pod "${SHORT_SBX_NAME}" -n "${TENANT}" -o wide 2>&1 || true
     echo "--- DIAGNOSTIC: runner log ---"
-    kubectl exec -n "${TENANT}" "${SHORT_SBX_NAME}" -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
+    kubectl exec -n "${TENANT}" "${SHORT_SBX_NAME}" -c agent -- cat /sandbox/.runner/logs/runner.log 2>&1 | tail -80 || echo "(no runner log)"
     echo "--- DIAGNOSTIC: supervisor log ---"
     kubectl logs -n "${TENANT}" "${SHORT_SBX_NAME}" -c agent --tail=80 2>&1 || true
     echo "--- DIAGNOSTIC: control plane log ---"
@@ -1080,7 +1091,7 @@ if [ -n "$LOCKED_AGENT_ID" ]; then
     CREATED_SESSIONS+=("$LOCKED_SESSION_ID")
     pass "Locked-down session started (id: ${LOCKED_SESSION_ID})"
 
-    LOCKED_SBX_NAME="session-$(echo "${LOCKED_SESSION_ID:0:40}" | tr '[:upper:]' '[:lower:]')"
+    LOCKED_SBX_NAME="$(sandbox_pod_name "$LOCKED_SESSION_ID")"
 
     LOCKED_POD_READY=false
     for i in $(seq 1 30); do
@@ -1114,10 +1125,11 @@ if [ -n "$LOCKED_AGENT_ID" ]; then
       # (HTTPS would fail at the CONNECT tunnel level with no response body.)
       # FIXME: switch to `openshell sandbox exec` when it is fixed upstream.
       if [ "$LOCKED_SESSION_RUNNING" = "true" ]; then
+        LOCKED_SSH_NAME="$(sandbox_name "$LOCKED_SESSION_ID")"
         run_cmd ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
           -o LogLevel=ERROR \
-          -o "ProxyCommand=openshell ssh-proxy --gateway-name $TENANT --name $LOCKED_SBX_NAME" \
-          "user@$LOCKED_SBX_NAME" \
+          -o "ProxyCommand=openshell ssh-proxy --gateway-name $TENANT --name $LOCKED_SSH_NAME" \
+          "user@$LOCKED_SSH_NAME" \
           'curl http://update.code.visualstudio.com 2>/dev/null'
         LOCKED_CURL_OUTPUT="${CMD_OUTPUT:-}"
 
@@ -1180,7 +1192,7 @@ if [ -n "$PERM_AGENT_ID" ]; then
     CREATED_SESSIONS+=("$PERM_SESSION_ID")
     pass "Permissive session started (id: ${PERM_SESSION_ID})"
 
-    PERM_SBX_NAME="session-$(echo "${PERM_SESSION_ID:0:40}" | tr '[:upper:]' '[:lower:]')"
+    PERM_SBX_NAME="$(sandbox_pod_name "$PERM_SESSION_ID")"
 
     PERM_POD_READY=false
     for i in $(seq 1 30); do
@@ -1213,10 +1225,11 @@ if [ -n "$PERM_AGENT_ID" ]; then
       # appears, the proxy blocked it; any other response means it got through.
       # FIXME: switch to `openshell sandbox exec` when it is fixed upstream.
       if [ "$PERM_SESSION_RUNNING" = "true" ]; then
+        PERM_SSH_NAME="$(sandbox_name "$PERM_SESSION_ID")"
         run_cmd ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
           -o LogLevel=ERROR \
-          -o "ProxyCommand=openshell ssh-proxy --gateway-name $TENANT --name $PERM_SBX_NAME" \
-          "user@$PERM_SBX_NAME" \
+          -o "ProxyCommand=openshell ssh-proxy --gateway-name $TENANT --name $PERM_SSH_NAME" \
+          "user@$PERM_SSH_NAME" \
           'curl https://update.code.visualstudio.com 2>/dev/null'
         PERM_CURL_OUTPUT="${CMD_OUTPUT:-}"
 

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -67,6 +67,18 @@ _ensure_port_forward() {
   done
 }
 
+_check_port_forward() {
+  local port
+  port=$(echo "$API_URL" | sed -n 's|.*localhost:\([0-9]*\).*|\1|p' | head -1)
+  [[ -z "$port" ]] && return 0
+  local _s
+  _s=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://localhost:${port}/healthcheck" 2>/dev/null || true)
+  if [[ "$_s" = "000" || -z "$_s" ]]; then
+    echo -e "  ${YELLOW}Port-forward dead — restarting...${NC}"
+    _ensure_port_forward
+  fi
+}
+
 _ensure_port_forward
 
 _ensure_gateway_port_forward() {
@@ -171,6 +183,7 @@ run_cmd_redact() {
 }
 
 section() {
+  _check_port_forward
   echo ""
   sep
   printf '%b━━  %s%b\n' "${CYAN}" "$*" "${NC}"

--- a/tests/e2e/gateway-e2e-test.sh
+++ b/tests/e2e/gateway-e2e-test.sh
@@ -190,6 +190,69 @@ strip_kubectl_noise() {
   CMD_OUTPUT=$(echo "${CMD_OUTPUT:-}" | grep -v '^Defaulted container ".*" out of:')
 }
 
+# Poll a condition with a progress indicator.
+# Usage: wait_for <message> <max_attempts> <sleep_secs> <check_fn> [args...]
+# Returns 0 on success, 1 on timeout. Check functions set WAIT_RESULT for callers.
+WAIT_RESULT=""
+wait_for() {
+  local msg="$1" max="$2" interval="$3"
+  shift 3
+  printf '  %b⏳ %s' "${DIM}" "$msg"
+  local _wf_i
+  for _wf_i in $(seq 1 "$max"); do
+    if "$@"; then
+      printf '%b\n' "${NC}"
+      return 0
+    fi
+    printf '.'
+    sleep "$interval"
+  done
+  printf '%b\n' "${NC}"
+  return 1
+}
+
+_pod_phase_running() {
+  WAIT_RESULT=$(kubectl get pod "$1" -n "$2" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  [ "$WAIT_RESULT" = "Running" ]
+}
+
+_session_phase_active() {
+  WAIT_RESULT=$(api GET "/api/ambient/v1/sessions/$1" 2>/dev/null \
+    | jq -r '.phase // empty' 2>/dev/null || echo "")
+  [ "$WAIT_RESULT" = "Running" ] || [ "$WAIT_RESULT" = "Succeeded" ] || [ "$WAIT_RESULT" = "Failed" ]
+}
+
+_session_phase_completed() {
+  WAIT_RESULT=$(api GET "/api/ambient/v1/sessions/$1" 2>/dev/null \
+    | jq -r '.phase // empty' 2>/dev/null || echo "")
+  [ "$WAIT_RESULT" = "Completed" ] || [ "$WAIT_RESULT" = "Succeeded" ]
+}
+
+_pod_terminated() {
+  WAIT_RESULT=$(kubectl get pod "$1" -n "$2" -o jsonpath='{.status.phase}' 2>/dev/null || echo "gone")
+  [ "$WAIT_RESULT" = "gone" ] || [ "$WAIT_RESULT" = "Succeeded" ] || [ "$WAIT_RESULT" = "Failed" ]
+}
+
+_gw_pod_ready() {
+  local _gw_pod _phase _ready
+  _gw_pod=$(kubectl get pod -n "$1" -l app.kubernetes.io/name=openshell,app.kubernetes.io/component=gateway \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+  [ -z "$_gw_pod" ] && return 1
+  _phase=$(kubectl get pod "$_gw_pod" -n "$1" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  _ready=$(kubectl get pod "$_gw_pod" -n "$1" -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo "")
+  [ "$_phase" = "Running" ] && [ "$_ready" = "true" ]
+}
+
+_gw_workload_exists() {
+  local _kind _name
+  for _kind in deployment statefulset; do
+    _name=$(kubectl get "$_kind" openshell-gateway -n "$1" \
+      -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+    [ "$_name" = "openshell-gateway" ] && return 0
+  done
+  return 1
+}
+
 run_cmd_redact() {
   CMD_RC=0
   echo ""
@@ -382,20 +445,8 @@ fi
 if [ "$E2E_GW_CLEANUP" = "true" ]; then
   # The gateway reconciler runs on a 30s interval. Wait up to 120s for the
   # gateway workload (Deployment or StatefulSet) to appear, checking every 5s.
-  GW_DEPLOYED=false
-  for i in $(seq 1 24); do
-    for _kind in deployment statefulset; do
-      _name=$(kubectl get "$_kind" openshell-gateway -n "$E2E_GW_PROJECT" \
-        -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
-      if [ "$_name" = "openshell-gateway" ]; then
-        GW_DEPLOYED=true
-        break 2
-      fi
-    done
-    sleep 5
-  done
-
-  if [ "$GW_DEPLOYED" = "true" ]; then
+  if wait_for "Waiting for gateway workload in ${E2E_GW_PROJECT} (reconciler interval ~30s)..." 24 5 \
+      _gw_workload_exists "$E2E_GW_PROJECT"; then
     pass "Gateway workload created in namespace '${E2E_GW_PROJECT}'"
   else
     fail "Gateway workload not found in namespace '${E2E_GW_PROJECT}' after 120s"
@@ -636,33 +687,18 @@ if [ -n "$CREATED_SESSION_ID" ]; then
   SBX_NAME="$(sandbox_pod_name "$CREATED_SESSION_ID")"
 
   # Wait for the sandbox pod to be running (up to 60s)
-  POD_READY=false
-  for i in $(seq 1 30); do
-    POD_PHASE=$(kubectl get pod "$SBX_NAME" -n "$TENANT" \
-      -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-    if [ "$POD_PHASE" = "Running" ]; then
-      POD_READY=true
-      break
-    fi
-    sleep 2
-  done
-
-  if [ "$POD_READY" = "true" ]; then
+  if wait_for "Waiting for sandbox pod ${SBX_NAME} to be Running..." 30 2 \
+      _pod_phase_running "$SBX_NAME" "$TENANT"; then
     pass "Sandbox pod '${SBX_NAME}' is running"
 
     # The control plane uploads payloads only after the sandbox reaches READY
     # phase, passes DNS verification, and transitions the session to Running.
     # Poll for the session phase instead of using a fixed sleep.
     SESSION_RUNNING=false
-    for i in $(seq 1 30); do
-      PHASE=$(api GET "/api/ambient/v1/sessions/${CREATED_SESSION_ID}" 2>/dev/null \
-        | jq -r '.phase // empty' 2>/dev/null || echo "")
-      if [ "$PHASE" = "Running" ] || [ "$PHASE" = "Succeeded" ] || [ "$PHASE" = "Failed" ]; then
-        SESSION_RUNNING=true
-        break
-      fi
-      sleep 2
-    done
+    if wait_for "Waiting for session to reach Running phase..." 30 2 \
+        _session_phase_active "$CREATED_SESSION_ID"; then
+      SESSION_RUNNING=true
+    fi
 
     if [ "$SESSION_RUNNING" = "true" ]; then
       # Session is Running — payloads are uploaded just before exec starts.
@@ -685,7 +721,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     else
       fail "Payload /sandbox/CLAUDE.md not found or content mismatch"
       echo "  Got: $(echo "${PAYLOAD_CONTENT:-}" | head -c 200)"
-      echo "  Session phase: ${PHASE:-unknown}"
+      echo "  Session phase: ${WAIT_RESULT:-unknown}"
     fi
 
     # 10b. Agent environment variable passed through to sandbox
@@ -760,7 +796,7 @@ if [ -n "$CREATED_SESSION_ID" ]; then
     fi
 
   else
-    fail "Sandbox configuration verification — sandbox pod not ready (phase: ${POD_PHASE:-unknown})"
+    fail "Sandbox configuration verification — sandbox pod not ready (phase: ${WAIT_RESULT:-unknown})"
   fi
 else
   fail "Sandbox configuration verification — session not created"
@@ -860,8 +896,10 @@ if [ -n "$CREATED_SESSION_ID" ] && [ "${SESSION_RUNNING:-false}" = "true" ]; the
   # deprovisioning can take up to ~2 minutes to kick in.
   LONGRUN_STABLE=true
   LONGRUN_FAIL_REASON=""
+  printf '  %b⏳ Verifying session remains Running for 120s...' "${DIM}"
   for i in $(seq 1 12); do
     sleep 10
+    printf '.'
     LONGRUN_PHASE=$(api GET "/api/ambient/v1/sessions/${CREATED_SESSION_ID}" 2>/dev/null \
       | jq -r '.phase // empty' 2>/dev/null || echo "")
     LONGRUN_POD_PHASE=$(kubectl get pod "${SBX_NAME}" -n "$TENANT" \
@@ -878,6 +916,7 @@ if [ -n "$CREATED_SESSION_ID" ] && [ "${SESSION_RUNNING:-false}" = "true" ]; the
       break
     fi
   done
+  printf '%b\n' "${NC}"
 
   if [ "$LONGRUN_STABLE" = "true" ]; then
     pass "Long-running session and sandbox remained Running for 120s after LLM response"
@@ -977,21 +1016,11 @@ if [ -n "$SHORT_SESSION_ID" ]; then
 
   # After the runner finishes with stop_on_run_finished=true, the control plane
   # marks the session as Completed and deprovisions the sandbox.
-  SHORT_COMPLETED=false
-  for i in $(seq 1 60); do
-    SHORT_PHASE=$(api GET "/api/ambient/v1/sessions/${SHORT_SESSION_ID}" 2>/dev/null \
-      | jq -r '.phase // empty' 2>/dev/null || echo "")
-    if [ "$SHORT_PHASE" = "Completed" ] || [ "$SHORT_PHASE" = "Succeeded" ]; then
-      SHORT_COMPLETED=true
-      break
-    fi
-    sleep 2
-  done
-
-  if [ "$SHORT_COMPLETED" = "true" ]; then
-    pass "Short-running session transitioned to ${SHORT_PHASE}"
+  if wait_for "Waiting for short-running session to complete..." 60 2 \
+      _session_phase_completed "$SHORT_SESSION_ID"; then
+    pass "Short-running session transitioned to ${WAIT_RESULT}"
   else
-    fail "Short-running session phase is '${SHORT_PHASE}' (expected Completed)"
+    fail "Short-running session phase is '${WAIT_RESULT}' (expected Completed)"
     echo "--- DIAGNOSTIC: session status_message ---"
     api GET "/api/ambient/v1/sessions/${SHORT_SESSION_ID}" 2>/dev/null \
       | jq '{phase, status_message: .status_message}' 2>/dev/null || true
@@ -999,21 +1028,11 @@ if [ -n "$SHORT_SESSION_ID" ]; then
 
   # Verify sandbox pod is terminated after session completion (up to 120s).
   # The sandbox controller may take up to ~2 minutes to fully deprovision.
-  SHORT_SBX_GONE=false
-  for i in $(seq 1 60); do
-    SHORT_POD_PHASE=$(kubectl get pod "$SHORT_SBX_NAME" -n "$TENANT" \
-      -o jsonpath='{.status.phase}' 2>/dev/null || echo "gone")
-    if [ "$SHORT_POD_PHASE" = "gone" ] || [ "$SHORT_POD_PHASE" = "Succeeded" ] || [ "$SHORT_POD_PHASE" = "Failed" ]; then
-      SHORT_SBX_GONE=true
-      break
-    fi
-    sleep 2
-  done
-
-  if [ "$SHORT_SBX_GONE" = "true" ]; then
+  if wait_for "Waiting for short-running sandbox to terminate..." 60 2 \
+      _pod_terminated "$SHORT_SBX_NAME" "$TENANT"; then
     pass "Short-running sandbox terminated after session completion"
   else
-    fail "Short-running sandbox pod still running (phase: ${SHORT_POD_PHASE})"
+    fail "Short-running sandbox pod still running (phase: ${WAIT_RESULT})"
   fi
 else
   fail "Failed to start short-running session"
@@ -1053,24 +1072,8 @@ fi
 
 # Wait for gateway pod to be fully ready — the reconciler may have restarted
 # the workload during sections 9-11 (DNS or config change detection).
-GW_READY_FOR_NET=false
-for _i in $(seq 1 30); do
-  _gw_pod=$(kubectl get pod -n "$TENANT" -l app.kubernetes.io/name=openshell,app.kubernetes.io/component=gateway \
-    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-  if [ -n "$_gw_pod" ]; then
-    _gw_phase=$(kubectl get pod "$_gw_pod" -n "$TENANT" \
-      -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-    _gw_ready=$(kubectl get pod "$_gw_pod" -n "$TENANT" \
-      -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo "")
-    if [ "$_gw_phase" = "Running" ] && [ "$_gw_ready" = "true" ]; then
-      GW_READY_FOR_NET=true
-      break
-    fi
-  fi
-  sleep 2
-done
-
-if [ "$GW_READY_FOR_NET" = "true" ]; then
+if wait_for "Waiting for gateway pod to be ready for network tests..." 30 2 \
+    _gw_pod_ready "$TENANT"; then
   pass "Gateway pod ready for network policy tests"
   # Re-establish port-forward if gateway restarted (old PF would be stale)
   if ! openshell sandbox list --gateway "${TENANT}" &>/dev/null 2>&1; then
@@ -1097,6 +1100,16 @@ LOCKED_AGENT_ID=$(echo "$AGENTS_RESP" \
   | jq -r '.items[] | select(.name == "network-test-locked-down") | .id' 2>/dev/null | head -1 || echo "")
 
 if [ -n "$LOCKED_AGENT_ID" ]; then
+  # The start handler returns an existing active session for the same agent
+  # instead of creating a new one.  Delete any stale session (left by a prior
+  # --skip-cleanup run) so we get a fresh sandbox for this test.
+  _stale=$(api GET "/api/ambient/v1/sessions?search=agent_id+%3D+'${LOCKED_AGENT_ID}'" 2>/dev/null \
+    | jq -r '.items[]? | select(.phase == "Pending" or .phase == "Creating" or .phase == "Running") | .id' 2>/dev/null || echo "")
+  for _sid in $_stale; do
+    api DELETE "/api/ambient/v1/sessions/${_sid}" >/dev/null 2>&1 || true
+  done
+  [ -n "$_stale" ] && sleep 2
+
   LOCKED_START_RESP=$(api POST "/api/ambient/v1/projects/${PROJECT_ID}/agents/${LOCKED_AGENT_ID}/start" \
     -d '{"prompt": "gateway-e2e-test: network policy enforcement"}' || echo "")
 
@@ -1109,31 +1122,16 @@ if [ -n "$LOCKED_AGENT_ID" ]; then
 
     LOCKED_SBX_NAME="$(sandbox_pod_name "$LOCKED_SESSION_ID")"
 
-    LOCKED_POD_READY=false
-    for i in $(seq 1 30); do
-      LOCKED_POD_PHASE=$(kubectl get pod "$LOCKED_SBX_NAME" -n "$TENANT" \
-        -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-      if [ "$LOCKED_POD_PHASE" = "Running" ]; then
-        LOCKED_POD_READY=true
-        break
-      fi
-      sleep 2
-    done
-
-    if [ "$LOCKED_POD_READY" = "true" ]; then
+    if wait_for "Waiting for locked-down sandbox pod ${LOCKED_SBX_NAME}..." 30 2 \
+        _pod_phase_running "$LOCKED_SBX_NAME" "$TENANT"; then
       pass "Locked-down sandbox pod '${LOCKED_SBX_NAME}' is running"
 
       # Wait for session to reach Running phase so sandbox is fully initialized
       LOCKED_SESSION_RUNNING=false
-      for i in $(seq 1 30); do
-        LOCKED_PHASE=$(api GET "/api/ambient/v1/sessions/${LOCKED_SESSION_ID}" 2>/dev/null \
-          | jq -r '.phase // empty' 2>/dev/null || echo "")
-        if [ "$LOCKED_PHASE" = "Running" ] || [ "$LOCKED_PHASE" = "Succeeded" ] || [ "$LOCKED_PHASE" = "Failed" ]; then
-          LOCKED_SESSION_RUNNING=true
-          break
-        fi
-        sleep 2
-      done
+      if wait_for "Waiting for locked-down session to reach Running phase..." 30 2 \
+          _session_phase_active "$LOCKED_SESSION_ID"; then
+        LOCKED_SESSION_RUNNING=true
+      fi
 
       # Verify locked-down policy blocks external network access.
       # SSH into the sandbox and curl a known endpoint over plain HTTP so
@@ -1162,10 +1160,10 @@ if [ -n "$LOCKED_AGENT_ID" ]; then
           echo "--- END DIAGNOSTICS ---"
         fi
       else
-        fail "Locked-down network test — session not Running (phase: ${LOCKED_PHASE:-unknown})"
+        fail "Locked-down network test — session not Running (phase: ${WAIT_RESULT:-unknown})"
       fi
     else
-      fail "Locked-down network test — sandbox pod not ready (phase: ${LOCKED_POD_PHASE:-unknown})"
+      fail "Locked-down network test — sandbox pod not ready (phase: ${WAIT_RESULT:-unknown})"
     fi
   else
     fail "Failed to start locked-down session"
@@ -1176,16 +1174,8 @@ else
 fi
 
 # Brief gateway readiness check — cleanup may coincide with a reconciler restart
-for _i in $(seq 1 15); do
-  _gw_pod=$(kubectl get pod -n "$TENANT" -l app.kubernetes.io/name=openshell,app.kubernetes.io/component=gateway \
-    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-  if [ -n "$_gw_pod" ]; then
-    _gw_ready=$(kubectl get pod "$_gw_pod" -n "$TENANT" \
-      -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo "")
-    [ "$_gw_ready" = "true" ] && break
-  fi
-  sleep 2
-done
+wait_for "Re-checking gateway readiness before permissive test..." 15 2 \
+    _gw_pod_ready "$TENANT" || true
 # Re-check CLI connectivity after potential gateway restart
 if ! openshell sandbox list --gateway "${TENANT}" &>/dev/null 2>&1; then
   _ensure_gateway_port_forward || true
@@ -1198,6 +1188,14 @@ PERM_AGENT_ID=$(echo "$AGENTS_RESP" \
   | jq -r '.items[] | select(.name == "network-test-permissive") | .id' 2>/dev/null | head -1 || echo "")
 
 if [ -n "$PERM_AGENT_ID" ]; then
+  # Same stale-session cleanup as for the locked-down agent above.
+  _stale=$(api GET "/api/ambient/v1/sessions?search=agent_id+%3D+'${PERM_AGENT_ID}'" 2>/dev/null \
+    | jq -r '.items[]? | select(.phase == "Pending" or .phase == "Creating" or .phase == "Running") | .id' 2>/dev/null || echo "")
+  for _sid in $_stale; do
+    api DELETE "/api/ambient/v1/sessions/${_sid}" >/dev/null 2>&1 || true
+  done
+  [ -n "$_stale" ] && sleep 2
+
   PERM_START_RESP=$(api POST "/api/ambient/v1/projects/${PROJECT_ID}/agents/${PERM_AGENT_ID}/start" \
     -d '{"prompt": "gateway-e2e-test: network policy enforcement"}' || echo "")
 
@@ -1210,30 +1208,15 @@ if [ -n "$PERM_AGENT_ID" ]; then
 
     PERM_SBX_NAME="$(sandbox_pod_name "$PERM_SESSION_ID")"
 
-    PERM_POD_READY=false
-    for i in $(seq 1 30); do
-      PERM_POD_PHASE=$(kubectl get pod "$PERM_SBX_NAME" -n "$TENANT" \
-        -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-      if [ "$PERM_POD_PHASE" = "Running" ]; then
-        PERM_POD_READY=true
-        break
-      fi
-      sleep 2
-    done
-
-    if [ "$PERM_POD_READY" = "true" ]; then
+    if wait_for "Waiting for permissive sandbox pod ${PERM_SBX_NAME}..." 30 2 \
+        _pod_phase_running "$PERM_SBX_NAME" "$TENANT"; then
       pass "Permissive sandbox pod '${PERM_SBX_NAME}' is running"
 
       PERM_SESSION_RUNNING=false
-      for i in $(seq 1 30); do
-        PERM_PHASE=$(api GET "/api/ambient/v1/sessions/${PERM_SESSION_ID}" 2>/dev/null \
-          | jq -r '.phase // empty' 2>/dev/null || echo "")
-        if [ "$PERM_PHASE" = "Running" ] || [ "$PERM_PHASE" = "Succeeded" ] || [ "$PERM_PHASE" = "Failed" ]; then
-          PERM_SESSION_RUNNING=true
-          break
-        fi
-        sleep 2
-      done
+      if wait_for "Waiting for permissive session to reach Running phase..." 30 2 \
+          _session_phase_active "$PERM_SESSION_ID"; then
+        PERM_SESSION_RUNNING=true
+      fi
 
       # Verify permissive policy allows external network access via curl.
       # The permissive policy allows /usr/bin/curl to reach
@@ -1264,10 +1247,10 @@ if [ -n "$PERM_AGENT_ID" ]; then
           echo "--- END DIAGNOSTICS ---"
         fi
       else
-        fail "Permissive network test — session not Running (phase: ${PERM_PHASE:-unknown})"
+        fail "Permissive network test — session not Running (phase: ${WAIT_RESULT:-unknown})"
       fi
     else
-      fail "Permissive network test — sandbox pod not ready (phase: ${PERM_POD_PHASE:-unknown})"
+      fail "Permissive network test — sandbox pod not ready (phase: ${WAIT_RESULT:-unknown})"
     fi
   else
     fail "Failed to start permissive session"

--- a/tests/e2e/local-dev-test.sh
+++ b/tests/e2e/local-dev-test.sh
@@ -684,7 +684,7 @@ test_security_token_redaction() {
     fi
 
     # Test 1: Logs should use tokenLen= instead of showing token
-    if echo "$logs" | grep -q "tokenLen=\|token (len="; then
+    if echo "$logs" | grep -q "tokenLen=\|token (len=\|REDACTED:len="; then
         pass "Logs use token length instead of token value (correct redaction)"
     else
         log_info "Token length logging not found (may need authenticated requests)"

--- a/tests/e2e/local-dev-test.sh
+++ b/tests/e2e/local-dev-test.sh
@@ -194,7 +194,13 @@ test_prerequisites() {
     assert_command_exists "make"
     assert_command_exists "kubectl"
     assert_command_exists "kind"
-    assert_command_exists "podman" || assert_command_exists "docker"
+    if command -v podman >/dev/null 2>&1; then
+        pass "Container runtime 'podman' is installed"
+    elif command -v docker >/dev/null 2>&1; then
+        pass "Container runtime 'docker' is installed"
+    else
+        fail "No container runtime installed (need podman or docker)"
+    fi
 
     # Check if running on macOS or Linux
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/tests/e2e/openshell-cli-e2e.sh
+++ b/tests/e2e/openshell-cli-e2e.sh
@@ -115,6 +115,33 @@ run_cmd() {
   echo ""
 }
 
+# Retry a command until an assertion on CMD_OUTPUT/CMD_RC passes.
+# Usage: eventually <max_attempts> <interval_secs> <assertion_fn> <cmd...>
+#   assertion_fn receives no args and should inspect CMD_OUTPUT/CMD_RC,
+#   returning 0 on success or non-zero to retry.
+eventually() {
+  local max_attempts=$1 interval=$2 assertion=$3
+  shift 3
+  local attempt=1
+  while [ "$attempt" -le "$max_attempts" ]; do
+    CMD_RC=0
+    CMD_OUTPUT=$("$@" 2>&1) || CMD_RC=$?
+    if $assertion; then
+      if [ "$attempt" -gt 1 ]; then
+        printf '    %b(passed on attempt %d/%d)%b\n' "${DIM}" "$attempt" "$max_attempts" "${NC}"
+      fi
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      printf '    %bretry %d/%d (waiting %ds)...%b\n' "${DIM}" "$attempt" "$max_attempts" "$interval" "${NC}"
+      sleep "$interval"
+    fi
+    ((attempt++))
+  done
+  echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
+  return 1
+}
+
 # --- Cleanup ---
 
 cleanup() {
@@ -453,11 +480,14 @@ fi
 
 # Exec into sandbox (only if ready)
 if [ "$SANDBOX_READY" = "true" ]; then
-  run_cmd openshell sandbox exec --gateway "$GATEWAY_NAME" -n "$SANDBOX_NAME" -- echo hello
-  if echo "$CMD_OUTPUT" | grep -q "hello"; then
+  printf '  %b▶%b  %b$ openshell sandbox exec --gateway "%s" -n "%s" -- echo hello%b\n' \
+    "${BOLD}" "${NC}" "${ORANGE}" "$GATEWAY_NAME" "$SANDBOX_NAME" "${NC}"
+  _assert_hello() { echo "$CMD_OUTPUT" | grep -q "hello"; }
+  if eventually 10 3 _assert_hello \
+    openshell sandbox exec --gateway "$GATEWAY_NAME" -n "$SANDBOX_NAME" -- echo hello; then
     pass "Sandbox exec: 'echo hello' returned 'hello'"
   else
-    fail "Sandbox exec: expected 'hello' in output"
+    fail "Sandbox exec: expected 'hello' in output (after retries)"
   fi
 else
   skip "Sandbox exec" "sandbox not ready"
@@ -616,11 +646,11 @@ else
   fi
 
   # Policy enforcement: allowed endpoint
-  printf '  %b▶%b  Policy enforcement (waiting 3s for propagation)...\n' "${BOLD}" "${NC}"
-  sleep 3
-  run_cmd openshell sandbox exec --gateway "$GATEWAY_NAME" \
-    -n "$SANDBOX_NAME" -- curl -sf https://update.code.visualstudio.com
-  if [ "$CMD_RC" -eq 0 ]; then
+  printf '  %b▶%b  Policy enforcement (with retries for supervisor relay)...\n' "${BOLD}" "${NC}"
+  _assert_allowed() { [ "$CMD_RC" -eq 0 ]; }
+  if eventually 10 3 _assert_allowed \
+    openshell sandbox exec --gateway "$GATEWAY_NAME" \
+      -n "$SANDBOX_NAME" -- curl -sf https://update.code.visualstudio.com; then
     pass "Policy enforcement: allowed endpoint (update.code.visualstudio.com) reachable"
   elif echo "$CMD_OUTPUT" | grep -q "policy_denied"; then
     fail "Allowed endpoint was denied by policy"
@@ -629,12 +659,15 @@ else
   fi
 
   # Policy enforcement: blocked endpoint
-  run_cmd openshell sandbox exec --gateway "$GATEWAY_NAME" \
-    -n "$SANDBOX_NAME" -- curl -sf http://example.com
-  if echo "$CMD_OUTPUT" | grep -q "policy_denied"; then
-    pass "Policy enforcement: blocked endpoint returned policy_denied"
-  elif [ "$CMD_RC" -ne 0 ]; then
-    pass "Policy enforcement: blocked endpoint rejected (rc=${CMD_RC})"
+  _assert_blocked() { echo "$CMD_OUTPUT" | grep -q "policy_denied" || [ "$CMD_RC" -ne 0 ]; }
+  if eventually 10 3 _assert_blocked \
+    openshell sandbox exec --gateway "$GATEWAY_NAME" \
+      -n "$SANDBOX_NAME" -- curl -sf http://example.com; then
+    if echo "$CMD_OUTPUT" | grep -q "policy_denied"; then
+      pass "Policy enforcement: blocked endpoint returned policy_denied"
+    else
+      pass "Policy enforcement: blocked endpoint rejected (rc=${CMD_RC})"
+    fi
   else
     fail "Policy enforcement: blocked endpoint was NOT denied"
   fi

--- a/tests/e2e/openshell-cli-e2e.sh
+++ b/tests/e2e/openshell-cli-e2e.sh
@@ -438,6 +438,11 @@ run_cmd $ACPCTL login --password-grant \
   --url "$API_URL" --project "$TENANT"
 openshell gateway remove "${GATEWAY_NAME}" 2>/dev/null || true
 run_cmd $ACPCTL gateway setup-cli --kubectl --project "$TENANT"
+if [ "$CMD_RC" -ne 0 ]; then
+  fail "acpctl gateway setup-cli failed (token refresh)"
+  echo ""; sep; printf '%b  %d passed, %d failed%b\n' "${RED}" "$PASSED" "$FAILED" "${NC}"; sep; echo ""
+  exit 1
+fi
 
 # List sandboxes
 run_cmd openshell sandbox list --gateway "$GATEWAY_NAME"
@@ -445,6 +450,8 @@ if echo "$CMD_OUTPUT" | grep -q "$SANDBOX_NAME"; then
   pass "Sandbox appears in list output"
 else
   fail "Sandbox '${SANDBOX_NAME}' not found in sandbox list"
+  echo ""; sep; printf '%b  %d passed, %d failed%b\n' "${RED}" "$PASSED" "$FAILED" "${NC}"; sep; echo ""
+  exit 1
 fi
 
 # Poll for sandbox readiness (180s timeout, 2s interval)
@@ -483,7 +490,7 @@ if [ "$SANDBOX_READY" = "true" ]; then
   printf '  %b▶%b  %b$ openshell sandbox exec --gateway "%s" -n "%s" -- echo hello%b\n' \
     "${BOLD}" "${NC}" "${ORANGE}" "$GATEWAY_NAME" "$SANDBOX_NAME" "${NC}"
   _assert_hello() { echo "$CMD_OUTPUT" | grep -q "hello"; }
-  if eventually 10 3 _assert_hello \
+  if eventually 5 3 _assert_hello \
     openshell sandbox exec --gateway "$GATEWAY_NAME" -n "$SANDBOX_NAME" -- echo hello; then
     pass "Sandbox exec: 'echo hello' returned 'hello'"
   else
@@ -648,7 +655,7 @@ else
   # Policy enforcement: allowed endpoint
   printf '  %b▶%b  Policy enforcement (with retries for supervisor relay)...\n' "${BOLD}" "${NC}"
   _assert_allowed() { [ "$CMD_RC" -eq 0 ]; }
-  if eventually 10 3 _assert_allowed \
+  if eventually 5 3 _assert_allowed \
     openshell sandbox exec --gateway "$GATEWAY_NAME" \
       -n "$SANDBOX_NAME" -- curl -sf https://update.code.visualstudio.com; then
     pass "Policy enforcement: allowed endpoint (update.code.visualstudio.com) reachable"
@@ -660,7 +667,7 @@ else
 
   # Policy enforcement: blocked endpoint
   _assert_blocked() { echo "$CMD_OUTPUT" | grep -q "policy_denied" || [ "$CMD_RC" -ne 0 ]; }
-  if eventually 10 3 _assert_blocked \
+  if eventually 5 3 _assert_blocked \
     openshell sandbox exec --gateway "$GATEWAY_NAME" \
       -n "$SANDBOX_NAME" -- curl -sf http://example.com; then
     if echo "$CMD_OUTPUT" | grep -q "policy_denied"; then

--- a/tests/e2e/openshell-cli-e2e.sh
+++ b/tests/e2e/openshell-cli-e2e.sh
@@ -80,10 +80,11 @@ NC='\033[0m'
 
 PASSED=0
 FAILED=0
+FAILED_TESTS=()
 
 sep()     { printf '%b%s%b\n' "${DIM}" "──────────────────────────────────────────────────" "${NC}"; }
 pass()    { echo -e "  ${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
-fail()    { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
+fail()    { echo -e "  ${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); FAILED_TESTS+=("$1"); }
 skip()    { echo -e "  ${YELLOW}⊘${NC} $1 (skipped: $2)"; }
 
 section() {
@@ -140,6 +141,46 @@ eventually() {
   done
   echo "$CMD_OUTPUT" | head -20 | sed 's/^/    /'
   return 1
+}
+
+# Poll a condition with a progress indicator.
+# Usage: wait_for <message> <max_attempts> <sleep_secs> <check_fn> [args...]
+# Returns 0 on success, 1 on timeout.
+WAIT_RESULT=""
+wait_for() {
+  local msg="$1" max="$2" interval="$3"
+  shift 3
+  printf '  %b⏳ %s' "${DIM}" "$msg"
+  local _wf_i
+  for _wf_i in $(seq 1 "$max"); do
+    if "$@"; then
+      printf '%b\n' "${NC}"
+      return 0
+    fi
+    printf '.'
+    sleep "$interval"
+  done
+  printf '%b\n' "${NC}"
+  return 1
+}
+
+_kubectl_pod_exists() {
+  kubectl get pod -l "$1" -n "$2" --no-headers 2>/dev/null | grep -q .
+}
+
+_certgen_finished() {
+  local _cg
+  _cg=$(kubectl get pod -n "$1" --no-headers 2>/dev/null | grep "certgen" || true)
+  [ -n "$_cg" ] && echo "$_cg" | grep -qE "Completed|Error"
+}
+
+_tls_secrets_exist() {
+  kubectl get secret openshell-ca-tls openshell-server-tls openshell-client-tls \
+    -n "$1" &>/dev/null
+}
+
+_kubectl_pod_running() {
+  kubectl get pod -l "$1" -n "$2" --no-headers 2>/dev/null | grep -q "Running"
 }
 
 # --- Cleanup ---
@@ -273,12 +314,9 @@ else
 fi
 
 # Wait for gateway pod to exist and reach ready (control plane reconciles asynchronously)
-printf '  %b▶%b  Waiting for gateway pod in %s...\n' "${BOLD}" "${NC}" "$TENANT"
 GW_POD_LABELS="app.kubernetes.io/instance=openshell-gateway,app.kubernetes.io/component=gateway"
-for _i in $(seq 1 120); do
-  kubectl get pod -l "$GW_POD_LABELS" -n "$TENANT" --no-headers 2>/dev/null | grep -q . && break
-  sleep 3
-done
+wait_for "Waiting for gateway pod in ${TENANT}..." 120 3 \
+    _kubectl_pod_exists "$GW_POD_LABELS" "$TENANT" || true
 kubectl wait --for=condition=ready pod -l "$GW_POD_LABELS" \
   -n "$TENANT" --timeout=180s 2>/dev/null || {
     fail "Gateway pod not ready in ${TENANT} after waiting"
@@ -297,24 +335,14 @@ pass "Gateway pod ready in ${TENANT}"
 #   2. Delete the server/client secrets (force cert-manager re-issue)
 #   3. Wait for cert-manager to recreate them
 #   4. Restart the gateway pod so it loads the final certs
-printf '  %b▶%b  Waiting for certgen to finish in %s...\n' "${BOLD}" "${NC}" "$TENANT"
-for _i in $(seq 1 30); do
-  _cg=$(kubectl get pod -n "$TENANT" --no-headers 2>/dev/null | grep "certgen" || true)
-  if [ -n "$_cg" ] && echo "$_cg" | grep -qE "Completed|Error"; then
-    break
-  fi
-  sleep 2
-done
+wait_for "Waiting for certgen to finish in ${TENANT}..." 30 2 \
+    _certgen_finished "$TENANT" || true
 
 kubectl delete secret openshell-server-tls openshell-client-tls \
   -n "$TENANT" --ignore-not-found 2>/dev/null || true
 
-printf '  %b▶%b  Waiting for cert-manager to issue TLS secrets in %s...\n' "${BOLD}" "${NC}" "$TENANT"
-for _i in $(seq 1 60); do
-  kubectl get secret openshell-ca-tls openshell-server-tls openshell-client-tls \
-    -n "$TENANT" &>/dev/null && break
-  sleep 3
-done
+wait_for "Waiting for cert-manager to issue TLS secrets in ${TENANT}..." 60 3 \
+    _tls_secrets_exist "$TENANT" || true
 if kubectl get secret openshell-ca-tls openshell-server-tls openshell-client-tls \
   -n "$TENANT" &>/dev/null; then
   pass "cert-manager TLS secrets ready in ${TENANT}"
@@ -326,10 +354,8 @@ else
 fi
 
 kubectl delete pod -l "$GW_POD_LABELS" -n "$TENANT" --wait=false
-for _i in $(seq 1 60); do
-  kubectl get pod -l "$GW_POD_LABELS" -n "$TENANT" --no-headers 2>/dev/null | grep -q "Running" && break
-  sleep 3
-done
+wait_for "Waiting for gateway pod to restart in ${TENANT}..." 60 3 \
+    _kubectl_pod_running "$GW_POD_LABELS" "$TENANT" || true
 kubectl wait --for=condition=ready pod -l "$GW_POD_LABELS" \
   -n "$TENANT" --timeout=120s 2>/dev/null || {
     fail "Gateway pod not ready after cert-manager restart"
@@ -852,6 +878,11 @@ echo ""
 sep
 if [ "$FAILED" -gt 0 ]; then
   printf '%b  %d passed, %d failed%b\n' "${RED}" "$PASSED" "$FAILED" "${NC}"
+  echo ""
+  printf '%b  Failed tests:%b\n' "${RED}" "${NC}"
+  for _ft in "${FAILED_TESTS[@]}"; do
+    printf '    %b✗ %s%b\n' "${RED}" "$_ft" "${NC}"
+  done
 else
   printf '%b  %d passed ✓%b\n' "${GREEN}" "$PASSED" "${NC}"
 fi


### PR DESCRIPTION
## Summary

Fixes to get the `test-local-dev-simulation` CI workflow green across Gateway E2E, OpenShell CLI E2E, and local Kind cluster setup.

**Control plane fixes:**
- Fix ndots:5 DNS workaround — delete sandbox pod for recreation from the patched CR instead of futile in-place sed, since the Sandbox CRD doesn't support `podTemplate.spec.dnsConfig`
- Fix static token auth — set a username on the static token path so the RBAC interceptor can auto-provision a service account, resolving gRPC "authorization service unavailable" errors
- Fix gateway NetworkPolicy to allow sandbox pods with the new `agents.x-k8s.io/sandbox-name-hash` label scheme (not just the old `openshell.ai/managed-by=openshell`)

**API server fix:**
- Redact `Authorization` and `X-Forwarded-Access-Token` headers in request logs

**CI workflow fix:**
- Map `image-tag` and `built-images` inputs to env vars in `test-local-dev-simulation` — they were never wired up, so CI always deployed `:latest` instead of the PR-built image

**E2E test fixes:**
- Align sandbox pod naming with control plane convention (`default--session-<first11chars>` not `session-<first40chars>`)
- Preload gateway/postgres images into Kind to avoid `ImagePullBackOff`
- Support both Deployment and StatefulSet gateway workloads in assertions
- Auto-restart dead port-forwards between test sections
- Add `eventually` retries around sandbox exec calls for supervisor relay startup lag
- Clean stale sessions before network-policy tests to avoid reusing sessions from prior `--skip-cleanup` runs
- Refactor all silent polling loops into `wait_for()` helpers with progress dots
- List failed test names in the results summary
- Strip `kubectl` "Defaulted container" stderr noise from `CMD_OUTPUT`
- Don't fail prereqs when podman is absent but docker is available

## Test plan

- [ ] `test-local-dev-simulation` CI workflow passes (Gateway E2E, OpenShell CLI E2E, RBAC E2E, Scheduled Sessions E2E)
- [ ] Control plane reconciler unit tests pass
- [ ] Local Kind cluster deploys successfully with `make kind-up`
- [ ] Re-running e2e tests after `--skip-cleanup` no longer hits stale session reuse