### PR TITLE
ENGPROD-10271 - Skill overlay

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -9,4 +9,6 @@ dependencies:
   - OpenShift-Fleet/agentic-sdlc
   mcp: []
 includes: auto
-scripts: {}
+scripts:
+  post-install: skills/tooling/overlay-sync-skills/overlay-sync.sh --hook post-install
+  post-update: skills/tooling/overlay-sync-skills/overlay-sync.sh --hook post-update

--- a/apm.yml
+++ b/apm.yml
@@ -12,3 +12,10 @@ includes: auto
 scripts:
   post-install: skills/tooling/overlay-sync-skills/overlay-sync.sh --hook post-install
   post-update: skills/tooling/overlay-sync-skills/overlay-sync.sh --hook post-update
+lifecycle:
+  post-install:
+    - type: command
+      run: skills/tooling/overlay-sync-skills/overlay-sync.sh --hook post-install
+  post-update:
+    - type: command
+      run: skills/tooling/overlay-sync-skills/overlay-sync.sh --hook post-update

--- a/overlays/jira-create/customized/batch-mode.md
+++ b/overlays/jira-create/customized/batch-mode.md
@@ -1,0 +1,89 @@
+# Batch Mode
+
+Inject this as a new section immediately after **User Input** and before the main **Instructions** flow. Batch mode takes precedence over the interactive single-ticket flow.
+
+## Recognizing Single vs Batch Mode
+
+**Single ticket** (default): The input is a sentence, paragraph, or block of text describing one piece of work. Follow the normal interactive Instructions below.
+
+**Batch mode**: The input contains a markdown bullet list (lines starting with `- ` or `* `). Each top-level bullet becomes a separate ticket. Sub-bullets provide context for that ticket's description. Batch mode skips the interactive interview — use sub-bullet context and reasonable defaults, then confirm the full batch before creating.
+
+## Batch Execution
+
+When batch mode is detected, skip Steps 1–7 of the interactive flow and follow these steps instead:
+
+### Batch Step 1 — Parse
+
+Extract from user input, per ticket:
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| Summary | (required) | Title of the issue |
+| Issue Type | Story | Also: Bug, Task, Spike, Epic. Normalize case. |
+| Priority | Normal | |
+| Description | (from context) | Sub-bullets and multi-line text |
+| Epic link | — | If a ticket should belong to an epic |
+| Blocking | — | "X blocks Y" relationships |
+| Related | — | "X related to Y" relationships |
+
+Type prefix syntax: `[Bug] Session crashes` → type=Bug, summary="Session crashes".
+
+Every non-Epic ticket still needs Testing Requirements and Relevant Paths in its description, even if you must infer them from the component.
+
+### Batch Step 2 — Build Descriptions
+
+Use the ACP description template from the project context section. Apply section guidance by issue type.
+
+### Batch Step 3 — Confirm
+
+Show a summary table:
+
+```
+About to create N ENGPROD tickets:
+
+| # | Type  | Summary                        | Epic          |
+|---|-------|--------------------------------|---------------|
+| 1 | Epic  | Feature X                      | —             |
+| 2 | Story | Implement Y                    | Feature X     |
+| 3 | Bug   | Fix Z                          | —             |
+
+Blocking: #2 blocks #3
+Related: #4 related to #5
+
+Create all? (yes/no/edit)
+```
+
+### Batch Step 4 — Create
+
+Always set on every ticket:
+- `project_key`: ENGPROD
+- `components`: acp
+- `labels`: team:acp
+- `customfield_10464`: Future Sustainability (10606) for non-Bugs; Quality / Stability / Reliability (10608) for Bugs
+- `security_level`: "Red Hat Employee" (ID: `10034`)
+
+**Execution order** (later steps depend on earlier ones):
+1. Create Epics first
+2. Create remaining tickets (Stories, Bugs, Tasks, Spikes)
+3. Link child tickets to epics
+4. Create blocking relationships with `link_type: "Blocks"`
+5. Create related links with `link_type: "Related"` (not "Relates")
+
+Parallelize within each phase, but complete each phase before the next.
+
+### Batch Step 5 — Report
+
+```
+Created N tickets:
+
+| Key            | Type  | Summary                        | Epic          |
+|----------------|-------|--------------------------------|---------------|
+| ENGPROD-XXXXX  | Epic  | Feature X                      | —             |
+| ENGPROD-XXXXX  | Story | Implement Y                    | Feature X     |
+
+Links created:
+- ENGPROD-XXXXX blocks ENGPROD-XXXXX
+- ENGPROD-XXXXX → Epic ENGPROD-XXXXX
+```
+
+Browse links: `https://redhat.atlassian.net/browse/[ISSUE_KEY]`

--- a/overlays/jira-create/customized/config.yaml
+++ b/overlays/jira-create/customized/config.yaml
@@ -1,0 +1,14 @@
+overlay-version: "1"
+base-skill: jira-create
+project: agent-control-plane
+overrides:
+  jira_project: "ENGPROD"
+  jira_component: "acp"
+  default_priority: "Normal"
+  default_labels: "team:acp"
+  default_activity_type: "Future Sustainability"
+  default_activity_type_id: "10606"
+  bug_activity_type: "Quality / Stability / Reliability"
+  bug_activity_type_id: "10608"
+  browse_url: "https://redhat.atlassian.net/browse/"
+  repo: "openshift-online/agent-control-plane"

