### PR TITLE
spec: reconciler token refresh for stale OIDC bug

### DIFF
--- a/specs/index.spec.md
+++ b/specs/index.spec.md
@@ -37,6 +37,7 @@ Machine-readable index for autonomous reconciliation (`/reconcile` skill).
 | `platform/session-activity-tracking.spec.md` | platform | Session (last_activity_at) | BE, API | data-model |
 | `platform/agent-inheritance.spec.md` | platform | Agent (kustomize overlays) | CP | agent-sandbox-config |
 | `platform/runner-constitution.md` | platform | Runner (governance) | Runner | runner |
+| `platform/reconciler-token-refresh.spec.md` | platform | SDKClientFactory, execAfterReady, OIDCTokenProvider | CP | control-plane, openshell-gateway-oidc |
 | `platform/openshell-cli-e2e-test.spec.md` | platform | E2E test (openshell CLI), Demo script | Tests, CLI | openshell-sandbox-provisioning, gateway-provisioning |
 | `security/identity-boundaries.spec.md` | security | Identity types (6) | CP, BE, Runner | - |
 | `security/sso-authentication.spec.md` | security | OIDC, JWT, BFF session | BE, FE, CLI | identity-boundaries |

--- a/specs/platform/reconciler-token-refresh.spec.md
+++ b/specs/platform/reconciler-token-refresh.spec.md
@@ -20,11 +20,14 @@ Session `dasfadsfdsa` (`3HHmQCYv7CBSoNwuiSeVohWmLm7`):
 | Time | Event |
 |------|-------|
 | 21:24:48 | OIDC token acquired (expires 21:29:48, 5 min TTL) |
-| 21:29:09 | `provisionSessionSandbox` → `ForProject()` captures SDK client with current token |
+| 21:29:09 | `provisionSessionSandbox` → `ForProject()` captures SDK client with current token (~39s remaining) |
 | 21:29:09 | Sandbox created, `execAfterReady` goroutine spawned |
 | 21:29:51–21:30:15 | Three ndots retry cycles (pod deleted and recreated 3×, ~26s added) |
-| 21:30:31 | Sandbox ready; `UpdateStatus(phase=Running)` → **HTTP 401** (token expired ~40s ago) |
+| 21:29:48 | Token expires — only ~39s after capture, not the full 5 min TTL |
+| 21:30:31 | Sandbox ready; `UpdateStatus(phase=Running)` → **HTTP 401** (token expired ~43s ago) |
 | 21:30:44 | `markCompleted` → **HTTP 401** |
+
+The token had only ~39 seconds of remaining validity at the time `ForProject()` captured it — the OIDC token was acquired ~4 min 21 s earlier by a prior reconciler cycle. This means even a short sandbox wait (30–90 seconds) can trigger a 401 if the token happens to be near expiry at capture time.
 
 The session never left `Creating`. The UI showed it stuck indefinitely.
 
@@ -63,6 +66,16 @@ This ensures that `OIDCTokenProvider.Token()` is called at the moment the token 
 - THEN `ForProject()` SHALL return the cached client (token unchanged)
 - AND no unnecessary token fetch occurs
 
+#### Scenario: Token nearly expired at capture time
+
+- GIVEN an OIDC token acquired at T₋₄min (with 5-minute TTL, so ~60s remaining)
+- AND `ForProject()` captures the SDK client at T₀ with only ~60s of validity
+- AND the sandbox becomes ready at T₀ + 90 seconds (beyond remaining validity)
+- WHEN `execAfterReady` re-acquires the SDK client before calling `UpdateStatus`
+- THEN `ForProject()` SHALL call `OIDCTokenProvider.Token()` which fetches a fresh token
+- AND `UpdateStatus(phase=Running)` SHALL succeed
+- NOTE: This is the actual failure mode from the 2026-07-31 incident — the token had ~39s remaining at capture, not a full 5-minute window
+
 #### Scenario: failSession closure uses fresh token
 
 - GIVEN `execAfterReady` times out after 600 seconds
@@ -70,12 +83,24 @@ This ensures that `OIDCTokenProvider.Token()` is called at the moment the token 
 - THEN it SHALL use a freshly acquired SDK client, not the one captured at provision start
 - AND the failure SHALL be recorded in the API server
 
-#### Scenario: Token refresh fails
+#### Scenario: Token refresh fails during phase update
 
 - GIVEN the OIDC provider is unreachable when `ForProject()` is called
-- WHEN `execAfterReady` attempts to re-acquire the SDK client
+- WHEN `execAfterReady` attempts to re-acquire the SDK client for `UpdateStatus(phase=Running)`
 - THEN the error SHALL be logged with the session ID
