### PR TITLE
fix(control-plane): use FQDN for sandbox-injected service URLs

### DIFF
--- a/components/ambient-control-plane/internal/reconciler/sandbox_policy.go
+++ b/components/ambient-control-plane/internal/reconciler/sandbox_policy.go
@@ -59,11 +59,8 @@ func acpInternalRule(namespace string) *sandboxpb.NetworkPolicyRule {
 	return &sandboxpb.NetworkPolicyRule{
 		Name: "acp-internal",
 		Endpoints: []*sandboxpb.NetworkEndpoint{
-			{Host: "ambient-control-plane." + namespace + ".svc", Port: 8080},
 			{Host: "ambient-control-plane." + namespace + ".svc.cluster.local", Port: 8080},
-			{Host: "ambient-api-server." + namespace + ".svc", Port: 8000},
 			{Host: "ambient-api-server." + namespace + ".svc.cluster.local", Port: 8000},
-			{Host: "ambient-api-server." + namespace + ".svc", Port: 9000},
 			{Host: "ambient-api-server." + namespace + ".svc.cluster.local", Port: 9000},
 		},
 		Binaries: []*sandboxpb.NetworkBinary{

--- a/components/manifests/overlays/hcmais-dev/control-plane-env-patch.yaml
+++ b/components/manifests/overlays/hcmais-dev/control-plane-env-patch.yaml
@@ -15,7 +15,7 @@ spec:
             - name: AMBIENT_GRPC_USE_TLS
               value: "false"
             - name: CP_TOKEN_URL
-              value: "http://ambient-control-plane.ambient-dev.svc:8080/token"
+              value: "http://ambient-control-plane.ambient-dev.svc.cluster.local:8080/token"
             - name: OIDC_TOKEN_URL
               value: "https://keycloak-ambient-keycloak.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com/realms/ambient-code/protocol/openid-connect/token"
             - name: OIDC_CLIENT_ID

--- a/components/manifests/overlays/hcmais/control-plane-env-patch.yaml
+++ b/components/manifests/overlays/hcmais/control-plane-env-patch.yaml
@@ -15,7 +15,7 @@ spec:
             - name: AMBIENT_GRPC_USE_TLS
               value: "false"
             - name: CP_TOKEN_URL
-              value: "http://ambient-control-plane.ambient-api.svc:8080/token"
+              value: "http://ambient-control-plane.ambient-api.svc.cluster.local:8080/token"
             - name: OIDC_TOKEN_URL
               value: "https://keycloak-ambient-keycloak.apps.rosa.hcmais01ue1.s9m2.p3.openshiftapps.com/realms/ambient-code/protocol/openid-connect/token"
             - name: OIDC_CLIENT_ID

--- a/components/manifests/templates/template-services.yaml
+++ b/components/manifests/templates/template-services.yaml
@@ -361,7 +361,7 @@ objects:
               - name: MCP_API_SERVER_URL
                 value: "http://ambient-api-server.${NAMESPACE}.svc:8000"
               - name: CP_TOKEN_URL
-                value: "http://ambient-control-plane.${NAMESPACE}.svc:8080/token"
+                value: "http://ambient-control-plane.${NAMESPACE}.svc.cluster.local:8080/token"
               - name: CP_RUNTIME_NAMESPACE
                 valueFrom:
                   fieldRef:


### PR DESCRIPTION
## Summary

- Use `.svc.cluster.local` FQDN in `CP_TOKEN_URL` across all deployment manifests
- Remove redundant `.svc` (non-FQDN) endpoints from sandbox network policy in `sandbox_policy.go`

## Problem

The `ndots:1` workaround for [NVIDIA/OpenShell#2053](https://github.com/NVIDIA/OpenShell/issues/2053) (musl libc DNS bug, fix proposed in [PR #2054](https://github.com/NVIDIA/OpenShell/pull/2054)) causes `.svc` short names to fail DNS resolution inside sandbox pods. With `ndots:1`, hostnames with 1+ dots are tried as absolute names first — `ambient-control-plane.<ns>.svc` is not a valid FQDN and fails with:

```
DNS resolution failed for ambient-control-plane.ambient-code.svc:8080:
failed to lookup address information: Name does not resolve
```

With the default `ndots:5`, the same name (3 dots < 5) would have search domains appended first, resolving correctly. The FQDN `.svc.cluster.local` resolves correctly regardless of `ndots` setting.

## Test plan

- [ ] Verify sandbox sessions start successfully on ROSA cluster
- [ ] Verify runner can reach control plane via `CP_TOKEN_URL`
- [ ] Verify kind cluster sessions still work (`.svc.cluster.local` is the standard Kubernetes FQDN)

🤖 Generated with [Claude Code](https://claude.ai/code)