### PR TITLE
fix(keycloak): add ambient-mobile client to realm config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -991,26 +991,32 @@ kind-up: preflight-cluster build-cli ## Start kind cluster and deploy the platfo
 		sleep 2; \
 		TOKEN=$$(kubectl get secret test-user-token -n $(NAMESPACE) -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null); \
 		$$ACPCTL login --url "http://localhost:$${PF_PORT}" --token "$$TOKEN" >/dev/null 2>&1; \
+		FLEET_FAILED=""; \
 		for ns in $(OPENSHELL_TENANTS); do \
 			if echo " $(SKIP_TENANT_SETUP) " | grep -q " $$ns "; then \
 				echo "  $$ns: skipped (SKIP_TENANT_SETUP)"; \
 				continue; \
 			fi; \
+			[ -f "examples/overlays/$$ns/kustomization.yaml" ] || continue; \
 			if [ -f "$(VERTEX_CRED)" ]; then \
 				kubectl create secret generic vertex-sa-key \
 					--namespace="$$ns" \
 					"--from-literal=token=$$(cat '$(VERTEX_CRED)')" \
 					--dry-run=client -o yaml | kubectl apply -f - 2>/dev/null; \
 			fi; \
-			if [ -d "examples/overlays/$$ns" ]; then \
-				VERTEX_SA_KEY=$$(cat "$(VERTEX_CRED)" 2>/dev/null || echo "") \
-				$$ACPCTL apply -k "examples/overlays/$$ns/" --project "$$ns" && \
+			if VERTEX_SA_KEY=$$(cat "$(VERTEX_CRED)" 2>/dev/null || echo "") \
+				$$ACPCTL apply -k "examples/overlays/$$ns/" --project "$$ns"; then \
 				echo "  $$ns: applied"; \
 			else \
-				echo "  $$ns: no overlay directory — skipping fleet"; \
+				echo "$(COLOR_RED)✗$(COLOR_RESET) $$ns: apply failed"; \
+				FLEET_FAILED="$$FLEET_FAILED $$ns"; \
 			fi; \
 		done; \
 		kill $$PF_PID 2>/dev/null || true; \
+		if [ -n "$$FLEET_FAILED" ]; then \
+			echo "$(COLOR_RED)✗$(COLOR_RESET) Fleet provisioning failed for:$$FLEET_FAILED"; \
+			exit 1; \
+		fi; \
 	fi
 	@if [ -f .dev-bootstrap.env ] && [ -f ./scripts/bootstrap-workspace.sh ]; then \
 		echo "$(COLOR_BLUE)▶$(COLOR_RESET) Bootstrapping developer workspace..."; \

--- a/components/manifests/overlays/openshift-local/keycloak-realm.json
+++ b/components/manifests/overlays/openshift-local/keycloak-realm.json
@@ -181,6 +181,80 @@
       ]
     },
     {
+      "clientId": "ambient-mobile",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "redirectUris": [
+        "acp-mobile://oauth/callback"
+      ],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": [
+        "openid",
+        "email",
+        "profile",
+        "groups"
+      ],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "ambient-frontend",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "preferred_username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
       "clientId": "ambient-e2e",
       "enabled": true,
       "protocol": "openid-connect",


### PR DESCRIPTION
## What

Adds the `ambient-mobile` Keycloak client to the realm JSON, establishing it as a proper source of truth in the codebase.

Previously the client existed only as a manually-created artifact on the live `jeder-prerel` cluster with no corresponding definition in the repo — meaning any realm reimport or new cluster provisioning would silently drop it and break mobile auth.

## Why

Mobile auth was broken with `unauthorized_client` due to two misconfigured properties on the live cluster client:

1. **Wrong redirect URI** — client had `ambient-mobile://oauth/callback` but the app sends `acp-mobile://oauth/callback`
2. **Direct access grants disabled** — the app's native password login uses `grant_type=password`, which Keycloak rejects as `unauthorized_client` when direct access grants are off

Both were fixed on the live cluster and are now codified in this realm JSON entry.

## Client config

- Public client (no secret), PKCE S256
- Standard flow + direct access grants enabled
- Redirect URI: `acp-mobile://oauth/callback`
- Scopes: `openid`, `email`, `profile`, `groups`