-- AND the operation (phase update or failure marking) SHALL be skipped with a warning, not crash the reconciler
+- AND the operation SHALL be skipped with a warning, not crash the reconciler
+- AND the session will be left in `Creating` (the next reconcile loop will pick it up)
+
+#### Scenario: Token refresh fails inside failSession
+
+- GIVEN `execAfterReady` times out or encounters a sandbox error
+- AND `failSession` calls `ForProject()` to acquire a fresh client
+- AND `ForProject()` returns an error (OIDC unreachable, network partition, etc.)
+- WHEN `failSession` cannot mark the session as `Failed` via the API
+- THEN `failSession` SHALL log the error at `Error` level with the session ID and the `ForProject()` error
+- AND `failSession` SHALL attempt a **Kubernetes-side annotation** on the session's Job or Pod recording the failure reason, as a last-resort breadcrumb
+- AND the session will remain in `Creating` — the reconciler's next full-sync pass will detect the stale session and retry the failure marking with a new token
+- NOTE: This prevents the exact same stuck-in-Creating outcome as the original bug. The reconciler's periodic resync is the ultimate backstop, not a single `failSession` invocation.
 
 ### Requirement: execAfterReady Receives Factory, Not Client
 
@@ -136,6 +161,18 @@ The `failSession` closure inside `execAfterReady` currently captures the `sdk` v
 - ndots retry loop optimization (tracked in #421)
 - Token endpoint for runner pods (orthogonal; runner uses CP token endpoint, not SDK client)
 
+### Design decision: per-call-site refresh vs. client-level token provider
+
+An alternative to patching individual call sites is making `sdkclient.Client` accept a `func() (string, error)` token provider so that every HTTP request lazily fetches a fresh token. This would eliminate the entire class of stale-token bugs across all current and future long-running functions (e.g. `deprovisionSessionSandbox` at ~line 1863).
+
+We chose per-call-site patching for this spec because:
+
+1. **Blast radius**: Modifying `sdkclient.Client` to use a token provider changes the SDK's HTTP transport layer, affecting all SDK consumers (CLI, runner, sidecars), not just the control plane reconciler. That change warrants its own spec and cross-component testing.
+2. **Urgency**: The stuck-in-Creating bug is actively blocking users. A targeted fix in `execAfterReady` can ship immediately while a client-level fix is designed properly.
+3. **Verification**: Per-call-site patching produces an explicit, auditable list of "these are the calls that run after a long wait." A transparent token provider fixes the bug silently, making it harder to reason about token lifecycle in code review.
+
+A follow-up spec SHOULD evaluate the client-level token provider pattern to prevent this bug class in future long-running functions. Until then, any new function that acquires an SDK client and waits (>30s) before using it should follow the same `ForProject()` re-acquisition pattern documented here.
+
 ---
 
 ## Implementation Notes
@@ -146,9 +183,11 @@ The key call sites inside `execAfterReady` that need fresh clients:
 
 | Line | Call | Risk |
 |------|------|------|
-| 949 | `sdk.Sessions().UpdateStatus(ctx, sessionID, {phase: Running})` | High — after readiness wait |
-| 783 | `sdk.Sessions().UpdateStatus(ctx, sessionID, {phase: Failed})` (via `failSession`) | High — after timeout |
-| 1059+ | completion marking after exec stream finishes | Medium — after entrypoint run |
+| ~958 | `sdk.Sessions().UpdateStatus(ctx, sessionID, {phase: Running})` | High — after readiness wait |
+| ~792 | `sdk.Sessions().UpdateStatus(ctx, sessionID, {phase: Failed})` (via `failSession`) | High — after timeout |
+| ~1054 | `sdk.Sessions().Get(checkCtx, sessionID)` (exec-retry loop, `codes.NotFound` branch) | High — after readiness wait + exec stream |
+| ~1086 | `sdk.Sessions().Get(ctx, sessionID)` (re-reads `stop_on_run_finished` after exec) | High — after readiness wait + full entrypoint execution |
+| ~1105 | `sdk.Sessions().UpdateStatus(ctx, sessionID, {phase: Completed/Failed})` (completion marking) | High — after readiness wait + full entrypoint execution (longest elapsed time, highest expiry risk) |
 
 Each of these should be preceded by `sdk, err := r.factory.ForProject(ctx, projectID)`.
 

--- a/specs/platform/reconciler-token-refresh.spec.md
+++ b/specs/platform/reconciler-token-refresh.spec.md
@@ -1,0 +1,163 @@
+# Reconciler Token Refresh
+
+**Date:** 2026-07-31
+**Status:** Draft
+**Parent:** `control-plane.spec.md` — KubeReconciler
+**Related:** `openshell-gateway-oidc.spec.md` — gateway OIDC; `openshell-sandbox-provisioning.spec.md` — sandbox lifecycle
+
+---
+
+## Purpose
+
+Prevent sessions from getting stuck in `Creating` phase when the control plane's OIDC token expires during the sandbox readiness polling loop.
+
+Today, `provisionSessionSandbox` calls `factory.ForProject(ctx, projectID)` once and passes the resulting `*sdkclient.Client` into `execAfterReady`. That client embeds a **static bearer token** captured at creation time. The readiness loop can block for up to 600 seconds (ndots retries, image pulls, scheduling delays). If the OIDC token expires during this wait, all subsequent API calls — `UpdateStatus` to `Running`, `failSession`, and `markCompleted` — fail with HTTP 401 and the session is orphaned in `Creating` forever.
+
+### Observed incident (2026-07-31)
+
+Session `dasfadsfdsa` (`3HHmQCYv7CBSoNwuiSeVohWmLm7`):
+
+| Time | Event |
+|------|-------|
+| 21:24:48 | OIDC token acquired (expires 21:29:48, 5 min TTL) |
+| 21:29:09 | `provisionSessionSandbox` → `ForProject()` captures SDK client with current token |
+| 21:29:09 | Sandbox created, `execAfterReady` goroutine spawned |
+| 21:29:51–21:30:15 | Three ndots retry cycles (pod deleted and recreated 3×, ~26s added) |
+| 21:30:31 | Sandbox ready; `UpdateStatus(phase=Running)` → **HTTP 401** (token expired ~40s ago) |
+| 21:30:44 | `markCompleted` → **HTTP 401** |
+
+The session never left `Creating`. The UI showed it stuck indefinitely.
+
+---
+
+## Root Cause
+
+`SDKClientFactory.ForProject()` (`internal/reconciler/shared.go:83`) calls `provider.Token(ctx)` and bakes the returned string into a new `sdkclient.Client`. The client has no mechanism to refresh its token. When `execAfterReady` (`kube_reconciler.go:766`) receives this client, it holds a token snapshot that can be minutes old by the time the sandbox becomes ready.
+
+The `OIDCTokenProvider` (`internal/auth/token_provider.go:51`) already handles lazy refresh — it returns a cached token if valid with >30s remaining, or fetches a new one. The problem is that the reconciler never calls it again after the initial `ForProject()`.
+
+---
+
+## Requirements
+
+### Requirement: SDK Client Refresh Before API Calls in execAfterReady
+
+`execAfterReady` SHALL re-acquire the SDK client via `factory.ForProject(ctx, projectID)` immediately before making any Ambient API call, rather than using the client captured at provision time.
+
+This ensures that `OIDCTokenProvider.Token()` is called at the moment the token is actually needed, not minutes earlier when the sandbox was first created.
+
+#### Scenario: Token expires during sandbox readiness wait
+
+- GIVEN an OIDC token with a 5-minute TTL acquired at T₀
+- AND `execAfterReady` begins polling at T₀
+- AND the sandbox becomes ready at T₀ + 6 minutes (beyond token expiry)
+- WHEN `execAfterReady` re-acquires the SDK client before calling `UpdateStatus`
+- THEN `ForProject()` SHALL call `OIDCTokenProvider.Token()` which fetches a fresh token
+- AND `UpdateStatus(phase=Running)` SHALL succeed
+
+#### Scenario: Token still valid during short sandbox wait
+
+- GIVEN an OIDC token with a 5-minute TTL acquired at T₀
+- AND the sandbox becomes ready at T₀ + 30 seconds
+- WHEN `execAfterReady` re-acquires the SDK client before calling `UpdateStatus`
+- THEN `ForProject()` SHALL return the cached client (token unchanged)
+- AND no unnecessary token fetch occurs
+
+#### Scenario: failSession closure uses fresh token
+
+- GIVEN `execAfterReady` times out after 600 seconds
+- WHEN `failSession` calls `UpdateStatus(phase=Failed)`
+- THEN it SHALL use a freshly acquired SDK client, not the one captured at provision start
+- AND the failure SHALL be recorded in the API server
+
+#### Scenario: Token refresh fails
+
+- GIVEN the OIDC provider is unreachable when `ForProject()` is called
+- WHEN `execAfterReady` attempts to re-acquire the SDK client
+- THEN the error SHALL be logged with the session ID
+- AND the operation (phase update or failure marking) SHALL be skipped with a warning, not crash the reconciler
+
+### Requirement: execAfterReady Receives Factory, Not Client
+
+The `execAfterReady` function signature SHALL accept `*SDKClientFactory` and `projectID` instead of `*sdkclient.Client`. This makes it structurally impossible to use a stale captured client.
+
+#### Scenario: Signature change
+
+- GIVEN the current signature:
+  ```go
+  func (r *SimpleKubeReconciler) execAfterReady(
+      namespace, sbxName, sessionID string,
+      entrypoint []string,
+      sdk *sdkclient.Client,       // ← captured snapshot
+      execEnv map[string]string,
+      payloads []types.Payload,
+      stopOnRunFinished bool,
+  )
+  ```
+- WHEN this spec is implemented
+- THEN the signature SHALL become:
+  ```go
+  func (r *SimpleKubeReconciler) execAfterReady(
+      namespace, sbxName, sessionID, projectID string,
+      entrypoint []string,
+      execEnv map[string]string,
+      payloads []types.Payload,
+      stopOnRunFinished bool,
+  )
+  ```
+- AND `execAfterReady` SHALL call `r.factory.ForProject(ctx, projectID)` at each API call site
+
+### Requirement: failSession Uses Fresh Client
+
+The `failSession` closure inside `execAfterReady` currently captures the `sdk` variable from the enclosing scope. After this change, it SHALL call `r.factory.ForProject()` to obtain a fresh client.
+
+#### Scenario: Failure after prolonged wait
+
+- GIVEN a sandbox that enters error phase at T₀ + 8 minutes
+- AND the original OIDC token expired at T₀ + 5 minutes
+- WHEN `failSession` is invoked
+- THEN it SHALL acquire a fresh SDK client
+- AND `UpdateStatus(phase=Failed, conditions=[...])` SHALL succeed
+
+---
+
+## Scope
+
+### In scope
+
+- `internal/reconciler/kube_reconciler.go`: change `execAfterReady` signature, re-acquire SDK client before `UpdateStatus` calls
+- `internal/reconciler/kube_reconciler.go`: update `failSession` closure to use factory
+- `internal/reconciler/kube_reconciler.go`: update both call sites of `execAfterReady` (lines 482, 562) to pass `projectID` instead of `sdk`
+
+### Out of scope
+
+- `SDKClientFactory` internals — the lazy refresh logic is already correct
+- `OIDCTokenProvider` — the 30-second buffer and mutex caching are sufficient
+- ndots retry loop optimization (tracked in #421)
+- Token endpoint for runner pods (orthogonal; runner uses CP token endpoint, not SDK client)
+
+---
+
+## Implementation Notes
+
+The `sdk` variable is also used earlier in `provisionSessionSandbox` for `Projects().Get()`, `Agents().Get()`, and `buildSandboxEnv()`. Those calls happen synchronously before `execAfterReady` is spawned and complete within seconds — they are not at risk of token expiry and do not need to change.
+
+The key call sites inside `execAfterReady` that need fresh clients:
+
+| Line | Call | Risk |
+|------|------|------|
+| 949 | `sdk.Sessions().UpdateStatus(ctx, sessionID, {phase: Running})` | High — after readiness wait |
+| 783 | `sdk.Sessions().UpdateStatus(ctx, sessionID, {phase: Failed})` (via `failSession`) | High — after timeout |
+| 1059+ | completion marking after exec stream finishes | Medium — after entrypoint run |
+
+Each of these should be preceded by `sdk, err := r.factory.ForProject(ctx, projectID)`.
+
+---
+
+## References
+
+- Incident log: session `3HHmQCYv7CBSoNwuiSeVohWmLm7` stuck in Creating (2026-07-31)
+- `internal/auth/token_provider.go` — `OIDCTokenProvider` with lazy refresh
+- `internal/reconciler/shared.go:83` — `ForProject()` token-to-client binding
+- `internal/reconciler/kube_reconciler.go:766` — `execAfterReady` entry point
+- Issue #421 — ndots retry loop (contributing factor, separate fix)


### PR DESCRIPTION
## Summary

- Adds `specs/platform/reconciler-token-refresh.spec.md` — spec for fixing sessions stuck in `Creating` phase due to stale OIDC tokens
- Registers the new spec in `specs/index.spec.md`

### Problem

`execAfterReady` receives a `*sdkclient.Client` with a static bearer token captured at provision time. The sandbox readiness polling loop can block for up to 600s (ndots retries, image pulls, scheduling delays). If the OIDC token expires during this wait, `UpdateStatus(phase=Running)` fails with HTTP 401 and the session is orphaned in `Creating` forever.

Observed on 2026-07-31: session `dasfadsfdsa` hit 3 ndots retries (~26s delay) which pushed the reconciler past the 5-minute token TTL. All subsequent API calls failed with 401.

### Fix (specified, not yet implemented)

- Change `execAfterReady` to accept `projectID` instead of `*sdkclient.Client`
- Re-acquire the SDK client via `r.factory.ForProject(ctx, projectID)` before each API call
- `OIDCTokenProvider.Token()` already handles lazy refresh — just needs to be called at the right time

### Related

- #421 — ndots retry loop optimization (contributing factor, separate fix)

## Test plan

- [ ] Spec review: requirements cover the three API call sites in `execAfterReady` (Running, Failed, Completed)
- [ ] Spec review: scenarios cover token-expired, token-valid, and token-refresh-failure cases
- [ ] Implementation PR will add unit test for stale-token scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)