### PR TITLE
fix(kind): fail loudly when fleet tenant apply fails in kind-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -991,26 +991,32 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 		sleep 2; \
 		TOKEN=$$(kubectl get secret test-user-token -n $(NAMESPACE) -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null); \
 		$$ACPCTL login --url "http://localhost:$${PF_PORT}" --token "$$TOKEN" >/dev/null 2>&1; \
+		FLEET_FAILED=""; \
 		for ns in $(OPENSHELL_TENANTS); do \
 			if echo " $(SKIP_TENANT_SETUP) " | grep -q " $$ns "; then \
 				echo "  $$ns: skipped (SKIP_TENANT_SETUP)"; \
 				continue; \
 			fi; \
+			[ -f "examples/overlays/$$ns/kustomization.yaml" ] || continue; \
 			if [ -f "$(VERTEX_CRED)" ]; then \
 				kubectl create secret generic vertex-sa-key \
 					--namespace="$$ns" \
 					"--from-literal=token=$$(cat '$(VERTEX_CRED)')" \
 					--dry-run=client -o yaml | kubectl apply -f - 2>/dev/null; \
 			fi; \
-			if [ -d "examples/overlays/$$ns" ]; then \
-				VERTEX_SA_KEY=$$(cat "$(VERTEX_CRED)" 2>/dev/null || echo "") \
-				$$ACPCTL apply -k "examples/overlays/$$ns/" --project "$$ns" && \
+			if VERTEX_SA_KEY=$$(cat "$(VERTEX_CRED)" 2>/dev/null || echo "") \
+				$$ACPCTL apply -k "examples/overlays/$$ns/" --project "$$ns"; then \
 				echo "  $$ns: applied"; \
 			else \
-				echo "  $$ns: no overlay directory — skipping fleet"; \
+				echo "$(COLOR_RED)✗$(COLOR_RESET) $$ns: apply failed"; \
+				FLEET_FAILED="$$FLEET_FAILED $$ns"; \
 			fi; \
 		done; \
 		kill $$PF_PID 2>/dev/null || true; \
+		if [ -n "$$FLEET_FAILED" ]; then \
+			echo "$(COLOR_RED)✗$(COLOR_RESET) Fleet provisioning failed for:$$FLEET_FAILED"; \
+			exit 1; \
+		fi; \
 	fi
 	@if [ -f .dev-bootstrap.env ] && [ -f ./scripts/bootstrap-workspace.sh ]; then \
 		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Bootstrapping developer workspace..."; \


### PR DESCRIPTION
Previously the fleet loop in `kind-up` silently moved on if `acpctl apply -k` returned non-zero or the overlay directory was absent. A broken tenant provisioning appeared as a successful `make kind-up`.

## Changes

- Skip tenants that have no `kustomization.yaml` (precise check, replaces directory existence check)
- Collect apply failures into `FLEET_FAILED` instead of swallowing them
- Exit 1 after the loop if any tenant apply failed

## Replaces

Closes #369 — that PR bundled this fix with doc and OPENSHELL_TENANTS changes. The OPENSHELL_TENANTS change is handled separately; the doc changes are no longer needed.