### PR TITLE
fix(control-plane): set workspace on vertex credential refresh gRPC requests

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -528,6 +528,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 			Providers:   providerNames,
 			Policy:      sandboxPolicy,
 		},
+		Workspace: "default",
 	}
 
 	if _, err := r.gateway.CreateSandbox(ctx, namespace, req); err != nil {
@@ -1607,6 +1608,7 @@ func (r *SimpleKubeReconciler) configureInferenceFromProviders(ctx context.Conte
 			ProviderName: osName,
 			ModelId:      inferenceModel,
 			NoVerify:     true,
+			Workspace:    "default",
 		})
 		if err != nil {
 			if status.Code(err) == codes.Unimplemented {

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -50,6 +50,9 @@ const (
 
 	annotationCredentialSourceNamespace = "ambient.ai/credential-source-namespace"
 	annotationCredentialSourceName      = "ambient.ai/credential-source-name"
+
+	// ACP currently uses a single "default" workspace on OpenShell gateways.
+	gatewayWorkspace = "default"
 )
 
 type credentialSidecarSpec struct {
@@ -528,7 +531,7 @@ func (r *SimpleKubeReconciler) provisionSessionSandbox(ctx context.Context, sess
 			Providers:   providerNames,
 			Policy:      sandboxPolicy,
 		},
-		Workspace: "default",
+		Workspace: gatewayWorkspace,
 	}
 
 	if _, err := r.gateway.CreateSandbox(ctx, namespace, req); err != nil {
@@ -1174,7 +1177,7 @@ func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context
 				"private_key":  material.PrivateKey,
 			},
 			SecretMaterialKeys: []string{"private_key"},
-			Workspace:          "default",
+			Workspace:          gatewayWorkspace,
 		}
 		r.logger.Info().
 			Str("provider", provName).
@@ -1201,7 +1204,7 @@ func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context
 				"private_key":   "not-used-for-oauth2",
 			},
 			SecretMaterialKeys: []string{"client_secret", "refresh_token", "private_key"},
-			Workspace:          "default",
+			Workspace:          gatewayWorkspace,
 		}
 		r.logger.Info().
 			Str("provider", provName).
@@ -1218,7 +1221,7 @@ func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context
 	rotateResp, err := r.gateway.RotateProviderCredential(ctx, namespace, &openshellpb.RotateProviderCredentialRequest{
 		Provider:      provName,
 		CredentialKey: credKey,
-		Workspace:     "default",
+		Workspace:     gatewayWorkspace,
 	})
 	if err != nil {
 		r.logger.Warn().Err(err).
@@ -1608,7 +1611,7 @@ func (r *SimpleKubeReconciler) configureInferenceFromProviders(ctx context.Conte
 			ProviderName: osName,
 			ModelId:      inferenceModel,
 			NoVerify:     true,
-			Workspace:    "default",
+			Workspace:    gatewayWorkspace,
 		})
 		if err != nil {
 			if status.Code(err) == codes.Unimplemented {

--- a/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
+++ b/components/ambient-control-plane/internal/reconciler/kube_reconciler.go
@@ -1173,6 +1173,7 @@ func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context
 				"private_key":  material.PrivateKey,
 			},
 			SecretMaterialKeys: []string{"private_key"},
+			Workspace:          "default",
 		}
 		r.logger.Info().
 			Str("provider", provName).
@@ -1199,6 +1200,7 @@ func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context
 				"private_key":   "not-used-for-oauth2",
 			},
 			SecretMaterialKeys: []string{"client_secret", "refresh_token", "private_key"},
+			Workspace:          "default",
 		}
 		r.logger.Info().
 			Str("provider", provName).
@@ -1215,6 +1217,7 @@ func (r *SimpleKubeReconciler) ensureVertexCredentialRefresh(ctx context.Context
 	rotateResp, err := r.gateway.RotateProviderCredential(ctx, namespace, &openshellpb.RotateProviderCredentialRequest{
 		Provider:      provName,
 		CredentialKey: credKey,
+		Workspace:     "default",
 	})
 	if err != nil {
 		r.logger.Warn().Err(err).


### PR DESCRIPTION
## Summary
- The OpenShell gateway requires a non-empty `workspace` field when persisting `StoredProviderCredentialRefreshState`
- The control plane was constructing `ConfigureProviderRefreshRequest` and `RotateProviderCredentialRequest` without setting `Workspace`, causing sandbox creation to fail for Vertex providers with: `provider_credential_refresh_state requires a non-empty workspace`
- Sets `Workspace: "default"` on all three gRPC request constructions in `ensureVertexCredentialRefresh`

## Test plan
- [ ] Deploy to dev cluster and create a session with a Vertex provider — verify sandbox creation succeeds
- [ ] Confirm credential refresh and rotation complete without errors in control plane logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)