--- a/overlays/jira-create/customized/generated/SKILL.md
+++ b/overlays/jira-create/customized/generated/SKILL.md
@@ -1,0 +1,406 @@
+---
+name: jira-create
+description: >
+  Create Jira issues in ENGPROD for Agent Control Plane (acp component).
+  Supports single interactive creation with duplicate detection, specialist-drafted
+  content, and quality grading — plus batch creation from bullet lists.
+  Use whenever work needs tracking in Jira: creating stories, filing bugs, logging
+  tasks, opening spikes, creating epics, or batch ticket creation.
+  Triggers on: "create jira", "log jira", "file a bug", "new ticket",
+  "open a story", "jira issue", "track this work", "create a ticket",
+  "create tickets", "batch tickets", "log these items".
+---
+
+# Jira Create — Agent Control Plane
+
+Create well-structured Jira issues in the **ENGPROD** project with the **acp** (Agent Control Plane) component pre-filled. Every issue is built to be agent-actionable from a cold start — meaning another agent (or human) can pick it up and start working immediately without asking clarifying questions.
+
+Includes duplicate detection, specialist-drafted content, activity type defaults, and a quality grading gate for single tickets. Supports batch creation from markdown bullet lists.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Consider the user input before proceeding (if not empty).
+
+## Recognizing Single vs Batch Mode
+
+**Single ticket** (default): The input is a sentence, paragraph, or block of text describing one piece of work. Follow the interactive Instructions below.
+
+**Batch mode**: The input contains a markdown bullet list (lines starting with `- ` or `* `). Each top-level bullet becomes a separate ticket. Sub-bullets provide context for that ticket's description. Batch mode skips the interactive interview — use sub-bullet context and reasonable defaults, then confirm the full batch before creating.
+
+When batch mode is detected, skip to **Batch Execution** at the end of this document.
+
+## Instructions
+
+Follow these steps in order for single-ticket mode. Use `AskUserQuestion` for each step unless `$ARGUMENTS` already provides enough context (see Fast Path below). Do NOT skip steps or guess values without user confirmation.
+
+### Fast Path from $ARGUMENTS
+
+When `$ARGUMENTS` is non-empty and descriptive:
+
+1. Parse type prefix if present: `[Bug]`, `[Task]`, `[Spike]`, `[Epic]`, `[Story]` → set issue type and summary.
+2. If type and summary are clear, skip Step 1 (Issue Type) and proceed to Step 2 (Duplicate Search).
+3. Pass the full `$ARGUMENTS` context to the specialist agent in Step 3 so it can draft without re-asking known details.
+
+### Step 1: Issue Type
+
+Use `AskUserQuestion` to ask the user what type of issue to create (skip if inferred from `$ARGUMENTS`):
+
+- **Story** — User-facing functionality with acceptance criteria
+- **Bug** — Defect report with reproduction steps
+- **Task** — Internal technical work, non-user-facing
+- **Spike** — Research, investigation, or proof-of-concept
+- **Feature** — Significant customer-facing capability
+- **Epic** — Large body of work spanning multiple sprints
+- **Initiative** — Internal capability or architectural improvement; typically ~6 months, or no larger than a single Quarter/Release
+- **Outcome** — Strategic business result tied to corporate objectives
+- **Sub-task** — Child task under an existing issue
+- **Risk** — Potential hazard that could block or delay work
+- **Ticket** — Stakeholder request for intake and triage
+
+### Step 2: Duplicate Search
+
+Before collecting any other fields, search for similar open issues using JQL.
+
+Run: `issuetype = [selected type] AND project = ENGPROD AND summary ~ "[keywords from user's intent]" AND status != Closed ORDER BY updated DESC`
+
+If similar issues are found, present them to the user and ask whether to proceed with a new issue or use an existing one. If no duplicates are found, continue.
+
+### Step 3: Delegate to Specialist Agent
+
+Based on the issue type selected, launch the appropriate specialist agent to help craft the content. The agent should help formulate the summary, description, and any type-specific fields.
+
+Pass ACP project context to the specialist:
+- **Repo**: openshift-online/agent-control-plane
+- **Jira component**: acp
+- **ACP code components**: ambient-api-server, ambient-control-plane, ambient-ui, ambient-runner, ambient-mcp, ambient-cli, ambient-sdk, manifests, docs
+- Use the ACP description template (see **ACP Description Template** below)
+
+| Issue Type | Agent | Template to reference |
+|------------|-------|-----------------------|
+| Story | `story-specialist` | `skills/story-specialist/template.md` |
+| Bug | `bug-specialist` | `skills/bug-specialist/template.md` |
+| Task | `task-specialist` | `skills/task-specialist/template.md` |
+| Spike | `spike-specialist` | `skills/spike-specialist/template.md` |
+| Feature | `feature-specialist` | `skills/feature-specialist/template.md` |
+| Epic | `epic-specialist` | `skills/epic-specialist/template.md` |
+| Initiative | `initiative-specialist` | `skills/initiative-specialist/template.md` |
+| Outcome | `outcome-specialist` | `skills/outcome-specialist/template.md` |
+| Sub-task | `task-specialist` | `skills/task-specialist/subtask-template.md` |
+| Risk | `risk-specialist` | `skills/risk-specialist/template.md` |
+| Ticket | `ticket-specialist` | `skills/ticket-specialist/template.md` |
+
+The agent should return a proposed **summary** and **description**. Present them to the user for approval or editing via `AskUserQuestion`.
+
+### Step 3b: Type-Appropriateness Check
+
+For **Outcome, Feature, and Initiative** issue types only, evaluate the drafted summary and description against the signal tables in `skills/jira-specialist/SKILL.md` (Type-Appropriateness Check section). Now that there is actual content to assess, ask 1–2 targeted clarifying questions if any signals are present.
+
+| Selected Type | Key clarifying question |
+|---|---|
+| **Outcome** | "Does this describe a measurable change in human behavior or business result that would warrant a press-release-level announcement — or is it primarily a product capability or internal improvement?" |
+| **Feature** | "Is the primary beneficiary an external customer (not a Red Hat associate), and is there a clear customer value statement beyond grouping Epics?" |
+| **Initiative** | "Is the result primarily an internal capability improvement for Red Hat associates (not a customer-facing product feature), within a ~6 month timeframe, or no larger than a single Quarter/Release?" |
+
+If the drafted content raises a type mismatch signal, recommend the more appropriate type and ask whether to switch. If switching, return to Step 3 with the correct type. If the type is confirmed correct (intentional scope), note it and proceed.
+
+For all other types (Story, Bug, Task, Spike, Epic, Sub-task, Risk, Ticket), skip this step.
+
+### Step 4: Structured Field Interview
+
+Use `AskUserQuestion` to collect all remaining required fields in **one pass** — group logically (up to 4 questions per call).
+
+**Before collecting any fields, ask whether this issue has a parent** (e.g., an Epic for a Story, an Initiative for an Epic, a parent Task for a Sub-task). Asking early lets you inherit Activity Type from the parent rather than asking the user to re-enter it.
+
+If a parent key is provided:
+1. Fetch the parent issue using the Jira MCP tool.
+2. Read its `customfield_10464` value (Activity Type).
+3. If the parent has an Activity Type set, automatically inherit it — do not ask the user to select one. Inform them: _"Activity Type copied from parent [KEY]: [value]."_ Give them the option to override.
+4. If the parent has no Activity Type set, fall through to the normal Activity Type selection below.
+
+If no parent is provided, apply ACP Activity Type defaults automatically — do not prompt unless the user wants to override:
+
+| Issue context | Activity Type | Option ID |
+|---------------|---------------|-----------|
+| Bug, tech debt, stability | Quality / Stability / Reliability | 10608 |
+| Everything else | Future Sustainability | 10606 |
+
+**Priority** (default: Normal):
+- Blocker
+- Critical
+- Major
+- Normal (Recommended)
+- Minor
+- Trivial
+
+Jira field key: `customfield_10464`. Set via MCP as `"customfield_10464": {"id": "<option_id>"}`.
+
+| Activity Type | Option ID | Best for |
+|---------------|-----------|----------|
+| Associate Wellness & Development | 10604 | Onboarding, training, team health |
+| BU Features | 10605 | Business unit feature commitments |
+| Future Sustainability | 10606 | Tooling, architecture, upstream |
+| Incidents & Support | 10607 | Escalations, customer support |
+| Quality / Stability / Reliability | 10608 | Bugs, tech debt, toil reduction |
+| Security & Compliance | 10609 | CVEs, vulnerabilities, compliance |
+| Product / Portfolio Work | 10610 | Features, outcomes, strategic work |
+
+**Original Estimate** (e.g., '2h', '1d', '30m')
+
+**Story Points** (default: 1) — MUST always be prompted for via `AskUserQuestion`. If the user does not provide a value, use 1.
+
+### Step 5: Collect Categorization Fields
+
+Apply ACP defaults — only ask if the user wants to override:
+
+**Component**: Default to **acp**. Do not ask unless the user indicates a different Jira component is needed.
+
+**Labels**: Default to **team:acp**. Ask only if the user wants additional labels.
+
+**Target Version** — Ask for the target version (fetch available versions using the registered Jira MCP tools if needed). Use `customfield_10855` for target version (NOT fix version for new/in-progress issues).
+
+### Step 6: Parent / Linking
+
+If a parent was already provided in Step 4, use that key here — do not ask again. Otherwise, use `AskUserQuestion` to ask if there is a parent or related issue.
+
+- If **Sub-task**: The parent issue key is required. Set the `parent` field on create.
+- If **Risk**: Ask which issue(s) this risk affects — link using the "caused by" link type.
+- If **any other type** and a parent is provided: Create the issue first, then link it. Ask which link type to use (Blocks, Depends, Related, Incorporates, etc.).
+- If **Epic**: Ask for an `epic_name` (required for Epics).
+
+For related links, use `"Related"` as the link type — not `"Relates"` (wrong name silently fails).
+
+### Step 7: Quality Grade
+
+Before creating, evaluate the planned issue content against the matching template (from the specialist's `template.md`) and the ACP description template below.
+
+Score the content on these 5 dimensions (see `skills/jira-report/SKILL.md` for the full grading rubric):
+
+| Dimension | Weight |
+|-----------|--------|
+| Completeness | 25% |
+| Linkage | 20% |
+| Clarity | 25% |
+| Sizing / Scoping | 15% |
+| Measurability | 15% |
+
+Assign an overall grade: **[A] READY**, **[B] MINOR GAPS**, **[C] NEEDS WORK**, or **[D] NOT READY**.
+
+- **[A] or [B]**: Proceed to confirmation.
+- **[C] or [D]**: Present the grade and specific gaps to the user. Ask whether to improve the content or proceed anyway. Do not proceed without explicit confirmation.
+
+### Step 8: Confirm and Create
+
+Before calling the create MCP tool, display a summary of ALL fields and the quality grade. Ask for confirmation.
+
+Always set:
+- `project_key`: ENGPROD
+- `components`: acp
+- `labels`: team:acp (plus any additional labels the user requested)
+- `security_level`: "Red Hat Employee" (ID: `10034`)
+- `assignee`: from personal config if available (tool-aware — see `CLAUDE.md` fallback chain)
+
+Call the registered Jira MCP create tool with all collected fields.
+
+After creation, if linking is needed, call the link MCP tool.
+
+### Step 9: Post-Creation
+
+After successful creation:
+1. Display the created issue key and link: `https://redhat.atlassian.net/browse/[ISSUE_KEY]`
+2. Report: Component acp, Agent Cold-Start Ready status
+3. If this is an Epic, ask if the user wants to create child stories/tasks now
+4. If this is a Feature, ask if the user wants to create related epics or stories
+5. If this is a Risk, remind the user to set a review cadence
+
+## Batch Execution
+
+When batch mode is detected (markdown bullet list in `$ARGUMENTS`), skip the interactive Instructions above and follow these steps.
+
+### Batch Step 1 — Parse
+
+Extract from user input, per ticket:
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| Summary | (required) | Title of the issue |
+| Issue Type | Story | Also: Bug, Task, Spike, Epic. Normalize case. |
+| Priority | Normal | |
+| Description | (from context) | Sub-bullets and multi-line text |
+| Epic link | — | If a ticket should belong to an epic |
+| Blocking | — | "X blocks Y" relationships |
+| Related | — | "X related to Y" relationships |
+
+Type prefix syntax: `[Bug] Session crashes` → type=Bug, summary="Session crashes".
+
+Every non-Epic ticket still needs Testing Requirements and Relevant Paths in its description, even if you must infer them from the component.
+
+### Batch Step 2 — Build Descriptions
+
+Use the ACP description template below. Apply section guidance by issue type.
+
+### Batch Step 3 — Confirm
+
+Show a summary table:
+
+```
+About to create N ENGPROD tickets:
+
+| # | Type  | Summary                        | Epic          |
+|---|-------|--------------------------------|---------------|
+| 1 | Epic  | Feature X                      | —             |
+| 2 | Story | Implement Y                    | Feature X     |
+| 3 | Bug   | Fix Z                          | —             |
+
+Blocking: #2 blocks #3
+Related: #4 related to #5
+
+Create all? (yes/no/edit)
+```
+
+### Batch Step 4 — Create
+
+Always set on every ticket:
+- `project_key`: ENGPROD
+- `components`: acp
+- `labels`: team:acp
+- `customfield_10464`: Future Sustainability (10606) for non-Bugs; Quality / Stability / Reliability (10608) for Bugs
+- `security_level`: "Red Hat Employee" (ID: `10034`)
+
+**Execution order** (later steps depend on earlier ones):
+1. Create Epics first
+2. Create remaining tickets (Stories, Bugs, Tasks, Spikes)
+3. Link child tickets to epics
+4. Create blocking relationships with `link_type: "Blocks"`
+5. Create related links with `link_type: "Related"` (not "Relates")
+
+Parallelize within each phase, but complete each phase before the next.
+
+### Batch Step 5 — Report
+
+```
+Created N tickets:
+
+| Key            | Type  | Summary                        | Epic          |
+|----------------|-------|--------------------------------|---------------|
+| ENGPROD-XXXXX  | Epic  | Feature X                      | —             |
+| ENGPROD-XXXXX  | Story | Implement Y                    | Feature X     |
+
+Links created:
+- ENGPROD-XXXXX blocks ENGPROD-XXXXX
+- ENGPROD-XXXXX → Epic ENGPROD-XXXXX
+```
+
+Browse links: `https://redhat.atlassian.net/browse/[ISSUE_KEY]`
+
+## ACP Description Template
+
+Use this template when building descriptions, dropping sections that do not apply:
+
+```markdown
+## Overview
+[One paragraph: what needs to be done and why]
+
+## User Story
+As a [type of user], I want [goal], so that [benefit].
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+## Technical Context
+**Repo**: openshift-online/agent-control-plane
+**Component**: [e.g. ambient-api-server, ambient-control-plane, ambient-ui, ambient-runner]
+**Relevant Paths**:
+- `components/[component]/path/to/relevant/file`
+
+## Related Links
+- Spec: [link to relevant spec in specs/]
+- Related Issues: [ENGPROD-XXXX]
+
+## Constraints
+- [What NOT to do]
+
+## Testing Requirements
+- [ ] Unit tests for [X]
+
+## Bug Details
+**Steps to Reproduce**: ...
+**Expected**: ...
+**Actual**: ...
+
+## Spike Deliverables
+- [ ] [Output: e.g. design doc, prototype, findings]
+**Time-box**: [e.g. 2 days]
+```
+
+**Section guidance by type:**
+- **Epics**: Overview only
+- **Stories**: Overview, User Story, Acceptance Criteria, Technical Context, Testing Requirements
+- **Bugs**: Overview, Bug Details, Technical Context, Testing Requirements
+- **Tasks**: Overview, Acceptance Criteria, Technical Context, Testing Requirements
+- **Spikes**: Overview, Spike Deliverables (must include Time-box), Technical Context
+
+## Field Reference
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| Project | ENGPROD | Engineering Productivity |
+| Component | acp | Agent Control Plane (lowercase) |
+| Label | `team:acp` | Set on create |
+| Issue Type | Story | Default; also Bug, Task, Spike, Epic |
+| Browse URL | `https://redhat.atlassian.net/browse/` | |
+| Board | 348 | ENGPROD kanban board (no sprints) |
+
+## Jira Link Types
+
+| Relationship | `link_type` value | Notes |
+|-------------|-------------------|-------|
+| Blocking | `"Blocks"` | inward issue blocks outward issue |
+| Related | `"Related"` | Not "Relates" — wrong name silently fails |
+
+## Examples
+
+### Quick Story
+```
+/jira-create Add session filtering by project scope
+```
+
+### Bug Report
+```
+/jira-create [Bug] Session list doesn't refresh after deletion
+
+Steps:
+1. Create a session
+2. Delete the session via UI
+3. Observe the list
+
+Expected: Session disappears from list
+Actual: Session remains until page refresh
+
+Component: ambient-ui
+Files: components/ambient-ui/src/components/session-list/
+```
+
+### Batch
+```
+/jira-create
+- [Epic] User Onboarding Flow
+- Implement SSO login page
+  - Component: ambient-ui
+  - Acceptance: user can log in via Keycloak
+- [Task] Add onboarding docs
+  - Component: docs
+- [Bug] Login redirect fails on Safari
+  - Steps: open Safari, click login, observe redirect loop
+```
+
+## Error Handling
+
+- Validate date formats (YYYY-MM-DD)
+- Validate time estimates use Jira format (e.g., '1h 30m', '2d')
+- If the create call fails, show the error and ask the user what to fix
+- Never retry creation without user confirmation

--- a/overlays/jira-create/customized/generated/overlay.lock.yaml
+++ b/overlays/jira-create/customized/generated/overlay.lock.yaml
@@ -1,0 +1,14 @@
+base-skill: jira-create
+base-skill-source: OpenShift-Fleet/agentic-sdlc
+overlay-version: "1"
+generated-at: "2026-07-30"
+upstream:
+  - path: SKILL.md
+    sha: a9056767b7572536cc4932573fdbf550321feed2a9c4cd28bb59aa8419feef5c
+inputs:
+  - path: config.yaml
+    sha: d4161f7705a6683c4a333fbe192875b700300fe773029221b6224236f945d3ae
+  - path: project-context.md
+    sha: 23cf10c2cfcef9b6032ac35e5f30f5cb671afa01e4b288f73d7dc633f23931bf
+  - path: batch-mode.md
+    sha: 4d310c367d9ba53076e480574c2bdd696e33c8ffcbd4d99ccdabef2e04f599f5

--- a/overlays/jira-create/customized/project-context.md
+++ b/overlays/jira-create/customized/project-context.md
@@ -1,0 +1,104 @@
+# Agent Control Plane — Jira Conventions
+
+All issues created by this skill target the **Agent Control Plane (ACP)** team in ENGPROD.
+
+## Field Defaults
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| Project | ENGPROD | Engineering Productivity |
+| Component | acp | Agent Control Plane (lowercase) |
+| Label | `team:acp` | Always set on create |
+| Priority | Normal | Unless user specifies otherwise |
+| Browse URL | `https://redhat.atlassian.net/browse/` | |
+| Board | 348 | ENGPROD kanban board (no sprints) |
+
+## Activity Type Defaults
+
+Set Activity Type (`customfield_10464`) automatically — do not prompt unless the user wants to override:
+
+| Issue context | Activity Type | Option ID |
+|---------------|---------------|-----------|
+| Bug, tech debt, stability | Quality / Stability / Reliability | 10608 |
+| Everything else (Story, Task, Spike, Epic, etc.) | Future Sustainability | 10606 |
+
+If a parent issue is provided, inherit its Activity Type instead.
+
+## ACP Components (for description Technical Context)
+
+Use these in the **description**, not as the Jira component field:
+
+- `ambient-api-server` — Go REST API, PostgreSQL-backed
+- `ambient-control-plane` — Go reconciler, K8s Jobs
+- `ambient-ui` — Next.js + Shadcn frontend
+- `ambient-runner` — Python runner in Job pods
+- `ambient-mcp` — MCP server integration
+- `ambient-cli` — Go CLI (`acpctl`)
+- `ambient-sdk` — Generated client SDKs
+- `manifests` — Kustomize deployment manifests
+- `docs` — Astro Starlight documentation site
+
+## Description Template
+
+When delegating to specialist agents or building descriptions directly, ensure every non-Epic issue includes agent-actionable content. Use this template, dropping sections that do not apply:
+
+```markdown
+## Overview
+[One paragraph: what needs to be done and why]
+
+## User Story
+As a [type of user], I want [goal], so that [benefit].
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+## Technical Context
+**Repo**: openshift-online/agent-control-plane
+**Component**: [e.g. ambient-api-server, ambient-control-plane, ambient-ui, ambient-runner]
+**Relevant Paths**:
+- `components/[component]/path/to/relevant/file`
+
+## Related Links
+- Spec: [link to relevant spec in specs/]
+- Related Issues: [ENGPROD-XXXX]
+
+## Constraints
+- [What NOT to do]
+
+## Testing Requirements
+- [ ] Unit tests for [X]
+
+## Bug Details
+**Steps to Reproduce**: ...
+**Expected**: ...
+**Actual**: ...
+
+## Spike Deliverables
+- [ ] [Output: e.g. design doc, prototype, findings]
+**Time-box**: [e.g. 2 days]
+```
+
+**Section guidance by type:**
+- **Epics**: Overview only. No Acceptance Criteria, Testing Requirements, or User Story — those belong on the children.
+- **Stories**: Overview, User Story, Acceptance Criteria, Technical Context (with Relevant Paths), Testing Requirements.
+- **Bugs**: Overview, Bug Details (Steps/Expected/Actual), Technical Context (with Relevant Paths), Testing Requirements.
+- **Tasks**: Overview, Acceptance Criteria, Technical Context (with Relevant Paths), Testing Requirements.
+- **Spikes**: Overview, Spike Deliverables (must include Time-box), Technical Context (with Relevant Paths).
+
+## Jira Link Types
+
+| Relationship | `link_type` value | Notes |
+|-------------|-------------------|-------|
+| Blocking | `"Blocks"` | inward issue blocks outward issue |
+| Related | `"Related"` | Not "Relates" — wrong name silently fails |
+
+## What Makes a Jira Agent-Actionable
+
+A Jira is ready for cold-start work when it has: a user story (who/why), acceptance criteria (definition of done), repo + file paths (where to edit), constraints (what not to do), and testing requirements (expected coverage). Bug reports additionally need repro steps. Spikes need deliverables and a time-box. Epics need an overview and linked children.
+
+## Type Prefix Syntax
+
+When `$ARGUMENTS` contains a type prefix, parse it before asking:
+- `[Bug] Session crashes` → type=Bug, summary="Session crashes"
+- `[Task]`, `[Spike]`, `[Epic]`, `[Story]` work the same way

--- a/skills/tooling/overlay-sync-skills/README.md
+++ b/skills/tooling/overlay-sync-skills/README.md
@@ -102,7 +102,7 @@ The `overlay.lock.yaml` file tracks the SHA-256 of the upstream skill and every 
 
 ```
   jira-create
-    ⚠ upstream SHA differs — overlay may be stale, run /overlay-sync-skills to regenerate
+    ⚠ upstream SKILL.md differs — overlay may be stale, run /overlay-sync-skills to regenerate
       lock:     a9056767b757...
       upstream: def456abc123...
     ✓ .claude/skills/jira-create/ (1 file(s) synced)

--- a/skills/tooling/overlay-sync-skills/README.md
+++ b/skills/tooling/overlay-sync-skills/README.md
@@ -1,0 +1,149 @@
+# Overlay Sync Skills
+
+Customize upstream APM skills with project-specific configuration without forking them.
+
+This directory contains two tools that work together:
+
+- **`/overlay-sync-skills`** (SKILL.md) — an agent skill that merges upstream skill files with your overlay inputs to produce generated output. Runs inside an agent session (requires LLM).
+- **`overlay-sync.sh`** — a bash script that copies generated files into active target deploy directories. Runs automatically as an APM `post-install`/`post-update` hook. No LLM needed.
+
+## Quick Start
+
+### 1. Create an overlay
+
+Create a directory under `skills/overlays/` named after the upstream skill you want to customize:
+
+```
+skills/overlays/<skill-name>/
+  customized/
+    config.yaml           # required — structured parameters
+    project-context.md    # optional — prose conventions, context
+    *.md                  # optional — additional overlay inputs
+```
+
+**`config.yaml`** must include at minimum:
+
+```yaml
+overlay-version: "1"
+base-skill: <upstream-skill-name>
+project: <your-project-name>
+overrides:
+  # key-value pairs that replace placeholders in the upstream skill
+```
+
+Example (`skills/overlays/jira-create/customized/config.yaml`):
+
+```yaml
+overlay-version: "1"
+base-skill: jira-create
+project: agent-control-plane
+overrides:
+  jira_project: "ENGPROD"
+  jira_component: "acp"
+  default_priority: "Normal"
+```
+
+**`*.md` files** contain free-form prose that gets injected into the merged skill — project conventions, template overrides, component lists, anything the agent should know when running the skill.
+
+### 2. Generate the merged output
+
+In your agent session, run:
+
+```
+/overlay-sync-skills jira-create
+```
+
+Or process all overlays at once:
+
+```
+/overlay-sync-skills
+```
+
+The skill reads the upstream SKILL.md + your overlay inputs, merges them, and writes the result to `customized/generated/`:
+
+```
+skills/overlays/jira-create/
+  customized/
+    config.yaml
+    project-context.md
+    generated/              # created by /overlay-sync-skills
+      SKILL.md              # merged skill — commit this
+      overlay.lock.yaml     # provenance record — commit this
+```
+
+Review the diff and commit the generated files.
+
+### 3. Sync to targets
+
+The generated files need to land in `.claude/skills/`, `.cursor/skills/`, etc. This happens automatically:
+
+- **On `apm install` / `apm update`**: the `overlay-sync.sh` script runs as a post-install/post-update hook (wired in `apm.yml`) and copies generated files into every active target's deploy directory.
+- **Standalone**: run `./skills/tooling/overlay-sync-skills/overlay-sync.sh` manually at any time.
+
+The sync script replaces the upstream skill files with your generated versions in each target directory.
+
+## Custom overlay directory
+
+Both tools default to `skills/overlays/` but accept a custom path:
+
+```
+# Agent skill — natural language
+/overlay-sync-skills jira-create from my-project/overlays
+
+# Bash script — flag
+./skills/tooling/overlay-sync-skills/overlay-sync.sh --overlay-dir my-project/overlays
+```
+
+## Drift warnings
+
+The `overlay.lock.yaml` file tracks the SHA-256 of the upstream skill and every overlay input at generation time. When something changes, you'll see warnings:
+
+**Upstream drift** — `apm update` pulled a newer version of the skill:
+
+```
+  jira-create
+    ⚠ upstream SHA differs — overlay may be stale, run /overlay-sync-skills to regenerate
+      lock:     a9056767b757...
+      upstream: def456abc123...
+    ✓ .claude/skills/jira-create/ (1 file(s) synced)
+```
+
+The stale generated files are still copied (stale is better than missing). Run `/overlay-sync-skills` to regenerate from the new upstream.
+
+**Input drift** — you edited `config.yaml` or a `*.md` file but didn't regenerate:
+
+The `/overlay-sync-skills` skill checks input SHAs before merging. If nothing changed, it skips the overlay. If inputs changed, it regenerates.
+
+## What gets synced
+
+- All files in `customized/generated/` **except** `overlay.lock.yaml` are copied to each target
+- The lock file stays in `generated/` as provenance metadata — agents don't need it
+- If the upstream skill has additional files (e.g., `template.md`), the merge produces generated versions of those too
+
+## Multi-file overlays
+
+Some skills reference additional `.md` files beyond `SKILL.md`. To customize those, add a `template-overrides.md` (or similar) to your `customized/` directory describing what to change:
+
+```
+skills/overlays/bug-specialist/
+  customized/
+    config.yaml
+    project-context.md
+    template-overrides.md    # instructions for modifying template.md
+    generated/
+      SKILL.md               # merged
+      template.md            # also merged
+      overlay.lock.yaml
+```
+
+The `/overlay-sync-skills` skill reads all `*.md` files in `customized/` and applies them to the appropriate upstream files.
+
+## File reference
+
+| File | Purpose |
+|---|---|
+| `SKILL.md` | Agent skill — LLM merge logic, runs in agent session |
+| `overlay-sync.sh` | Bash script — copies generated files to targets, drift detection |
+| `apm.yml` (repo root) | Hooks: `post-install` and `post-update` point to `overlay-sync.sh` |
+| `skills/overlays/` | Default overlay directory |
+| `skill-overlay-architecture.md` (repo root) | Architecture doc — design rationale and spec alignment |

--- a/skills/tooling/overlay-sync-skills/README.md
+++ b/skills/tooling/overlay-sync-skills/README.md
@@ -11,10 +11,10 @@ This directory contains two tools that work together:
 
 ### 1. Create an overlay
 
-Create a directory under `skills/overlays/` named after the upstream skill you want to customize:
+Create a directory under `overlays/` named after the upstream skill you want to customize:
 
 ```
-skills/overlays/<skill-name>/
+overlays/<skill-name>/
   customized/
     config.yaml           # required — structured parameters
     project-context.md    # optional — prose conventions, context
@@ -31,7 +31,7 @@ overrides:
   # key-value pairs that replace placeholders in the upstream skill
 ```
 
-Example (`skills/overlays/jira-create/customized/config.yaml`):
+Example (`overlays/jira-create/customized/config.yaml`):
 
 ```yaml
 overlay-version: "1"
@@ -62,7 +62,7 @@ Or process all overlays at once:
 The skill reads the upstream SKILL.md + your overlay inputs, merges them, and writes the result to `customized/generated/`:
 
 ```
-skills/overlays/jira-create/
+overlays/jira-create/
   customized/
     config.yaml
     project-context.md
@@ -84,7 +84,7 @@ The sync script replaces the upstream skill files with your generated versions i
 
 ## Custom overlay directory
 
-Both tools default to `skills/overlays/` but accept a custom path:
+Both tools default to `overlays/` but accept a custom path:
 
 ```
 # Agent skill — natural language
@@ -125,7 +125,7 @@ The `/overlay-sync-skills` skill checks input SHAs before merging. If nothing ch
 Some skills reference additional `.md` files beyond `SKILL.md`. To customize those, add a `template-overrides.md` (or similar) to your `customized/` directory describing what to change:
 
 ```
-skills/overlays/bug-specialist/
+overlays/bug-specialist/
   customized/
     config.yaml
     project-context.md
@@ -145,5 +145,5 @@ The `/overlay-sync-skills` skill reads all `*.md` files in `customized/` and app
 | `SKILL.md` | Agent skill — LLM merge logic, runs in agent session |
 | `overlay-sync.sh` | Bash script — copies generated files to targets, drift detection |
 | `apm.yml` (repo root) | Hooks: `post-install` and `post-update` point to `overlay-sync.sh` |
-| `skills/overlays/` | Default overlay directory |
+| `overlays/` | Default overlay directory |
 | `skill-overlay-architecture.md` (repo root) | Architecture doc — design rationale and spec alignment |

--- a/skills/tooling/overlay-sync-skills/README.md
+++ b/skills/tooling/overlay-sync-skills/README.md
@@ -82,6 +82,8 @@ The generated files need to land in `.claude/skills/`, `.cursor/skills/`, etc. T
 
 The sync script replaces the upstream skill files with your generated versions in each target directory.
 
+> **Note:** APM captures `post-install`/`post-update` hook output only to `~/.apm/logs/scripts.log` — it does not print to the console, even with `-v`. If you're relying on the hook, either check that log for drift/skip warnings after `apm install`/`apm update`, or run `./skills/tooling/overlay-sync-skills/overlay-sync.sh --hook post-install` (or `post-update`) manually to see the output directly.
+
 ## Custom overlay directory
 
 Both tools default to `overlays/` but accept a custom path:

--- a/skills/tooling/overlay-sync-skills/SKILL.md
+++ b/skills/tooling/overlay-sync-skills/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: overlay-sync-skills
+description: >
+  Merge upstream skills with project-specific overlays from skills/overlays/
+  to produce generated files in customized/generated/. Use when overlays need
+  initial generation, upstream skills drift (warned by apm install/update), or
+  overlay inputs change. Triggers on: "sync overlay", "generate overlay",
+  "regenerate skill", "overlay sync", "update generated skill".
+---
+
+# Overlay Sync Skills
+
+Merge upstream skill files with project-specific overlay inputs to produce generated files.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+The user may provide:
+
+- An overlay name (e.g., `jira-create`) — process only that overlay
+- A custom overlay directory path (e.g., `my-project/my-overlays`) — use instead of the default
+- Both (e.g., `jira-create from my-project/my-overlays`)
+- Nothing — process all overlays under the default directory
+
+## Instructions
+
+### Step 1: Discover Overlays
+
+Determine the overlay directory from user input. Default to `skills/overlays/` if no directory was specified.
+
+Scan the overlay directory for subdirectories containing `customized/config.yaml`.
+
+If an overlay name was provided, validate it exists in the overlay directory. If it doesn't, list available overlays and stop.
+
+### Step 2: Discover Active Targets
+
+Run `apm targets --json` to find all active target deploy directories.
+
+### Step 3: Process Each Overlay
+
+For each overlay:
+
+#### 3a: Read Overlay Inputs
+
+Read all files in `customized/` **excluding the `generated/` subdirectory**:
+
+- `config.yaml` — structured parameters and overrides
+- All `*.md` files — prose conventions, template overrides, project context
+
+#### 3b: Locate and Validate Upstream Files
+
+Read `base-skill` from `config.yaml`.
+
+**Path validation**: `base-skill` must not contain `/`, `\`, or `..`. If it does, report a config error and skip this overlay.
+
+Look in each active target's `<deploy_dir>/skills/<base-skill>/` directory. If no active target has the directory, warn that the upstream skill is not installed and skip.
+
+**Cross-target validation**: If there are multiple active targets, compute SHA-256 of the upstream SKILL.md in each target's deploy directory. If the SHAs differ across targets, warn that targets are out of sync (likely a partial `apm install` or manual edit) and skip this overlay. Do not merge against inconsistent upstream sources.
+
+If all targets agree (or there is only one), use the first active target's files for the merge. Read all files in that directory (`SKILL.md` and any additional `.md` files).
+
+#### 3c: Check for Drift
+
+If `customized/generated/overlay.lock.yaml` exists, check whether anything has changed:
+
+1. Compute SHA-256 of the upstream SKILL.md. Compare against `base-skill-sha` in the lock file.
+2. For each entry in the lock file's `inputs` list, compute SHA-256 of the file at that path. Compare against the recorded `sha`.
+
+If **all SHAs match** — both upstream and every input — the generated files are current. Report the overlay as up to date and **skip to Step 4** (do not re-merge).
+
+If **any SHA differs**, proceed to Step 3d. If no lock file exists (first-time generation), proceed to Step 3d.
+
+#### 3d: Merge
+
+Produce a merged version of each upstream file. Follow these rules in order:
+
+1. **Structure**: Keep the upstream file's section headings, step numbering, and overall flow intact. Do not reorder, remove, or rename sections unless an overlay `.md` file explicitly says to.
+2. **Config substitution**: Where the upstream file uses a generic placeholder or says to read from config (e.g., `[PROJECT]`, "read the project key from personal config"), replace with the concrete value from `config.yaml` overrides.
+3. **Prose injection**: Insert content from overlay `.md` files into the most relevant existing section of the upstream file. If the overlay content doesn't fit an existing section, add it as a new section at the end of the logical group it belongs to.
+4. **Template overrides**: If an overlay `.md` file names a specific upstream file and describes replacements (e.g., "Replace the Environment section"), apply those changes to that upstream file.
+5. **Self-contained output**: The merged file must stand alone. An agent reading it should never need to consult the overlay inputs. Do not add references to `config.yaml` or `customized/` in the output.
+6. **No additions beyond inputs**: Do not invent project-specific content that isn't in the overlay inputs. Only merge what is provided.
+
+#### 3e: Write Generated Files
+
+Write all merged files to `customized/generated/`.
+
+Write `overlay.lock.yaml`:
+
+```yaml
+base-skill: <base-skill from config.yaml>
+base-skill-sha: <SHA-256 of upstream SKILL.md file content>
+base-skill-source: <package name from apm.lock, or "" if not found>
+overlay-version: <overlay-version value from config.yaml>
+generated-at: <today's date, YYYY-MM-DD>
+inputs:
+  - path: <relative path of customized/ file>
+    sha: <SHA-256 of that file's content>
+```
+
+#### 3f: Validate
+
+After writing, verify:
+
+- Every generated `.md` file has valid YAML frontmatter (if the upstream original had frontmatter)
+- `overlay.lock.yaml` is valid YAML
+- The `base-skill-sha` in the lock file matches `shasum -a 256` of the upstream SKILL.md
+
+If validation fails, report the error and do not proceed to the next overlay.
+
+### Step 4: Report
+
+Display a summary per overlay:
+
+```
+Overlay merge complete:
+
+  <overlay-name>
+    ✓ generated/SKILL.md (merged)
+    ✓ generated/overlay.lock.yaml
+    upstream SHA: <sha>...
+
+  <overlay-name>
+    ✓ up to date (no changes detected)
+
+  <overlay-name>
+    ✗ skipped — upstream SKILL.md differs across targets
+      .claude/skills/<name>/SKILL.md: abc123...
+      .cursor/skills/<name>/SKILL.md: def456...
+      Run 'apm install' to sync targets before merging.
+```
+
+Include any additional generated files in the list. Remind the user to review the diff and commit any changed overlays.

--- a/skills/tooling/overlay-sync-skills/SKILL.md
+++ b/skills/tooling/overlay-sync-skills/SKILL.md
@@ -66,18 +66,20 @@ Read `base-skill` from `config.yaml`.
 
 Look in each active target's `<deploy_dir>/skills/<base-skill>/` directory. If no active target has the directory, warn that the upstream skill is not installed and skip.
 
-**Cross-target validation**: If there are multiple active targets, compute SHA-256 of the upstream SKILL.md in each target's deploy directory. If the SHAs differ across targets, warn that targets are out of sync (likely a partial `apm install` or manual edit) and skip this overlay. Do not merge against inconsistent upstream sources.
+**Partial availability**: If some active targets have the directory and others don't, warn that the base skill is only installed in a subset of targets (name which ones) and note that the targets without it will only ever receive generated output via `overlay-sync.sh` — they have no upstream copy of their own to detect future drift against. Proceed with the merge using the targets that do have it.
 
-If all targets agree (or there is only one), use the first active target's files for the merge. Read all files in that directory (`SKILL.md` and any additional `.md` files).
+**Cross-target validation**: Among the targets that have the directory, if there is more than one, compute SHA-256 of the upstream SKILL.md in each. If the SHAs differ, warn that targets are out of sync (likely a partial `apm install` or manual edit) and skip this overlay. Do not merge against inconsistent upstream sources.
+
+If all targets with the directory agree (or there is only one), use the first such target's files for the merge. Read all files in that directory (`SKILL.md` and any additional `.md` files).
 
 #### 3c: Check for Drift
 
-If `customized/generated/overlay.lock.yaml` exists, check whether anything has changed:
+If `generated/overlay.lock.yaml` exists, check whether anything has changed:
 
-1. Compute SHA-256 of the upstream SKILL.md. Compare against `base-skill-sha` in the lock file.
+1. For each entry in the lock file's `upstream` list, compute SHA-256 of the corresponding file in the upstream skill directory (from Step 3b). Compare against the recorded `sha`. This must cover every upstream file read in 3b — `SKILL.md` and any additional `.md` files — not just `SKILL.md`.
 2. For each entry in the lock file's `inputs` list, compute SHA-256 of the file at that path. Compare against the recorded `sha`.
 
-If **all SHAs match** — both upstream and every input — the generated files are current. Report the overlay as up to date and **skip to Step 4** (do not re-merge).
+If **all SHAs match** — every upstream file and every input — the generated files are current. Report the overlay as up to date and **skip to Step 4** (do not re-merge).
 
 If **any SHA differs**, proceed to Step 3d. If no lock file exists (first-time generation), proceed to Step 3d.
 
@@ -85,12 +87,14 @@ If **any SHA differs**, proceed to Step 3d. If no lock file exists (first-time g
 
 Produce a merged version of each upstream file. Follow these rules in order:
 
-1. **Structure**: Keep the upstream file's section headings, step numbering, and overall flow intact. Do not reorder, remove, or rename sections unless an overlay `.md` file explicitly says to.
-2. **Config substitution**: Where the upstream file uses a generic placeholder or says to read from config (e.g., `[PROJECT]`, "read the project key from personal config"), replace with the concrete value from `config.yaml` overrides.
-3. **Prose injection**: Insert content from overlay `.md` files into the most relevant existing section of the upstream file. If the overlay content doesn't fit an existing section, add it as a new section at the end of the logical group it belongs to.
-4. **Template overrides**: If an overlay `.md` file names a specific upstream file and describes replacements (e.g., "Replace the Environment section"), apply those changes to that upstream file.
-5. **Self-contained output**: The merged file must stand alone. An agent reading it should never need to consult the overlay inputs. Do not add references to `config.yaml` or `customized/` in the output.
-6. **No additions beyond inputs**: Do not invent project-specific content that isn't in the overlay inputs. Only merge what is provided.
+1. **Precedence**: The overlay always wins. Where upstream content and overlay content conflict — a described behavior, a default value, a listed option — rewrite or replace the upstream text to match the overlay. Never keep the upstream version alongside the overlay's or leave the two contradicting each other.
+2. **Structure**: Keep the upstream file's section headings, step numbering, and overall flow intact. Do not reorder, remove, or rename sections unless an overlay `.md` file explicitly says to.
+3. **Config substitution**: Where the upstream file uses a generic placeholder or says to read from config (e.g., `[PROJECT]`, "read the project key from personal config"), replace with the concrete value from `config.yaml` overrides. Where an override's key instead matches something the upstream skill treats as a runtime/user-supplied input (not a literal placeholder — e.g. an example value the user would normally pass in), add it as a standing default alongside the existing behavior rather than only rewriting the example text, so the project-specific value is available even when the user supplies nothing.
+4. **Prose injection**: Insert content from overlay `.md` files into the most relevant existing section of the upstream file. If the overlay content doesn't fit an existing section, add it as a new section at the end of the logical group it belongs to.
+5. **Template overrides**: If an overlay `.md` file names a specific upstream file and describes replacements (e.g., "Replace the Environment section"), apply those changes to that upstream file.
+6. **Self-contained output**: The merged file must stand alone. An agent reading it should never need to consult the overlay inputs. Do not add references to `config.yaml` or `customized/` in the output.
+7. **No additions beyond inputs**: Do not invent project-specific content that isn't in the overlay inputs. Only merge what is provided.
+8. **Preserve identity**: Do not change the upstream file's frontmatter `name` field. It must keep matching `base-skill` so `overlay-sync.sh` can locate and replace the right target directory.
 
 #### 3e: Write Generated Files
 
@@ -100,14 +104,18 @@ Write `overlay.lock.yaml`:
 
 ```yaml
 base-skill: <base-skill from config.yaml>
-base-skill-sha: <SHA-256 of upstream SKILL.md file content>
 base-skill-source: <package name from apm.lock, or "" if not found>
 overlay-version: <overlay-version value from config.yaml>
 generated-at: <today's date, YYYY-MM-DD>
+upstream:
+  - path: <relative filename read in Step 3b, e.g. SKILL.md>
+    sha: <SHA-256 of that upstream file's content>
 inputs:
-  - path: <relative path of customized/ file>
+  - path: <relative path of the overlay input file>
     sha: <SHA-256 of that file's content>
 ```
+
+Include one entry under `upstream` for every upstream file read in Step 3b, not just `SKILL.md`.
 
 #### 3f: Validate
 
@@ -115,7 +123,7 @@ After writing, verify:
 
 - Every generated `.md` file has valid YAML frontmatter (if the upstream original had frontmatter)
 - `overlay.lock.yaml` is valid YAML
-- The `base-skill-sha` in the lock file matches `shasum -a 256` of the upstream SKILL.md
+- Every entry in the lock file's `upstream` list matches `shasum -a 256` of its corresponding upstream file
 
 If validation fails, report the error and do not proceed to the next overlay.
 

--- a/skills/tooling/overlay-sync-skills/SKILL.md
+++ b/skills/tooling/overlay-sync-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: overlay-sync-skills
 description: >
-  Merge upstream skills with project-specific overlays from skills/overlays/
+  Merge upstream skills with project-specific overlays from overlays/
   to produce generated files in customized/generated/. Use when overlays need
   initial generation, upstream skills drift (warned by apm install/update), or
   overlay inputs change. Triggers on: "sync overlay", "generate overlay",
@@ -29,7 +29,7 @@ The user may provide:
 
 ### Step 1: Discover Overlays
 
-Determine the overlay directory from user input. Default to `skills/overlays/` if no directory was specified.
+Determine the overlay directory from user input. Default to `overlays/` if no directory was specified.
 
 Scan the overlay directory for subdirectories containing `customized/config.yaml`.
 

--- a/skills/tooling/overlay-sync-skills/SKILL.md
+++ b/skills/tooling/overlay-sync-skills/SKILL.md
@@ -12,6 +12,14 @@ description: >
 
 Merge upstream skill files with project-specific overlay inputs to produce generated files.
 
+## Scope
+
+This skill **only** merges overlay inputs into `customized/generated/`. It does **not** deploy generated files to target directories.
+
+**Do not run `overlay-sync.sh`.** Deploying generated files to `.claude/skills/`, `.cursor/skills/`, etc. is handled separately by APM `post-install`/`post-update` hooks or when the user explicitly asks to run the sync script.
+
+When an overlay is up to date, stop after reporting — do not re-merge and do not deploy.
+
 ## User Input
 
 ```text

--- a/skills/tooling/overlay-sync-skills/overlay-sync.sh
+++ b/skills/tooling/overlay-sync-skills/overlay-sync.sh
@@ -23,7 +23,7 @@ skip() { echo -e "    ${RED}✗${NC} $*"; }
 
 # ── Parse arguments ────────────────────────────────────────────────────────
 
-OVERLAY_DIR="skills/overlays"
+OVERLAY_DIR="overlays"
 HOOK=""
 
 while [[ $# -gt 0 ]]; do
@@ -33,7 +33,7 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       echo "Usage: $(basename "$0") [--overlay-dir <path>] [--hook <post-install|post-update>]"
       echo ""
-      echo "  --overlay-dir   Path to overlays directory (default: skills/overlays)"
+      echo "  --overlay-dir   Path to overlays directory (default: overlays)"
       echo "  --hook          APM lifecycle hook that invoked this script"
       exit 0
       ;;

--- a/skills/tooling/overlay-sync-skills/overlay-sync.sh
+++ b/skills/tooling/overlay-sync-skills/overlay-sync.sh
@@ -107,6 +107,28 @@ file_sha256() {
   shasum -a 256 "$1" 2>/dev/null | cut -d' ' -f1
 }
 
+# ── Helper: read (path, sha) pairs from a YAML list, e.g. the lock file's `upstream:` list ──
+
+yaml_list_kv() {
+  local file="$1" key="$2"
+  awk -v key="$key" '
+    $0 ~ "^"key":[[:space:]]*$" { inblock=1; path=""; next }
+    inblock && $0 !~ /^[[:space:]]/ { inblock=0 }
+    inblock && /^[[:space:]]*-[[:space:]]*path:/ {
+      p=$0
+      sub(/^[[:space:]]*-[[:space:]]*path:[[:space:]]*/, "", p)
+      path=p
+      next
+    }
+    inblock && /^[[:space:]]*sha:/ {
+      s=$0
+      sub(/^[[:space:]]*sha:[[:space:]]*/, "", s)
+      if (path != "") { print path "\t" s }
+      path=""
+    }
+  ' "$file"
+}
+
 # ── Process each overlay ───────────────────────────────────────────────────
 
 SYNCED=0
@@ -161,9 +183,8 @@ for overlay_name in "${OVERLAYS[@]}"; do
     continue
   fi
 
-  # 4d: Check upstream exists + 4e: Drift check
+  # 4d: Check upstream exists across targets
   upstream_found=false
-  upstream_sha=""
   first_deploy_dir=""
 
   while IFS= read -r deploy_dir; do
@@ -172,24 +193,28 @@ for overlay_name in "${OVERLAYS[@]}"; do
       upstream_found=true
       if [[ -z "$first_deploy_dir" ]]; then
         first_deploy_dir="$deploy_dir"
-        upstream_sha=$(file_sha256 "$upstream_file")
       fi
     fi
   done <<< "$DEPLOY_DIRS"
 
   if ! $upstream_found; then
-    warn "upstream skill '$base_skill' not found in any active target"
+    warn "upstream skill '$base_skill' not found in any active target — future updates can't be detected until it's reinstalled somewhere"
   fi
 
-  # Drift check
-  if [[ -f "$lock_file" ]] && [[ -n "$upstream_sha" ]]; then
-    lock_sha=$(yaml_value "$lock_file" "base-skill-sha")
-    if [[ -n "$lock_sha" ]] && [[ "$lock_sha" != "$upstream_sha" ]]; then
-      warn "upstream SHA differs — overlay may be stale, run /overlay-sync-skills to regenerate"
-      echo -e "      lock:     ${lock_sha:0:12}..."
-      echo -e "      upstream: ${upstream_sha:0:12}..."
-      WARNED=$((WARNED + 1))
-    fi
+  # 4e: Drift check — every upstream file tracked in the lock, not just SKILL.md
+  if [[ -f "$lock_file" ]] && [[ -n "$first_deploy_dir" ]]; then
+    while IFS=$'\t' read -r rel_path lock_sha; do
+      [[ -z "$rel_path" ]] && continue
+      upstream_path="$REPO_ROOT/${first_deploy_dir}skills/$base_skill/$rel_path"
+      [[ -f "$upstream_path" ]] || continue
+      current_sha=$(file_sha256 "$upstream_path")
+      if [[ "$current_sha" != "$lock_sha" ]]; then
+        warn "upstream $rel_path differs — overlay may be stale, run /overlay-sync-skills to regenerate"
+        echo -e "      lock:     ${lock_sha:0:12}..."
+        echo -e "      upstream: ${current_sha:0:12}..."
+        WARNED=$((WARNED + 1))
+      fi
+    done < <(yaml_list_kv "$lock_file" "upstream")
   fi
 
   # 4f: Copy to each active target

--- a/skills/tooling/overlay-sync-skills/overlay-sync.sh
+++ b/skills/tooling/overlay-sync-skills/overlay-sync.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# overlay-sync.sh — Copy generated overlay files into active target deploy directories.
+#
+# Designed to run as an APM post-install/post-update lifecycle hook or standalone.
+#
+# Usage:
+#   scripts/overlay-sync.sh [--overlay-dir <path>] [--hook <post-install|post-update>]
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "ERROR: not in a git repo" >&2; exit 1; }
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+die() { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
+warn() { echo -e "    ${YELLOW}⚠${NC} $*"; }
+ok() { echo -e "    ${GREEN}✓${NC} $*"; }
+skip() { echo -e "    ${RED}✗${NC} $*"; }
+
+# ── Parse arguments ────────────────────────────────────────────────────────
+
+OVERLAY_DIR="skills/overlays"
+HOOK=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --overlay-dir) OVERLAY_DIR="$2"; shift 2 ;;
+    --hook) HOOK="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $(basename "$0") [--overlay-dir <path>] [--hook <post-install|post-update>]"
+      echo ""
+      echo "  --overlay-dir   Path to overlays directory (default: skills/overlays)"
+      echo "  --hook          APM lifecycle hook that invoked this script"
+      exit 0
+      ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+OVERLAY_PATH="$REPO_ROOT/$OVERLAY_DIR"
+
+if [[ ! -d "$OVERLAY_PATH" ]]; then
+  echo "Overlay sync: overlay directory not found at $OVERLAY_DIR — nothing to do."
+  exit 0
+fi
+
+# ── Check dependencies ─────────────────────────────────────────────────────
+
+if ! command -v jq &>/dev/null; then
+  die "jq is required but not installed"
+fi
+
+# ── Discover active targets ────────────────────────────────────────────────
+
+if command -v apm &>/dev/null; then
+  DEPLOY_DIRS=$(apm targets --json 2>/dev/null | jq -r '.[] | select(.status == "active") | .deploy_dir' || true)
+else
+  warn "apm not found — falling back to .claude/ if it exists"
+  if [[ -d "$REPO_ROOT/.claude" ]]; then
+    DEPLOY_DIRS=".claude/"
+  else
+    echo "Overlay sync: no active targets found — nothing to do."
+    exit 0
+  fi
+fi
+
+if [[ -z "$DEPLOY_DIRS" ]]; then
+  echo "Overlay sync: no active targets — nothing to do."
+  exit 0
+fi
+
+TARGET_COUNT=$(echo "$DEPLOY_DIRS" | wc -l | tr -d ' ')
+
+# ── Discover overlays ──────────────────────────────────────────────────────
+
+OVERLAYS=()
+for dir in "$OVERLAY_PATH"/*/; do
+  [[ -d "$dir" ]] || continue
+  if [[ -f "$dir/customized/config.yaml" ]]; then
+    OVERLAYS+=("$(basename "$dir")")
+  fi
+done
+
+if [[ ${#OVERLAYS[@]} -eq 0 ]]; then
+  echo "Overlay sync: no overlays found in $OVERLAY_DIR — nothing to do."
+  exit 0
+fi
+
+echo ""
+echo -e "${BOLD}Overlay sync:${NC} ${#OVERLAYS[@]} overlay(s) found, $TARGET_COUNT active target(s)"
+echo ""
+
+# ── Helper: read a simple YAML scalar ──────────────────────────────────────
+
+yaml_value() {
+  local file="$1" key="$2"
+  grep -m1 "^${key}:" "$file" 2>/dev/null | sed "s/^${key}:[[:space:]]*//" | sed 's/^["'\'']\(.*\)["'\'']$/\1/'
+}
+
+# ── Helper: compute SHA-256 ────────────────────────────────────────────────
+
+file_sha256() {
+  shasum -a 256 "$1" 2>/dev/null | cut -d' ' -f1
+}
+
+# ── Process each overlay ───────────────────────────────────────────────────
+
+SYNCED=0
+WARNED=0
+SKIPPED=0
+
+for overlay_name in "${OVERLAYS[@]}"; do
+  overlay="$OVERLAY_PATH/$overlay_name"
+  config="$overlay/customized/config.yaml"
+  gen_dir="$overlay/customized/generated"
+  lock_file="$gen_dir/overlay.lock.yaml"
+
+  echo -e "  ${BOLD}$overlay_name${NC}"
+
+  # 4a: Read base-skill
+  base_skill=$(yaml_value "$config" "base-skill")
+  if [[ -z "$base_skill" ]]; then
+    skip "config.yaml missing base-skill — skipped"
+    SKIPPED=$((SKIPPED + 1))
+    echo ""
+    continue
+  fi
+
+  # 4b: Path validation
+  if [[ "$base_skill" == */* ]] || [[ "$base_skill" == *\\* ]] || [[ "$base_skill" == *..* ]]; then
+    skip "base-skill contains path traversal characters — skipped"
+    SKIPPED=$((SKIPPED + 1))
+    echo ""
+    continue
+  fi
+
+  # 4c: Check generated/ exists
+  if [[ ! -d "$gen_dir" ]]; then
+    warn "no generated files — run /overlay-sync-skills in your agent session to generate"
+    SKIPPED=$((SKIPPED + 1))
+    echo ""
+    continue
+  fi
+
+  # Count files to sync (everything in generated/ except overlay.lock.yaml)
+  gen_files=()
+  for f in "$gen_dir"/*; do
+    [[ -f "$f" ]] || continue
+    [[ "$(basename "$f")" == "overlay.lock.yaml" ]] && continue
+    gen_files+=("$f")
+  done
+
+  if [[ ${#gen_files[@]} -eq 0 ]]; then
+    warn "generated/ directory is empty — run /overlay-sync-skills to generate"
+    SKIPPED=$((SKIPPED + 1))
+    echo ""
+    continue
+  fi
+
+  # 4d: Check upstream exists + 4e: Drift check
+  upstream_found=false
+  upstream_sha=""
+  first_deploy_dir=""
+
+  while IFS= read -r deploy_dir; do
+    upstream_file="$REPO_ROOT/${deploy_dir}skills/$base_skill/SKILL.md"
+    if [[ -f "$upstream_file" ]]; then
+      upstream_found=true
+      if [[ -z "$first_deploy_dir" ]]; then
+        first_deploy_dir="$deploy_dir"
+        upstream_sha=$(file_sha256 "$upstream_file")
+      fi
+    fi
+  done <<< "$DEPLOY_DIRS"
+
+  if ! $upstream_found; then
+    warn "upstream skill '$base_skill' not found in any active target"
+  fi
+
+  # Drift check
+  if [[ -f "$lock_file" ]] && [[ -n "$upstream_sha" ]]; then
+    lock_sha=$(yaml_value "$lock_file" "base-skill-sha")
+    if [[ -n "$lock_sha" ]] && [[ "$lock_sha" != "$upstream_sha" ]]; then
+      warn "upstream SHA differs — overlay may be stale, run /overlay-sync-skills to regenerate"
+      echo -e "      lock:     ${lock_sha:0:12}..."
+      echo -e "      upstream: ${upstream_sha:0:12}..."
+      WARNED=$((WARNED + 1))
+    fi
+  fi
+
+  # 4f: Copy to each active target
+  while IFS= read -r deploy_dir; do
+    target_dir="$REPO_ROOT/${deploy_dir}skills/$base_skill"
+    mkdir -p "$target_dir"
+
+    copied=0
+    for f in "${gen_files[@]}"; do
+      cp "$f" "$target_dir/$(basename "$f")"
+      copied=$((copied + 1))
+    done
+
+    ok "${deploy_dir}skills/$base_skill/ ($copied file(s) synced)"
+    SYNCED=$((SYNCED + 1))
+  done <<< "$DEPLOY_DIRS"
+
+  echo ""
+done
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo -e "${BOLD}Done.${NC} $SYNCED target(s) synced, $WARNED stale, $SKIPPED skipped."
+
+if [[ $WARNED -gt 0 ]]; then
+  echo ""
+  echo "Run /overlay-sync-skills in your agent session to regenerate stale overlays."
+fi


### PR DESCRIPTION
## Summary

ACP pulls shared agent skills from upstream packages (via [APM](https://github.com/OpenShift-Fleet/agentic-sdlc), the Agent Package Manager). Those skills are generic — they work across many projects but lack ACP-specific context like Jira project keys, component names, field mappings, and team conventions.

Today we handle that by maintaining project-specific copies of upstream skills (for example, `jira-log`) with ACP values hardcoded in. That works, but it doesn't scale: every upstream improvement requires manual porting into our local copy.

This PR introduces a **skill overlay system** that lets us customize upstream skills without forking them. We keep hand-authored project configuration in committed overlay files, pre-merge that configuration into generated skill files (reviewed in PR), and automatically deploy those generated files when developers run `apm install` or `apm update`.

The first concrete overlay customizes the upstream `jira-create` skill for ACP's ENGPROD Jira conventions.  
  
NOTE: This PR will need to be modified or a follow up will be needed once #447 and #450 are merged.  Those PRs introduce a custom install and update commands. 

## Background (for readers new to APM)

**APM** is a package manager for AI agent tooling. It installs shared primitives — skills, commands, prompts, and the like — from upstream repositories into per-tool directories such as `.claude/` and `.cursor/`. ACP declares its upstream dependencies in `apm.yml` and pulls from `OpenShift-Fleet/agentic-sdlc`.

The [Agentic SDLC Working Group skill overlay standard](https://wg-agentic-sdlc-d415e7.pages.redhat.com/best-practices/read.html?p=skill-overlays.md) defines how consuming repos can layer project-specific configuration on top of shared skills. ACP implements that standard with one important adaptation: **pre-merge at install time** rather than runtime discovery.

Agent platforms (Claude, Cursor, etc.) read `SKILL.md` directly. They do not natively understand a `customized/` subdirectory sitting alongside it. So instead of asking every agent to discover and merge overlays at runtime, ACP uses an LLM merge step (run deliberately inside an agent session) to produce a single, self-contained `SKILL.md` that agents read as usual. The merge output is committed, reviewed, and shared by every developer.

For the full design rationale, see the **Skill Overlay Architecture** doc in the ACP Obsidian vault (`ACP/Skill Overlay Architecture.md`).

## What this PR adds



### 1. Overlay tooling (`skills/tooling/overlay-sync-skills/`)

Two complementary tools:


| Tool                                 | Runs when                                     | Needs LLM? | Purpose                                                                                 |
| ------------------------------------ | --------------------------------------------- | ---------- | --------------------------------------------------------------------------------------- |
| `/overlay-sync-skills` (agent skill) | Developer runs it in an agent session         | Yes        | Reads upstream skill + overlay inputs, produces merged files in `customized/generated/` |
| `overlay-sync.sh` (bash script)      | Automatically on `apm install` / `apm update` | No         | Copies generated files into active target deploy directories; warns on upstream drift   |


The bash script is intentionally dumb — it copies files, compares SHA-256 hashes, and prints warnings. It never calls an LLM. That means `apm install` works without LLM credentials; regeneration is always a separate, deliberate step.

### 2. Overlay directory (`overlays/`)

Overlays live at the repo root (not inside gitignored `.claude/skills/`):

```
overlays/<skill-name>/
  customized/
    config.yaml              # structured parameters (required)
    *.md                     # prose conventions (optional)
    generated/               # LLM-merged output (committed, reviewed)
      SKILL.md               # replaces upstream skill at deploy time
      overlay.lock.yaml      # provenance / drift tracking
```



### 3. Example overlay (`overlays/jira-create/`)

Demonstrates the pattern end-to-end for the upstream `jira-create` skill:

- `config.yaml` — ENGPROD project, `acp` component, default labels, activity type IDs, browse URL
- `project-context.md` — ACP Jira conventions, component list, issue type guidance, description templates
- `batch-mode.md` — ACP-specific batch creation behavior
- `generated/SKILL.md` — pre-merged skill ready for agents to use
- `generated/overlay.lock.yaml` — records upstream and input file SHAs for drift detection



### 4. APM integration (`apm.yml`)

Wires `overlay-sync.sh` into both APM lifecycle hooks and top-level scripts:

- `lifecycle.post-install` **/** `lifecycle.post-update` — run automatically after `apm install` / `apm update`
- `scripts.post-install` **/** `scripts.post-update` — same script, runnable via `apm run post-install` with console output (lifecycle hook output is captured to `~/.apm/logs/scripts.log` only)

